### PR TITLE
(SIMP-526) CCE Compliance Disable IPv6

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -1,7 +1,7 @@
 Summary: A collection of common SIMP functions, facts, and puppet code
 Name: pupmod-simplib
 Version: 1.0.0
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -50,6 +50,11 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Thu Dec 17 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.0-2
+- CCE-18455-6, CCE-3562-6 disable ipv6.  Ipv6 remains enabled at
+  the kernel level, but is functionally disabled via sysctl when
+  ipv6_enabled = false.
+
 * Thu Dec 10 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.0-1
 - CCE-4241-6 Single user mode is now password protected.
 - Added a simp_enabled fact to return true if the 'simp' class is in the catalog.

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -200,6 +200,9 @@ class simplib::sysctl (
           'net.ipv6.conf.default.router_solicitations': value => $net__ipv6__conf__default__router_solicitations;
         }
       }
+      else {
+        sysctl::value { 'net.ipv6.conf.all.disable_ipv6': value => '1'; }
+      }
 
       file { '/var/core':
         ensure => 'directory',


### PR DESCRIPTION
CCE-18455-6, CCE-3562-6 disable ipv6.  Ipv6 remains enabled at
the kernel level, but is functionally disabled via sysctl when
ipv6_enabled = false.

SIMP-526 #close
SIMP-525 #close