### PR TITLE
(SIMP-648) Updated for SSSD Support

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -50,6 +50,11 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Thu Nov 19 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-0
+- Added validate_uri_list function
+- Ensure that nsswitch works properly for SSSD
+- Add sudoers support for SSSD and nsswitch
+
 * Fri Nov 13 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.0-0
 - Imported manifests/ template/ and files/ assets from pupmod-common
 - manifests/ assets from pupmod-functions are deprecated and will not be imported

--- a/lib/puppet/parser/functions/validate_uri_list.rb
+++ b/lib/puppet/parser/functions/validate_uri_list.rb
@@ -1,0 +1,35 @@
+module Puppet::Parser::Functions
+  newfunction(:validate_uri_list, :arity => -1, :doc => <<-'ENDHEREDOC') do |args|
+    Usage: validate_uri_list([LIST],[<VALID_SCHEMES>])
+
+    Validate that a passed list (Array or single String) of URIs is valid
+    according to Ruby's URI parser.
+
+    The following values will pass:
+
+      $uris = ['http://foo.bar.baz:1234','ldap://my.ldap.server']
+      validate_uri_list($uris)
+
+      $uris = ['ldap://my.ldap.server','ldaps://my.ldap.server']
+      validate_uri_list($uris,['ldap','ldaps'])
+    ENDHEREDOC
+
+    uri_list = Array(args.shift)
+    scheme_list = Array(args.shift)
+
+    uri_list.each do |uri|
+      begin
+        require 'uri'
+        uri_obj = URI(uri)
+
+        unless scheme_list.empty?
+          unless scheme_list.include?(uri_obj.scheme)
+            raise Puppet::ParseError, ("validate_uri_list(): Scheme '#{uri_obj.scheme}' must be one of '#{uri_list.join(',')}'")
+          end
+        end
+      rescue URI::InvalidURIError
+        raise Puppet::ParseError, ("validate_uri_list(): '#{uri}' is not a valid URI")
+      end
+    end
+  end
+end

--- a/manifests/nsswitch.pp
+++ b/manifests/nsswitch.pp
@@ -75,7 +75,7 @@
 #
 # [*use_ldap*]
 # Type: boolean
-# Default: true
+# Default: false
 #   If true, inject LDAP settings into various options as appropriate.
 #
 # [*use_sssd*]
@@ -103,9 +103,10 @@ class simplib::nsswitch (
   $publickey =  ['nisplus'],
   $automount =  ['files','nisplus'],
   $aliases =  ['files','nisplus'],
-  $use_ldap = hiera('use_ldap',true),
-  $use_sssd = hiera('use_sssd',false)
-){
+  $sudoers = ['files'],
+  $use_ldap = '',
+  $use_sssd = defined('$::use_sssd') ? { true => $::use_sssd, default => hiera('use_sssd',false) }
+) {
   validate_array($passwd)
   validate_array($shadow)
   validate_array($group)
@@ -122,8 +123,22 @@ class simplib::nsswitch (
   validate_array($publickey)
   validate_array($automount)
   validate_array($aliases)
-  validate_bool($use_ldap)
   validate_bool($use_sssd)
+
+  # Unless we're explicitly using LDAP, let SSSD do its thing
+  if empty("$use_ldap") {
+    if $use_sssd {
+      $_use_ldap = false
+    }
+    else {
+      $_use_ldap = defined('$::use_ldap') ? { true => $::use_ldap, default => hiera('use_ldap',false) }
+    }
+  }
+  else {
+    $_use_ldap = $use_ldap
+  }
+
+  validate_bool($_use_ldap)
 
   file { '/etc/nsswitch.conf':
     owner   => 'root',

--- a/spec/classes/localusers_spec.rb
+++ b/spec/classes/localusers_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
 describe 'simplib::localusers' do
-  let(:facts){{
-    :fqdn => 'foo.bar.baz',
-    :operatingsystem => 'CentOS',
-    :operatingsystemrelease => '6.5',
-    :operatingsystemmajrelease => '6'
-  }}
-
-  context 'real_file' do
-    $fh = Tempfile.new('localusers')
-    $fh.puts("*.bar.baz,foo,100,100,/home/foo,foobar")
-    $fh.close
-
-    let(:params){{ :source => $fh.path }}
-
-    it {
-      should compile.with_all_deps
-    }
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts){ facts }
+          context 'real_file' do
+          $fh = Tempfile.new('localusers')
+          $fh.puts("*.bar.baz,foo,100,100,/home/foo,foobar")
+          $fh.close
+      
+          let(:params){{ :source => $fh.path }}
+      
+          it {
+            should compile.with_all_deps
+          }
+        end
+      
+        it { should contain_exec('modify_local_users').with_refreshonly(true) }
+        it { should contain_file('/usr/local/sbin/simp/localusers.rb').that_notifies('Exec[modify_local_users]') }
+      
+      end
+    end
   end
-
-  it { should contain_exec('modify_local_users').with_refreshonly(true) }
-  it { should contain_file('/usr/local/sbin/simp/localusers.rb').that_notifies('Exec[modify_local_users]') }
-
 end

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -1,123 +1,134 @@
 require 'spec_helper'
 
 describe 'simplib::nsswitch' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts){ facts }
+        it { should compile.with_all_deps }
+        it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files [!NOTFOUND=return] ldap
+            shadow: files [!NOTFOUND=return] ldap
+            group: files [!NOTFOUND=return] ldap
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files
+            netgroup: files [!NOTFOUND=return] ldap
+            publickey: nisplus
+            automount: files [!NOTFOUND=return] nisplus ldap
+            aliases: files nisplus
+            EOM
+        }
 
