### PR TITLE
(SIMP-705) Install tmpwatch package for EL6 systems

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -32,8 +32,9 @@ class simplib::cron (
   $use_rsync = true,
   $rsync_root = 'default/global_etc',
   $rsync_server = hiera('rsync::server',''),
-  $rsync_timeout = hiera('rsync::timeout','2')
-){
+  $rsync_timeout = hiera('rsync::timeout','2'),
+  $install_tmpwatch = $::simplib::params::install_tmpwatch,
+) inherits simplib::params {
   validate_bool($use_rsync)
 
   compliance_map()
@@ -62,7 +63,6 @@ class simplib::cron (
   }
 
   if $use_rsync {
-
     rsync { 'cron':
       source  => "${rsync_root}/cron.*",
       target  => '/etc',
@@ -77,5 +77,9 @@ class simplib::cron (
     enable     => true,
     hasstatus  => true,
     hasrestart => true
+  }
+
+  if $install_tmpwatch {
+    package { 'tmpwatch': ensure => latest }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,15 +13,18 @@ class simplib::params {
   if $::operatingsystem in ['RedHat','CentOS'] {
     if versioncmp($::operatingsystemrelease,'6.7') < 0 {
       $_use_sssd = false
+      $_install_tmpwatch = true
     }
     else {
       $_use_sssd = true
+      $_install_tmpwatch = false
     }
 
     $use_sssd = defined('$::use_sssd') ? {
       true => $::use_sssd,
       default => hiera('use_sssd',$_use_sssd)
     }
+
   }
   else {
     fail("${::operatingsystem} not yet supported by ${module_name}")

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -18,6 +18,12 @@ describe 'simplib::cron' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to create_rsync('cron') }
         end
+
+        if facts['operatingsystemmajrelease' == 6 ]
+          it { is_expected.to contain_package('tmpwatch') }
+        else
+          it { is_expected.not_to contain_package('tmpwatch') }
+        end
       end
     end
 


### PR DESCRIPTION
We have a cron job for tmpwatch but it may not necessarily exist.

This should only apply on EL6 systems.

SIMP-705 #close