### PR TITLE
(SIMP-1337) Mitigate CVE-2016-5696 via sysctl

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Aug 11 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 1.3.0-0
+- Mitigate CVE-2016-5696 via sysctl
+
 * Fri Jul 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.7-0
 - Fixed the acceptance tests
 

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -55,6 +55,7 @@ class simplib::sysctl (
   $net__ipv4__conf__default__send_redirects = '0',                # CCE-27001-7
   $net__ipv4__icmp_echo_ignore_broadcasts = '1',                  # CCE-26883-9
   $net__ipv4__icmp_ignore_bogus_error_responses = '1',            # CCE-26993-6
+  $net__ipv4__tcp_challenge_ack_limit = '2147483647',             # CVE-2016-5696 mitigation
   $net__ipv4__tcp_max_syn_backlog = '4096',
   $net__ipv4__tcp_syncookies = '1',                               # CCE-27053-8
   $enable_ipv6 = defined('$::enable_ipv6') ? { true => $::enable_ipv6, default => hiera('enable_ipv6',true) },
@@ -113,6 +114,7 @@ class simplib::sysctl (
   validate_array_member($net__ipv4__conf__default__send_redirects,['0','1'])
   validate_array_member($net__ipv4__icmp_echo_ignore_broadcasts,['0','1'])
   validate_array_member($net__ipv4__icmp_ignore_bogus_error_responses,['0','1'])
+  validate_integer($net__ipv4__tcp_challenge_ack_limit)
   validate_integer($net__ipv4__tcp_max_syn_backlog)
   validate_array_member($net__ipv4__tcp_syncookies,['0','1'])
   validate_bool($enable_ipv6)
@@ -180,6 +182,7 @@ class simplib::sysctl (
         'net.ipv4.conf.default.send_redirects':       value => $net__ipv4__conf__default__send_redirects;
         'net.ipv4.icmp_echo_ignore_broadcasts':       value => $net__ipv4__icmp_echo_ignore_broadcasts;
         'net.ipv4.icmp_ignore_bogus_error_responses': value => $net__ipv4__icmp_ignore_bogus_error_responses;
+        'net.ipv4.tcp_challenge_ack_limit':           value => $net__ipv4__tcp_challenge_ack_limit;
         'net.ipv4.tcp_max_syn_backlog':               value => $net__ipv4__tcp_max_syn_backlog;
         'net.ipv4.tcp_syncookies':                    value => $net__ipv4__tcp_syncookies;
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simplib",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "author":  "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
Set sysctl `net.ipv4.tcp_challenge_ack_limit` to its maximum value to
mitigate CVE-2016-5696, off-path TCP hijack via a blind in-window attack
due to improperly rate-limited ACK segments.  Note that this does not
fix the vulnerability, it only makes it more difficult for an attacker
to exploit it.