-  it { should compile.with_all_deps }
-  it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-      passwd: files [!NOTFOUND=return] ldap
-      shadow: files [!NOTFOUND=return] ldap
-      group: files [!NOTFOUND=return] ldap
-      hosts: files dns
-      bootparams: nisplus [NOTFOUND=return] files
-      ethers: files
-      netmasks: files
-      networks: files
-      protocols: files
-      rpc: files
-      services: files
-      netgroup: files [!NOTFOUND=return] ldap
-      publickey: nisplus
-      automount: files [!NOTFOUND=return] nisplus ldap
-      aliases: files nisplus
-      EOM
-  }
+        context 'with_initgroups' do
+          let(:params){{ :initgroups => ['files'] }}
 
-  context 'with_initgroups' do
-    let(:params){{ :initgroups => ['files'] }}
+          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files [!NOTFOUND=return] ldap
+            shadow: files [!NOTFOUND=return] ldap
+            group: files [!NOTFOUND=return] ldap
+            initgroups: files
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files
+            netgroup: files [!NOTFOUND=return] ldap
+            publickey: nisplus
+            automount: files [!NOTFOUND=return] nisplus ldap
+            aliases: files nisplus
+            EOM
+          }
+        end
 
-    it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-      passwd: files [!NOTFOUND=return] ldap
-      shadow: files [!NOTFOUND=return] ldap
-      group: files [!NOTFOUND=return] ldap
-      initgroups: files
-      hosts: files dns
-      bootparams: nisplus [NOTFOUND=return] files
-      ethers: files
-      netmasks: files
-      networks: files
-      protocols: files
-      rpc: files
-      services: files
-      netgroup: files [!NOTFOUND=return] ldap
-      publickey: nisplus
-      automount: files [!NOTFOUND=return] nisplus ldap
-      aliases: files nisplus
-      EOM
-    }
-  end
+        context 'with_no_ldap' do
+          let(:params){{ :use_ldap => false }}
 
-  context 'with_no_ldap' do
-    let(:params){{ :use_ldap => false }}
+          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files
+            shadow: files
+            group: files
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files
+            netgroup: files
+            publickey: nisplus
+            automount: files nisplus
+            aliases: files nisplus
+            EOM
+          }
+        end
 
-    it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-      passwd: files
-      shadow: files
-      group: files
-      hosts: files dns
-      bootparams: nisplus [NOTFOUND=return] files
-      ethers: files
-      netmasks: files
-      networks: files
-      protocols: files
-      rpc: files
-      services: files
-      netgroup: files
-      publickey: nisplus
-      automount: files nisplus
-      aliases: files nisplus
-      EOM
-    }
-  end
+        context 'with_sssd' do
+          let(:params){{
+            :use_ldap => false,
+            :use_sssd => true
+          }}
 
-  context 'with_sssd' do
-    let(:params){{
-      :use_ldap => false,
-      :use_sssd => true
-    }}
+          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files [!NOTFOUND=return] sss
+            shadow: files [!NOTFOUND=return] sss
+            group: files [!NOTFOUND=return] sss
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files [!NOTFOUND=return] sss
+            netgroup: files [!NOTFOUND=return] sss
+            publickey: nisplus
+            automount: files nisplus
+            aliases: files nisplus
+            EOM
+          }
+        end
 
-    it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-      passwd: files [!NOTFOUND=return] sss
-      shadow: files [!NOTFOUND=return] sss
-      group: files [!NOTFOUND=return] sss
-      hosts: files dns
-      bootparams: nisplus [NOTFOUND=return] files
-      ethers: files
-      netmasks: files
-      networks: files
-      protocols: files
-      rpc: files
-      services: files
-      netgroup: files [!NOTFOUND=return] sss
-      publickey: nisplus
-      automount: files nisplus
-      aliases: files nisplus
-      EOM
-    }
-  end
+        context 'with_sssd_and_ldap' do
+          let(:params){{
+            :use_ldap => true,
+            :use_sssd => true
+          }}
 
