### PR TITLE
(SIMP-720) Added a to_string() function

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -1,7 +1,7 @@
 Summary: A collection of common SIMP functions, facts, and puppet code
 Name: pupmod-simplib
 Version: 1.0.1
-Release: 2
+Release: 3
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -51,6 +51,12 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Mon Feb 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.1-3
+- Added a to_string() function which simply converts the passed argument to a
+  string.
+  This has been added to both pass linting and allow for the case where you
+  *know* you need a string and you want to make sure that is known.
+
 * Fri Feb 19 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 1.0.1-2
 - Added compliance function support
 

--- a/lib/puppet/parser/functions/to_string.rb
+++ b/lib/puppet/parser/functions/to_string.rb
@@ -1,0 +1,19 @@
+module Puppet::Parser::Functions
+  newfunction(:to_string, :type => :rvalue, :arity => 1, :doc => <<-EOS
+    Converts the argument into a String.
+
+    Only works if the passed argument responds to the 'to_s' Ruby method.
+    EOS
+  ) do |arguments|
+
+    arg = arguments[0]
+
+    return arg if arg.is_a?(String)
+
+    if arg.respond_to?(:to_s)
+      return arg.to_s
+    else
+      raise(Puppet::ParseError, "to_string(): Object type '#{arg.class}' cannot be converted to a String")
+    end
+  end
+end

--- a/spec/functions/to_string_spec.rb
+++ b/spec/functions/to_string_spec.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe Puppet::Parser::Functions.function(:to_string) do
+  let(:scope) do
+    PuppetlabsSpec::PuppetInternals.scope
+  end
+
+  subject do
+    function_name = Puppet::Parser::Functions.function(:to_string)
+    scope.method(function_name)
+  end
+
+  it 'should run successfully' do
+    expect {
+      expect(subject.call([12])).to be == '12'
+      expect(subject.call([12])).to_not be == 12
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
To get the Puppet Linter to stop yelling about proper string casts on
single variables, I've added a to_string() function to make it quite
explicit.

SIMP-720 #comment Added to_string function for openldap::server::conf::threads

Change-Id: I21b1a322ca77444cc5c9946a14a6739f63f4fb07