### PR TITLE
(SIMP-631) Updated to make sssd default in EL7

### DIFF
--- a/manifests/nsswitch.pp
+++ b/manifests/nsswitch.pp
@@ -104,9 +104,9 @@ class simplib::nsswitch (
   $automount =  ['files','nisplus'],
   $aliases =  ['files','nisplus'],
   $sudoers = ['files'],
-  $use_ldap = '',
-  $use_sssd = defined('$::use_sssd') ? { true => $::use_sssd, default => hiera('use_sssd',false) }
-) {
+  $use_ldap = defined('$::use_ldap') ? { true => $::use_ldap, default => hiera('use_ldap',false) },
+  $use_sssd = $::simplib::params::use_sssd
+) inherits ::simplib::params {
   validate_array($passwd)
   validate_array($shadow)
   validate_array($group)
@@ -123,15 +123,12 @@ class simplib::nsswitch (
   validate_array($publickey)
   validate_array($automount)
   validate_array($aliases)
+  validate_bool($use_ldap)
   validate_bool($use_sssd)
 
-  # Unless we're explicitly using LDAP, let SSSD do its thing
-  if empty($use_ldap) {
+  if $use_ldap {
     if $use_sssd {
       $_use_ldap = false
-    }
-    else {
-      $_use_ldap = defined('$::use_ldap') ? { true => $::use_ldap, default => hiera('use_ldap',false) }
     }
   }
   else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,29 @@
+# == Class: simplib::params
+#
+# A set of defaults for the 'simplib' namespace
+#
+# $use_sssd
+# Default: false on EL<7, true otherwise
+#   There are issues with ldap and nslcd on EL7+ which can result in users
+#   being locked out of the system. SSSD contains a bug which will allow users
+#   with a valid SSH key to bypass the password lockout as returned by LDAP but
+#   this can be worked around much more easily than the workaround for the ldap
+#   issues which significantly weaken your security posture.
+class simplib::params {
+  if $::operatingsystem in ['RedHat','CentOS'] {
+    if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+      $_use_sssd = false
+    }
+    else {
+      $_use_sssd = true
+    }
+
+    $use_sssd = defined('$::use_sssd') ? {
+      true => $::use_sssd,
+      default => hiera('use_sssd',$_use_sssd)
+    }
+  }
+  else {
+    fail("${::operatingsystem} not yet supported by ${module_name}")
+  }
+}

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -6,81 +6,154 @@ describe 'simplib::nsswitch' do
       context "on #{os}" do
         let(:facts){ facts }
         it { should compile.with_all_deps }
-        it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files [!NOTFOUND=return] ldap
-            shadow: files [!NOTFOUND=return] ldap
-            group: files [!NOTFOUND=return] ldap
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files
-            netgroup: files [!NOTFOUND=return] ldap
-            publickey: nisplus
-            automount: files [!NOTFOUND=return] nisplus ldap
-            aliases: files nisplus
-            EOM
+        it {
+          if facts[:osfamily] == 'RedHat'
+            if facts[:operatingsystemmajrelease] < '7'
+              should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                passwd: files
+                shadow: files
+                group: files
+                hosts: files dns
+                bootparams: nisplus [NOTFOUND=return] files
+                ethers: files
+                netmasks: files
+                networks: files
+                protocols: files
+                rpc: files
+                services: files
+                sudoers: files
+                netgroup: files
+                publickey: nisplus
+                automount: files nisplus
+                aliases: files nisplus
+                EOM
+            else
+              should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                passwd: files [!NOTFOUND=return] sss
+                shadow: files [!NOTFOUND=return] sss
+                group: files [!NOTFOUND=return] sss
+                hosts: files dns
+                bootparams: nisplus [NOTFOUND=return] files
+                ethers: files
+                netmasks: files
+                networks: files
+                protocols: files
+                rpc: files
+                services: files
+                sudoers: files [!NOTFOUND=return] sss
+                netgroup: files [!NOTFOUND=return] sss
+                publickey: nisplus
+                automount: files nisplus
+                aliases: files nisplus
+                EOM
+            end
+          end
         }
 
         context 'with_initgroups' do
           let(:params){{ :initgroups => ['files'] }}
-
-          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files [!NOTFOUND=return] ldap
-            shadow: files [!NOTFOUND=return] ldap
-            group: files [!NOTFOUND=return] ldap
-            initgroups: files
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files
-            netgroup: files [!NOTFOUND=return] ldap
-            publickey: nisplus
-            automount: files [!NOTFOUND=return] nisplus ldap
-            aliases: files nisplus
-            EOM
+  
+          it {
+            if facts[:osfamily] == 'RedHat'
+              if facts[:operatingsystemmajrelease] < '7'
+                should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files
+                  shadow: files
+                  group: files
+                  initgroups: files
+                  hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files
+                  netgroup: files
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              else
+                should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files [!NOTFOUND=return] sss
+                  shadow: files [!NOTFOUND=return] sss
+                  group: files [!NOTFOUND=return] sss
+                  initgroups: files
+                  hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files [!NOTFOUND=return] sss
+                  netgroup: files [!NOTFOUND=return] sss
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              end
+            end
           }
         end
-
+  
         context 'with_no_ldap' do
           let(:params){{ :use_ldap => false }}
-
-          it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files
-            shadow: files
-            group: files
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files
-            netgroup: files
-            publickey: nisplus
-            automount: files nisplus
-            aliases: files nisplus
-            EOM
+  
+          it {
+            if facts[:osfamily] == 'RedHat'
+              if facts[:operatingsystemmajrelease] < '7'
+                should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files
+                  shadow: files
+                  group: files
+                  hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files
+                  netgroup: files
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              else
+                should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files [!NOTFOUND=return] sss
+                  shadow: files [!NOTFOUND=return] sss
+                  group: files [!NOTFOUND=return] sss
+                  hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files [!NOTFOUND=return] sss
+                  netgroup: files [!NOTFOUND=return] sss
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              end
+            end
           }
         end
-
+  
         context 'with_sssd' do
           let(:params){{
             :use_ldap => false,
             :use_sssd => true
           }}
-
+  
           it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
             passwd: files [!NOTFOUND=return] sss
             shadow: files [!NOTFOUND=return] sss
@@ -101,13 +174,13 @@ describe 'simplib::nsswitch' do
             EOM
           }
         end
-
+  
         context 'with_sssd_and_ldap' do
           let(:params){{
             :use_ldap => true,
             :use_sssd => true
           }}
-
+  
           it { should create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
             passwd: files [!NOTFOUND=return] sss ldap
             shadow: files [!NOTFOUND=return] sss ldap


### PR DESCRIPTION
This change adds 'sss' as a option in /etc/nsswitch.conf as the default
for EL>6. If the SSSD daemon is not running, this will have no adverse
affects and it makes the system function properly out of the box for
systems that do have SSSD running.

Unfortunately, SSSD can have both local and remote accounts so the
situation is not as cut and dry as it was with the 'use_ldap' variable
in the past.

Luckily, nsswitch is quite well written and will not fail on items that
it does not recognize in the configuration file.

SIMP-631 #comment Update nsswitch to use sssd by default in EL>6