### PR TITLE
(SIMP-1435) Fix `swappiness` to use `sysctl` type

### DIFF
--- a/spec/classes/swappiness_spec.rb
+++ b/spec/classes/swappiness_spec.rb
@@ -10,13 +10,12 @@ describe 'simplib::swappiness' do
 
         it { is_expected.to create_file('/usr/local/sbin/dynamic_swappiness.rb') }
         it { is_expected.to create_cron('dynamic_swappiness') }
-        it { is_expected.not_to create_sysctl__value('vm.swappiness') }
+        it { is_expected.not_to create_sysctl('vm.swappiness') }
 
         context 'absolute_swappiness' do
           let(:params){{ :absolute_swappiness => '10' }}
-          it { is_expected.not_to create_file('/usr/local/sbin/dynamic_swappiness.rb') }
           it { is_expected.to create_cron('dynamic_swappiness').with(:ensure => 'absent') }
-          it { is_expected.to create_sysctl__value('vm.swappiness').with_value('10') }
+          it { is_expected.to create_sysctl('vm.swappiness').with_value('10') }
         end
       end
     end


### PR DESCRIPTION
Before this commit, the `simplib::swappiness` class still used the
`sysctl::value` define instead of the `sysctl` type from
`augeasproviders_systctl`.  This resulted in a SyntaxError that broke
the catalog when the `absolute_swappiness` was used.

This commit fixes the issue by convering the class and its tests from
using `sysctl::value` to `sysctl`.

SIMP-1435 #close #comment Fix `swappiness` to use `sysctl` type

Change-Id: I93c7cf3bfffc925fccc6fb11cc7d1cabf04864b6