### PR TITLE
(SIMP-1062) Modeled new static module assets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,28 +1,28 @@
 fixtures:
   repositories:
     # from common
-    auditd:                 'git://github.com/simp/pupmod-simp-auditd.git'
+    auditd:                 'https://github.com/simp/pupmod-simp-auditd'
     augeasproviders_core:
-      repo : 'git://github.com/simp/augeasproviders_core.git'
+      repo : 'https://github.com/simp/augeasproviders_core'
       branch : 'simp-master'
     augeasproviders_grub:
-      repo : 'git://github.com/simp/augeasproviders_grub.git'
+      repo : 'https://github.com/simp/augeasproviders_grub'
       branch : 'simp-master'
     augeasproviders_sysctl:
-      repo : 'git://github.com/simp/augeasproviders_sysctl.git'
+      repo : 'https://github.com/simp/augeasproviders_sysctl'
       branch : 'simp-master'
-    simpcat:                'git://github.com/simp/pupmod-simp-concat.git'
-    functions:              'git://github.com/simp/pupmod-simp-functions.git'
-    gpasswd:                'git://github.com/simp/puppet-gpasswd.git'
-    iptables:               'git://github.com/simp/pupmod-simp-iptables.git'
-    named:                  'git://github.com/simp/pupmod-simp-named.git'
-    oddjob:                 'git://github.com/simp/pupmod-simp-oddjob.git'
-    pam:                    'git://github.com/simp/pupmod-simp-pam.git'
-    rsync:                  'git://github.com/simp/pupmod-simp-rsync.git'
-    stdlib:                 'git://github.com/simp/puppetlabs-stdlib.git'
-    sudo:                   'git://github.com/simp/pupmod-simp-sudo.git'
-    sysctl:                 'git://github.com/simp/pupmod-simp-sysctl.git'
-    upstart:                'git://github.com/simp/pupmod-simp-upstart.git'
+    simpcat:                'https://github.com/simp/pupmod-simp-concat'
+    functions:              'https://github.com/simp/pupmod-simp-functions'
+    gpasswd:                'https://github.com/simp/puppet-gpasswd'
+    iptables:               'https://github.com/simp/pupmod-simp-iptables'
+    named:                  'https://github.com/simp/pupmod-simp-named'
+    oddjob:                 'https://github.com/simp/pupmod-simp-oddjob'
+    pam:                    'https://github.com/simp/pupmod-simp-pam'
+    rsync:                  'https://github.com/simp/pupmod-simp-rsync'
+    stdlib:                 'https://github.com/simp/puppetlabs-stdlib'
+    sudo:                   'https://github.com/simp/pupmod-simp-sudo'
+    sysctl:                 'https://github.com/simp/pupmod-simp-sysctl'
+    upstart:                'https://github.com/simp/pupmod-simp-upstart'
     compliance: "https://github.com/trevor-vaughan/pupmod-compliance"
   symlinks:
     simplib: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,54 +11,87 @@ script:
 notifications:
   email: false
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
+  - 1.9.3
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
-  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
     - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 4.4.0"
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 1.8.7
+    - rvm: 1.9.3
     - rvm: 2.2.1
     - env: PUPPET_VERSION="~> 3.5.0"
     - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+    - env: PUPPET_VERSION="~> 4.3.0"
+
 
   exclude:
-  # Ruby 1.8.7
-  # - Ruby 1.8.7 & Puppet 4.X is impossibru
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0"
-
-  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
-  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
-  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.0"
+  # Ruby 1.9.3
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.2.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.3.0"
 
   # Ruby 2.1.0
   - rvm: 2.1.0
-    env: PUPPET_VERSION="< 3.8"
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
 
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.0"
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.2.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,24 @@
-# Variables:
-#
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# Environment variables:
+#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+#   PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
+# ------------------------------------------------------------------------------
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
-group :development do
+group :test do
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'beaker-rspec'
-  gem 'vagrant-wrapper'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts", "~> 1.3"
+
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -19,7 +27,25 @@ group :development do
       RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
+end
 
-  gem 'google-api-client', '0.9.4'
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "travish"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
+  gem 'pry-doc'
+
+  # `listen` is a dependency of `guard`
+  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
+  gem 'listen', '~> 3.0.6'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
+  gem 'simp-beaker-helpers', '>= 1.0.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
 require 'simp/rake/pupmod/helpers'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
