### PR TITLE
(SIMP-643) Added bugfix for fixfiles

### DIFF
--- a/files/etc/init.d/bugfix1049656
+++ b/files/etc/init.d/bugfix1049656
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# bugfix1049656 A double check that autorelabel is working
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1049656
+# 
+# Make sure that the system set the SELinux contexts
+# Autorelabel does not always seem to work properly
+# for more information.
+#
+# chkconfig - 99 99
+# description: A double check that autorelabel is working
+#
+### BEGIN INIT INFO
+# Provides: $bugfix1049656
+# Short-Description: Double check that autorelabel is working
+# Description: Double check that autorelabel is working
+### END INIT INFO
+case "$1" in
+   start)
+      if [ -f '/.autorelabel' ]; then
+        echo 'Running fixfiles, this may take some time....'
+        fixfiles restore;
+        rm /.autorelabel
+      fi
+      ;;
+   status)
+      return 0;
+      ;;
+  stop)
+      return 0;
+      ;;
+esac
+EOF

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,12 @@
 #   Ensure that /root has restricted permissions and proper SELinux
 #   contexts.
 #
+# [*use_os_bugfixes*]
+# Type: Boolean
+# Default: true
+#   If enabled, activate the OS specific bugfixes in the simplib::os_bugfixes
+#   class. These may be individually toggled using parameters in that class.
+#
 # [*use_fips*]
 # Type: Boolean
 # Default: false
@@ -163,6 +169,7 @@ class simplib (
   ],
   $manage_tmp_perms = true,
   $manage_root_perms = true,
+  $use_os_bugfixes = true,
   $use_fips = hiera('use_fips', false),
   # I'm not entirely sure what happens if you mix CPUs and one doesn't have AES
   # enabled...
@@ -182,7 +189,14 @@ class simplib (
   validate_array($securetty)
   validate_bool($manage_tmp_perms)
   validate_bool($manage_root_perms)
+  validate_bool($use_os_bugfixes)
+  validate_bool($use_fips)
+  validate_bool($use_fips_aesni)
   validate_array_member($proc_hidepid,['0','1','2'])
+
+  if $use_os_bugfixes {
+    include '::simplib::os_bugfixes'
+  }
 
   runlevel { $runlevel: }
 

--- a/manifests/os_bugfixes.pp
+++ b/manifests/os_bugfixes.pp
@@ -1,0 +1,22 @@
+# == Class: simplib::os_bugfixes
+#
+# This class collects Operating System bugfixes and workarounds that do not
+# belong specifically in another module.
+#
+class simplib::os_bugfixes {
+  if $::operatingsystem in ['CentOS','RedHat'] {
+    if $::operatingsystemmajrelease == '7' {
+      file { '/etc/init.d/bugfix1049656':
+        ensure => 'file',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+        source => "puppet:///modules/${module_name}/etc/init.d/bugfix1049656"
+      }
+
+      service { 'bugfix1049656':
+        enable => true
+      }
+    }
+  }
+}

--- a/manifests/os_bugfixes.pp
+++ b/manifests/os_bugfixes.pp
@@ -3,20 +3,45 @@
 # This class collects Operating System bugfixes and workarounds that do not
 # belong specifically in another module.
 #
-class simplib::os_bugfixes {
-  if $::operatingsystem in ['CentOS','RedHat'] {
-    if $::operatingsystemmajrelease == '7' {
-      file { '/etc/init.d/bugfix1049656':
-        ensure => 'file',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
-        source => "puppet:///modules/${module_name}/etc/init.d/bugfix1049656"
-      }
+# === Params
+#
+# [*include_bugfix1049656*]
+# Type: Boolean
+# Default: true
+#   A workaround for the case where EL7 does not always properly run a
+#   filesystem relabel if the /.autorelabel file is present.
+#
+#   See: https://bugzilla.redhat.com/show_bug.cgi?id=1049656
+# 
+class simplib::os_bugfixes (
+  $include_bugfix1049656 = true
+) {
 
-      service { 'bugfix1049656':
-        enable => true
+  validate_bool($include_bugfix1049656)
+
+  if $include_bugfix1046956 {
+    if $::operatingsystem in ['CentOS','RedHat'] {
+      if $::operatingsystemmajrelease == '7' {
+        file { '/etc/init.d/bugfix1049656':
+          ensure => 'file',
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
+          source => "puppet:///modules/${module_name}/etc/init.d/bugfix1049656"
+        }
+  
+        service { 'bugfix1049656':
+          enable => true
+        }
       }
     }
+  }
+  else {
+    file { '/etc/init.d/bugfix1049656':
+      ensure  => 'absent',
+      require => Service['bugfix1049656']
+    }
+
+    service { 'bugfix1049656': enable => false }
   }
 }


### PR DESCRIPTION
EL 7 appears to have a bug where /.autorelabel is not honored at boot
time. This works around the issue using a startup script.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1049656

SIMP-643 #close