### PR TITLE
(SIMP-716) Confine Linux facts that break Windows

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -1,7 +1,7 @@
 Summary: A collection of common SIMP functions, facts, and puppet code
 Name: pupmod-simplib
-Version: 1.0.0
-Release: 3
+Version: 1.0.1
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -50,6 +50,9 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Fri Jan 08 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.1-0
+- Confined Linux facts that were causing errors during Windows agent runs
+
 * Thu Dec 24 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-3
 - Removed the simp_enabled fact as it is not needed.
 

--- a/lib/facter/boot_dir_uuid.rb
+++ b/lib/facter/boot_dir_uuid.rb
@@ -1,5 +1,7 @@
 # Return the UUID of the partition holding the /boot directory
 Facter.add('boot_dir_uuid') do
+  confine :kernel => 'Linux'
+
   setcode do
     df_cmd = Facter::Util::Resolution.which('df')
     blkid_cmd = Facter::Util::Resolution.which('blkid')

--- a/lib/facter/defaultgateway.rb
+++ b/lib/facter/defaultgateway.rb
@@ -3,13 +3,15 @@
 # Return the default gateway of the system
 #
 Facter.add(:defaultgateway) do
-    setcode do
-        netstat = %x{/bin/netstat -rn}
-        gw = "unknown"
-        if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
-            gw = $1.split(/\s+/).first
-        end
+  confine :kernel => 'Linux'
 
-        gw
+  setcode do
+    netstat = %x{/bin/netstat -rn}
+    gw = "unknown"
+    if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
+      gw = $1.split(/\s+/).first
     end
+
+    gw
+  end
 end

--- a/lib/facter/defaultgatewayiface.rb
+++ b/lib/facter/defaultgatewayiface.rb
@@ -3,13 +3,15 @@
 # Return the default gw interface of the system.
 #
 Facter.add(:defaultgatewayiface) do
-    setcode do
-        netstat = %x{/bin/netstat -rn}
-        gw_iface = "unknown"
-        if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
-            gw_iface = $1.split(/\s+/).last
-        end
+  setcode do
+    confine :kernel => 'Linux'
 
-        gw_iface
+    netstat = %x{/bin/netstat -rn}
+    gw_iface = "unknown"
+    if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
+      gw_iface = $1.split(/\s+/).last
     end
+
+    gw_iface
+  end
 end

--- a/lib/facter/runlevel.rb
+++ b/lib/facter/runlevel.rb
@@ -4,7 +4,8 @@
 # Return the current system runlevel
 #
 Facter.add("runlevel") do
-    setcode do
-        %x{"/sbin/runlevel"}.split.last
-    end
+  confine :kernel => 'Linux'
+  setcode do
+    %x{"/sbin/runlevel"}.split.last
+  end
 end

--- a/lib/facter/shmall.rb
+++ b/lib/facter/shmall.rb
@@ -3,6 +3,7 @@
 # Return the value of shmall from sysctl.
 #
 Facter.add("shmall") do
+  confine :kernel => 'Linux'
   setcode do
     %x{/sbin/sysctl -n kernel.shmall}.strip
   end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simplib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author":  "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
Before this commit, the custom facts `boot_dir_uuid`, `defaultgateway`,
`defaultgatewayiface`, `runlevel`, `shmall` would report errors during
agent runs on Windows clients.

This patch confines the problem facts to the `:kernel` type `linux`.

SIMP-716 #close #comment Confined Linux facts that break Windows agents