### PR TITLE
Fix ipv6_enabled

### DIFF
--- a/lib/facter/ipv6_enabled.rb
+++ b/lib/facter/ipv6_enabled.rb
@@ -6,7 +6,7 @@
 Facter.add("ipv6_enabled") do
   setcode do
     retval = false
-    ipv6_enabled = Facter::Core::Execution.exec('/sbin/sysctl -n net.ipv6.conf.all.disable_ipv6')
+    ipv6_enabled = Facter::Core::Execution.exec('/sbin/sysctl -n -e net.ipv6.conf.all.disable_ipv6')
 
     # we have observed this exec non-deterministically populate $? with
     # nil, although the exec succeeds.  This will happen with %x, ``, or


### PR DESCRIPTION
If you completly disable ipv6 via options ipv6 disable=1 at module load
this fact throws annoying errors during every puppet run
adding -e will not print error and return ""

PS: Sorry for not creating an issue in your jira