+

--- a/manifests/resolv.pp
+++ b/manifests/resolv.pp
@@ -73,10 +73,13 @@ class simplib::resolv (
     defined('named') and defined(Class['named'])
   ) or (
     $named_autoconf and host_is_me($nameservers)
-  )
-  {
+  ){
     $l_is_named_server = true
   }
+  else{
+    $l_is_named_server = false
+  }
+
 
   if $named_autoconf {
     # Having 127.0.0.1 or ::1 first tells us that we want to be a
@@ -114,8 +117,8 @@ class simplib::resolv (
     deconflict => true
   }
 
-  if defined(Class['named']) and ! $::named::chroot {
-    $bind_pkg = 'bind'
+  if defined_with_params(Class['named'], {'chroot' => false}) {
+      $bind_pkg = 'bind'
   }
   else {
     $bind_pkg = 'bind-chroot'

--- a/manifests/secure_mountpoints.pp
+++ b/manifests/secure_mountpoints.pp
@@ -84,7 +84,7 @@ class simplib::secure_mountpoints (
   # If we decide to secure the tmp mounts....
   if $secure_tmp_mounts {
     # If /tmp is mounted
-    if $::tmp_mount_tmp and !empty($::tmp_mount_tmp) {
+    if getvar('::tmp_mount_tmp') and !empty($::tmp_mount_tmp) {
       $tmp_mount_tmp_opts = split($::tmp_mount_tmp,',')
 
       # If /tmp is not a bind mount and doesn't contain the required options
@@ -140,12 +140,14 @@ class simplib::secure_mountpoints (
       }
     }
 
-    if defined('::simplib::manage_tmp_perms') and $::tmp_mount_tmp {
+    if (defined('$::simplib::manage_tmp_perms') and
+        getvar('::simplib::manage_tmp_perms') and
+        getvar('::tmp_mount_tmp')) {
       File['/tmp'] -> Mount['/tmp']
     }
 
     # If /var/tmp is mounted
-    if $::tmp_mount_var_tmp and !empty($::tmp_mount_var_tmp) {
+    if getvar('::tmp_mount_var_tmp') and !empty($::tmp_mount_var_tmp) {
       $tmp_mount_var_tmp_opts = split($::tmp_mount_var_tmp,',')
 
       # If /var/tmp is not a bind mount then mount it properly.
@@ -198,12 +200,14 @@ class simplib::secure_mountpoints (
       }
     }
 
-    if defined('::simplib::manage_tmp_perms') and $::tmp_mount_var_tmp {
+    if (defined('$::simplib::manage_tmp_perms') and
+        getvar('::simplib::manage_tmp_perms')  and
+        getvar('::tmp_mount_var_tmp')) {
       File['/var/tmp'] -> Mount['/var/tmp']
     }
 
     # If /dev/shm is mounted
-    if $::tmp_mount_dev_shm and !empty($::tmp_mount_dev_shm) {
+    if getvar('::tmp_mount_dev_shm') and !empty($::tmp_mount_dev_shm) {
       $tmp_mount_dev_shm_opts = split($::tmp_mount_dev_shm,',')
 
       # If /dev/shm doesn't contain the required options then mount it

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "source":  "https://github.com/simp/pupmod-simp-simplib",
   "project_page": "https://github.com/simp/pupmod-simp-simplib",
   "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "functions" ],
+  "tags": [ "simp", "functions", "facts", "types" ],
   "dependencies": [
     {
       "name": "onyxpoint/compliance_markup",
@@ -29,5 +29,16 @@
         "7"
       ]
     }
-  ]
+  ],
+  "requirements": [ 
+    {
+      "name": "pe", 
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "simp", 
+      "version_requirement": "3.x"
+    }
+  ],
+  "package_release_version": "0"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,10 +46,6 @@ describe 'simplib' do
 
         context 'when_disabling_fips_and_fips_enabled' do
           let(:facts){ facts.merge({
-              :osfamily => 'RedHat',
-              :operatingsystem => 'CentOS',
-              :operatingsystemrelease => '6.5',
-              :operatingsystemmajrelease => '6',
               :fips_enabled => true,
               :boot_dir_uuid => '123-456-789'
           })}
@@ -70,10 +66,6 @@ describe 'simplib' do
 
         context 'when_disabling_fips_and_fips_not_enabled' do
           let(:facts){ facts.merge({
-            :osfamily => 'RedHat',
-            :operatingsystem => 'CentOS',
-            :operatingsystemrelease => '6.5',
-            :operatingsystemmajrelease => '6',
             :fips_enabled => false,
             :boot_dir_uuid => '123-456-789'
           })}

--- a/spec/classes/resolv_spec.rb
+++ b/spec/classes/resolv_spec.rb
@@ -1,90 +1,89 @@
 require 'spec_helper'
 
 describe 'simplib::resolv' do
-  let(:params){{
-    :nameservers => ['1.2.3.4','5.6.7.8']
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:params){{
+          :nameservers => ['1.2.3.4','5.6.7.8']
+        }}
 
-  let(:facts){{
-    :fqdn => 'foo.bar.baz',
-    :hostname => 'foo',
-    :interfaces => 'eth0',
-    :ipaddress_eth0 => '10.10.10.10',
-    :operatingsystem => 'RedHat',
-    :operatingsystemmajrelease => '7'
-  }}
+        let(:facts){facts.merge({
+          :fqdn => 'foo.bar.baz',
+          :hostname => 'foo',
+          :interfaces => 'eth0',
+          :ipaddress_eth0 => '10.0.2.15',
+        })}
 
-  it { is_expected.to compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-  it { is_expected.not_to contain_named__caching }
-  it { is_expected.to contain_simp_file_line('resolv_peerdns') }
-  it { is_expected.to contain_file('/etc/resolv.conf') }
-  # I think rspec-puppet is broken...
-  # it { should_not contain_file('/etc/resolv.conf').that_comes_before('Service[named]') }
+        it { is_expected.not_to contain_named__caching }
+        it { is_expected.to contain_simp_file_line('resolv_peerdns') }
+        it { is_expected.to contain_file('/etc/resolv.conf') }
+        it { is_expected.not_to contain_file('/etc/resolv.conf').that_comes_before('Service[named]') }
 
-  context 'node_is_nameserver' do
-    let(:params){{
-      :nameservers => ['1.2.3.4','5.6.7.8','10.10.10.10']
-    }}
+        context 'node_is_nameserver' do
+          let(:facts){facts.merge({:ipaddress => '10.0.2.15'})}
 
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.not_to contain_named__caching }
-    it { is_expected.to contain_named }
-    # I think rspec-puppet is broken...
-    # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind]') }
+          let(:params){{
+            :nameservers => ['1.2.3.4','5.6.7.8','10.0.2.15']
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_named__caching }
+          it { is_expected.to contain_named }
+          # I think rspec-puppet is broken...
+          # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind]') }
+        end
+
+        context 'node_is_nameserver_with_selinux' do
+          let(:facts){facts.merge({
+            :fqdn => 'foo.bar.baz',
+            :hostname => 'foo',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '10.0.2.15',
+            :selinux_enforced => true,
+          })}
+          let(:params){{
+            :nameservers => ['1.2.3.4','5.6.7.8','10.0.2.15']
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_named__caching }
+          it { is_expected.to contain_named }
+          # I think rspec-puppet is broken...
+          # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind-chroot]') }
+        end
+
+        context 'node_with_named_autoconf_and_caching' do
+          let(:facts){facts.merge({
+            :fqdn => 'foo.bar.baz',
+            :hostname => 'foo',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '10.0.2.15',
+          })}
+          let(:params){{
+            :nameservers => ['127.0.0.1','1.2.3.4','5.6.7.8']
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_named__caching }
+        end
+
+        context 'node_with_named_autoconf_and_caching_only_127.0.0.1' do
+          let(:facts){facts.merge({
+            :fqdn => 'foo.bar.baz',
+            :hostname => 'foo',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '10.0.2.15',
+          })}
+          let(:params){{
+            :nameservers => ['127.0.0.1']
+          }}
+          it { expect { is_expected.to compile.with_all_deps}.to raise_error(/not be your only/) }
+        end
+
+      end
+    end
   end
-
-  context 'node_is_nameserver_with_selinux' do
-    let(:facts){{
-      :fqdn => 'foo.bar.baz',
-      :hostname => 'foo',
-      :interfaces => 'eth0',
-      :ipaddress_eth0 => '10.10.10.10',
-      :selinux_enforced => true,
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7'
-    }}
-    let(:params){{
-      :nameservers => ['1.2.3.4','5.6.7.8','10.10.10.10']
-    }}
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.not_to contain_named__caching }
-    it { is_expected.to contain_named }
-    # I think rspec-puppet is broken...
-    # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind-chroot]') }
-  end
-
-  context 'node_with_named_autoconf_and_caching' do
-    let(:facts){{
-      :fqdn => 'foo.bar.baz',
-      :hostname => 'foo',
-      :interfaces => 'eth0',
-      :ipaddress_eth0 => '10.10.10.10',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7'
-    }}
-    let(:params){{
-      :nameservers => ['127.0.0.1','1.2.3.4','5.6.7.8']
-    }}
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_named__caching }
-  end
-
-  context 'node_with_named_autoconf_and_caching_only_127.0.0.1' do
-    let(:facts){{
-      :fqdn => 'foo.bar.baz',
-      :hostname => 'foo',
-      :interfaces => 'eth0',
-      :ipaddress_eth0 => '10.10.10.10',
-      :operatingsystem => 'RedHat',
-      :operatingsystemmajrelease => '7'
-    }}
-    let(:params){{
-      :nameservers => ['127.0.0.1']
-    }}
-    it { expect { is_expected.to compile.with_all_deps}.to raise_error(/not be your only/) }
-  end
-
 end

--- a/spec/classes/secure_mountpoints_spec.rb
+++ b/spec/classes/secure_mountpoints_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'simplib::secure_mountpoints' do
-  on_supported_os.each do |os, base_facts|
+  on_supported_os({:selinux_mode => :disabled}).each do |os, os_facts|
 
     context "on #{os}" do
-      let(:facts){ base_facts.dup }
+      let(:facts){ os_facts }
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_mount('/dev/pts').with_options('rw,gid=5,mode=620,noexec') }
       it { is_expected.to contain_mount('/sys').with_options('rw,nodev,noexec') }
@@ -18,13 +18,12 @@ describe 'simplib::secure_mountpoints' do
       })}
 
       context 'tmp_is_partition' do
-        new_facts = base_facts.dup
-        new_facts[:tmp_mount_tmp] = 'rw,seclabel,relatime,data=ordered'
-        new_facts[:tmp_mount_fstype_tmp] = 'ext4'
-        new_facts[:tmp_mount_path_tmp] = '/dev/sda3'
-
-        let(:facts){new_facts}
-
+        let(:facts) do os_facts.merge({
+            :tmp_mount_tmp        => 'rw,seclabel,relatime,data=ordered',
+            :tmp_mount_fstype_tmp => 'ext4',
+            :tmp_mount_path_tmp   => '/dev/sda3',
+          })
+        end
         it { is_expected.to contain_mount('/tmp').with({
           :options => 'data=ordered,nodev,noexec,nosuid,relatime,rw',
           :device  => '/dev/sda3'
@@ -32,13 +31,11 @@ describe 'simplib::secure_mountpoints' do
       end
 
       context 'tmp_is_already_bind_mounted' do
-        new_facts = base_facts.dup
-        new_facts[:tmp_mount_tmp] = 'bind,foo'
-        new_facts[:tmp_mount_fstype_tmp] = 'ext4'
-        new_facts[:tmp_mount_path_tmp] = '/tmp'
-
-        let(:facts){new_facts}
-
+        let(:facts) { os_facts.merge({
+            :tmp_mount_tmp        => 'bind,foo',
+            :tmp_mount_fstype_tmp => 'ext4',
+            :tmp_mount_path_tmp   => '/tmp',
+        })}
         it { is_expected.to contain_mount('/tmp').with({
           :options => "bind,nodev,noexec,nosuid",
           :device  => '/tmp'
@@ -46,13 +43,11 @@ describe 'simplib::secure_mountpoints' do
       end
 
       context 'var_tmp_is_partition' do
-        new_facts = base_facts.dup
-        new_facts[:tmp_mount_var_tmp] = 'rw,seclabel,relatime,data=ordered'
-        new_facts[:tmp_mount_fstype_var_tmp] = 'ext4'
-        new_facts[:tmp_mount_path_var_tmp] = '/dev/sda3'
-
-        let(:facts){new_facts}
-
+        let(:facts) { os_facts.merge({
+            :tmp_mount_var_tmp        => 'rw,seclabel,relatime,data=ordered',
+            :tmp_mount_fstype_var_tmp => 'ext4',
+            :tmp_mount_path_var_tmp   => '/dev/sda3',
+        })}
         it { is_expected.to contain_mount('/var/tmp').with({
           :options => 'data=ordered,nodev,noexec,nosuid,relatime,rw',
           :device  => '/dev/sda3'
@@ -60,31 +55,55 @@ describe 'simplib::secure_mountpoints' do
       end
 
       context 'var_tmp_is_already_bind_mounted' do
-        new_facts = base_facts.dup
-        new_facts[:tmp_mount_var_tmp] = 'bind,foo'
-        new_facts[:tmp_mount_fstype_var_tmp] = 'ext4'
-        new_facts[:tmp_mount_path_var_tmp] = '/var/tmp'
-
-        let(:facts){new_facts}
-
+        let(:facts) { os_facts.merge({
+            :tmp_mount_var_tmp        => 'bind,foo',
+            :tmp_mount_fstype_var_tmp => 'ext4',
+            :tmp_mount_path_var_tmp   => '/var/tmp',
+        })}
         it { is_expected.to contain_mount('/var/tmp').with({
           :options => "bind,nodev,noexec,nosuid",
-          :device  => new_facts[:tmp_mount_path_var_tmp]
+          :device  => facts[:tmp_mount_path_var_tmp]
         })}
       end
 
       context 'tmp_mount_dev_shm_mounted' do
-        new_facts = base_facts.dup
-        new_facts[:tmp_mount_dev_shm] = 'rw,seclabel,nosuid,nodev'
-        new_facts[:tmp_mount_fstype_dev_shm] = 'tmpfs'
-        new_facts[:tmp_mount_path_dev_shm] = 'tmpfs'
-
-        let(:facts){new_facts}
-
+        let(:facts) { os_facts.merge({
+            :tmp_mount_dev_shm        => 'rw,seclabel,nosuid,nodev',
+            :tmp_mount_fstype_dev_shm => 'tmpfs',
+            :tmp_mount_path_dev_shm   => 'tmpfs',
+        })}
         it { is_expected.to contain_mount('/dev/shm').with({
           :options => 'nodev,noexec,nosuid,rw',
-          :device  => new_facts[:tmp_mount_path_dev_shm]
+          :device  => facts[:tmp_mount_path_dev_shm]
         })}
+      end
+
+      context 'when `::simplib` is included' do
+        let(:pre_condition){ 'include "simplib"' }
+        let(:facts){ os_facts.merge({
+          :tmp_mount_tmp            => 'rw,relatime,data=ordered',
+          :tmp_mount_fstype_tmp     => 'ext4',
+          :tmp_mount_path_tmp       => '/dev/sda3',
+          :tmp_mount_var_tmp        => 'rw,relatime,data=ordered',
+          :tmp_mount_fstype_var_tmp => 'ext4',
+          :tmp_mount_path_var_tmp   => '/dev/sda4',
+        })}
+
+        context 'and `::simplib::manage_tmp_perms => true' do
+          let(:pre_condition){ 'class{"simplib": manage_tmp_perms=>true}'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/tmp').that_comes_before('Mount[/tmp]') }
+          it { is_expected.to contain_file('/var/tmp').that_comes_before('Mount[/var/tmp]') }
+        end
+
+        context 'and `::simplib::manage_tmp_perms => false' do
+          let(:pre_condition){ 'class{"simplib": manage_tmp_perms=>false}'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_mount('/tmp') }
+          it { is_expected.to contain_mount('/var/tmp') }
+          it { is_expected.not_to contain_file('/tmp') }
+          it { is_expected.not_to contain_file('/var/tmp') }
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ default_hiera_config =<<-EOM
   :datadir: "stub"
 :hierarchy:
   - "%{custom_hiera}"
-  - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM


### PR DESCRIPTION
This commit contains prototype static assets for running spec tests when
`STRICT_VARIABLES=yes`

**NOTE:** The spec tests for this commit require v1.2.0i or above of
`simp-rspec-puppet-facts`

SIMP-1062 #close Updated static module assets in `pupmod-simp-simplib`
SIMP-1062 #comment Codifeid SELinux as `disabled` in secure mnts test
Change-Id: I41852569223c44bb3ad625c805d151deef121551