### PR TITLE
(SIMP-1006) Fix nsswitch edge case

### DIFF
--- a/build/pupmod-simplib.spec
+++ b/build/pupmod-simplib.spec
@@ -1,7 +1,7 @@
 Summary: A collection of common SIMP functions, facts, and puppet code
 Name: pupmod-simplib
-Version: 1.2.2
-Release: 1
+Version: 1.2.3
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -53,6 +53,10 @@ mkdir -p %{buildroot}/%{prefix}/simplib
 # Post uninstall stuff
 
 %changelog
+* Thu Apr 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.3-0
+- The nsswitch.conf logic has been updated to work properly between SSSD and
+  non-SSSD systems.
+
 * Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.2.2-1
 - Fixed deprecation warning in custom types
 

--- a/manifests/nsswitch.pp
+++ b/manifests/nsswitch.pp
@@ -128,24 +128,6 @@ class simplib::nsswitch (
 
   compliance_map()
 
-  # Forcibly set _use_ldap false if use_sssd is true.
-  # Otherwise, use the default parameters.
-  if $use_ldap {
-    if $use_sssd {
-      $_use_sssd = true
-      $_use_ldap = false
-    }
-    else {
-      $_use_ldap = $use_ldap
-    }
-  }
-  else {
-    $_use_ldap = $use_ldap
-    $_use_sssd = $use_sssd
-  }
-
-  validate_bool($_use_ldap)
-
   file { '/etc/nsswitch.conf':
     owner   => 'root',
     group   => 'root',

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -175,6 +175,33 @@ describe 'simplib::nsswitch' do
           }
         end
 
+        context 'with_ldap_and_not_sssd' do
+          let(:params){{
+            :use_ldap => true,
+            :use_sssd => false
+          }}
+
+          it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+            passwd: files [!NOTFOUND=return] ldap
+            shadow: files [!NOTFOUND=return] ldap
+            group: files [!NOTFOUND=return] ldap
+            hosts: files dns
+            bootparams: nisplus [NOTFOUND=return] files
+            ethers: files
+            netmasks: files
+            networks: files
+            protocols: files
+            rpc: files
+            services: files
+            sudoers: files
+            netgroup: files [!NOTFOUND=return] ldap
+            publickey: nisplus
+            automount: files [!NOTFOUND=return] nisplus ldap
+            aliases: files nisplus
+            EOM
+          }
+        end
+
         context 'with_sssd_and_ldap' do
           let(:params){{
             :use_ldap => true,

--- a/templates/etc/nsswitch.conf.erb
+++ b/templates/etc/nsswitch.conf.erb
@@ -23,12 +23,6 @@ options = [
 sss_affects = ['passwd','shadow','group', 'netgroup','sudoers']
 ldap_affects = ['passwd','shadow', 'group', 'netgroup', 'automount']
 
-# This is just here to keep the class consistent with all of the other classes.
-variable_map = {
-  'sss'   => 'sssd',
-  'ldap'  => 'ldap'
-}
-
 def append_content(content,modlist,orig_hash)
   to_mod = orig_hash.dup
   modlist.each do |opt|
@@ -52,12 +46,11 @@ options.each do |opt|
 end
 
 # SSSD Takes precedence
-['sss','ldap'].each do |x|
-  # This relies on knowing that our variables may have internal mappings
-  # This all should probably be rewritten....
-  opt = eval("@_use_#{variable_map[x]}")
-  next unless opt
-  outfile = append_content(x,eval("#{x}_affects"),outfile)
+if @use_sssd
+  outfile = append_content('sss',sss_affects,outfile)
+
+elsif @use_ldap
+  outfile = append_content('ldap',ldap_affects,outfile)
 end
 
 to_ret = []


### PR DESCRIPTION
We had missed a test case where use_ldap was true but use_sssd was
false. This meant that having your environment set this way using the
global catalyst variables would cause nsswitch to be malformed.

SIMP-1006 #close