### PR TITLE
(SIMP-913) Update spec to use proper compliance dependency

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -8,7 +8,7 @@ Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: puppetlabs-stdlib
 Requires: puppet >= 3.3.0
-Requires: pupmod-simp-compliance_markup
+Requires: pupmod-onyxpoint-compliance_markup
 
 Buildarch: noarch
 


### PR DESCRIPTION
Spec file referred to the wrong name for pupmod compliance.

SIMP-913 #close