-  context 'with_sssd_and_ldap' do
-    let(:params){{
-      :use_ldap => true,
-      :use_sssd => true
-    }}
-
-    it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-      passwd: files [!NOTFOUND=return] sss ldap
-      shadow: files [!NOTFOUND=return] sss ldap
-      group: files [!NOTFOUND=return] sss ldap
-      hosts: files dns
-      bootparams: nisplus [NOTFOUND=return] files
-      ethers: files
-      netmasks: files
-      networks: files
-      protocols: files
-      rpc: files
-      services: files
-      netgroup: files [!NOTFOUND=return] sss ldap
-      publickey: nisplus
-      automount: files [!NOTFOUND=return] nisplus ldap
-      aliases: files nisplus
-      EOM
-    }
+          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files [!NOTFOUND=return] sss ldap
+            shadow: files [!NOTFOUND=return] sss ldap
+            group: files [!NOTFOUND=return] sss ldap
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files [!NOTFOUND=return] sss
+            netgroup: files [!NOTFOUND=return] sss ldap
+            publickey: nisplus
+            automount: files [!NOTFOUND=return] nisplus ldap
+            aliases: files nisplus
+            EOM
+          }
+        end
+      end
+    end
   end
 end

--- a/spec/functions/validate_uri_list_spec.rb
+++ b/spec/functions/validate_uri_list_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe 'validate_uri_list' do
+  context 'IPv4' do
+    it do
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'rsync://127.0.0.1:1234',
+            'http://some.domain.net',
+            'http://some.domain.net',
+            'http://localhost.my.domain:8989',
+            'fuu.bar.baz',
+            'my.example.net:900'
+          ]].map(&:freeze)
+        )
+      }.to_not raise_error
+
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://1.2.3.4',
+            'ldaps://1.2.3.4'
+          ],
+          [
+            'ldap',
+            'ldaps'
+          ]].map(&:freeze)
+        )
+      }.to_not raise_error
+    end
+
+    it do
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://1.2.3.4:bob:alice'
+          ]].map(&:freeze)
+        )
+      }.to raise_error(Puppet::ParseError)
+    end
+
+    it do
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://1.2.3.4',
+            'ldaps://1.2.3.4'
+          ],
+          [
+            'http'
+          ]].map(&:freeze)
+        )
+      }.to raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'IPv6' do
+    it do
+      expect {
+        retval = scope.function_strip_ports(
+          [[
+            'ldap://[2001:db8:1f70::999:de8:7648:001]:100',
+            'ldaps://[2001:db8:1f70::999:de8:7648:002]'
+          ]].map(&:freeze)
+        )
+      }.to_not raise_error
+
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://[2001:db8:1f70::999:de8:7648:001]:100',
+            'ldaps://[2001:db8:1f70::999:de8:7648:002]'
+          ],
+          [
+            'ldap',
+            'ldaps'
+          ]].map(&:freeze)
+        )
+      }.to_not raise_error
+    end
+
+    it do
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://[2001:db8:1f70::999:de8:7648:]'
+          ]].map(&:freeze)
+        )
+      }.to raise_error(Puppet::ParseError)
+    end
+
+    it do
+      expect {
+        scope.function_validate_uri_list(
+          [[
+            'ldap://[2001:db8:1f70::999:de8:7648:001]:100',
+            'ldaps://[2001:db8:1f70::999:de8:7648:002]'
+          ],
+          [
+            'http'
+          ]].map(&:freeze)
+        )
+      }.to raise_error(Puppet::ParseError)
+    end
+  end
+end

--- a/templates/etc/nsswitch.conf.erb
+++ b/templates/etc/nsswitch.conf.erb
@@ -13,13 +13,14 @@ options = [
   'protocols',
   'rpc',
   'services',
+  'sudoers',
   'netgroup',
   'publickey',
   'automount',
   'aliases'
 ]
 
-sss_affects = ['passwd','shadow','group', 'netgroup']
+sss_affects = ['passwd','shadow','group', 'netgroup','sudoers']
 ldap_affects = ['passwd','shadow', 'group', 'netgroup', 'automount']
 
 # This is just here to keep the class consistent with all of the other classes.
@@ -52,13 +53,20 @@ end
 
 # SSSD Takes precedence
 ['sss','ldap'].each do |x|
-  next if not eval("@use_#{variable_map[x]}")
+  # This relies on knowing that our variables may have internal mappings
+  # This all should probably be rewritten....
+  opt = eval("@_use_#{variable_map[x]}")
+  unless opt
+    opt = eval("@use_#{variable_map[x]}")
+  end
+
+  next unless opt
   outfile = append_content(x,eval("#{x}_affects"),outfile)
 end
 
 to_ret = []
 options.each do |k|
-  next if not outfile[k]
+  next unless outfile[k]
   to_ret << "#{k}: #{outfile[k].join(' ')}"
 end
 -%>


### PR DESCRIPTION
This update ensures that SSSD is properly used in nsswitch.conf.

A function was also added 'validate_uri_list' for use in other modules.

SIMP-648 #comment SSSD Support in nsswitch.conf

Change-Id: Id5a6e38b8d78cfef52886e70c215a425768e59a2