### PR TITLE
(SIMP-917) Updated to default to SSSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 dist
 /pkg
 /spec/fixtures
+/spec/rp_env
 !/spec/hieradata/default.yaml
 !/spec/fixtures/site.pp
 /.rspec_system

--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -1,6 +1,6 @@
 Summary: A collection of common SIMP functions, facts, and puppet code
 Name: pupmod-simplib
-Version: 1.1.0
+Version: 1.2.0
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -53,6 +53,9 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Mon Mar 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.0-0
+- Updated to use SSSD for EL6.7+
+
 * Thu Mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
 - Ensure that the validate_between() function can handle string/integer
   combinations.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # A set of defaults for the 'simplib' namespace
 #
 # $use_sssd
-# Default: false on EL<7, true otherwise
+# Default: false on EL<6.7, true otherwise
 #   There are issues with ldap and nslcd on EL7+ which can result in users
 #   being locked out of the system. SSSD contains a bug which will allow users
 #   with a valid SSH key to bypass the password lockout as returned by LDAP but
@@ -11,7 +11,7 @@
 #   issues which significantly weaken your security posture.
 class simplib::params {
   if $::operatingsystem in ['RedHat','CentOS'] {
-    if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+    if versioncmp($::operatingsystemmajrelease,'6.7') < 0 {
       $_use_sssd = false
     }
     else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simplib",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author":  "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
All systems EL6.7+ should default to using SSSD.

SIMP-917 #comment Update in the simplib space