### PR TITLE
(SIMP-1371) Fix for diverse named service names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'vagrant-wrapper'
 end

--- a/manifests/resolv.pp
+++ b/manifests/resolv.pp
@@ -97,14 +97,14 @@ class simplib::resolv (
         $l_forwarders = inline_template('<%= @nameservers[1..-1].join(" ") %>')
         named::caching::forwarders { $l_forwarders: }
 
-        File['/etc/resolv.conf'] -> Service['named']
+        File['/etc/resolv.conf'] -> Class['named::service']
       }
     }
     else {
       if $l_is_named_server {
         include 'named'
 
-        File['/etc/resolv.conf'] -> Service['named']
+        File['/etc/resolv.conf'] -> Class['named::service']
       }
     }
   }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
     roles:
       - client
     platform:   el-6-x86_64
-    box:        centos/6
+    box:        puppetlabs/centos-6.6-64-nocm
     hypervisor: vagrant
 CONFIG:
   log_level: verbose

--- a/spec/classes/resolv_spec.rb
+++ b/spec/classes/resolv_spec.rb
@@ -20,7 +20,9 @@ describe 'simplib::resolv' do
         it { is_expected.not_to contain_named__caching }
         it { is_expected.to contain_simp_file_line('resolv_peerdns') }
         it { is_expected.to contain_file('/etc/resolv.conf') }
-        it { is_expected.not_to contain_file('/etc/resolv.conf').that_comes_before('Service[named]') }
+        it { is_expected.to contain_file('/etc/resolv.conf') }
+        it { is_expected.not_to contain_class('named') }
+        it { is_expected.not_to contain_class('named::caching') }
 
         context 'node_is_nameserver' do
           let(:facts){facts.merge({:ipaddress => '10.0.2.15'})}
@@ -32,8 +34,7 @@ describe 'simplib::resolv' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_named__caching }
           it { is_expected.to contain_named }
-          # I think rspec-puppet is broken...
-          # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind]') }
+          it { is_expected.to contain_file('/etc/resolv.conf').that_comes_before('Class[named::service]') }
         end
 
         context 'node_is_nameserver_with_selinux' do
@@ -51,8 +52,7 @@ describe 'simplib::resolv' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_named__caching }
           it { is_expected.to contain_named }
-          # I think rspec-puppet is broken...
-          # it { should contain_file('/etc/resolv.conf').that_comes_before('Service[bind-chroot]') }
+          it { is_expected.to contain_file('/etc/resolv.conf').that_comes_before('Class[named::service]') }
         end
 
         context 'node_with_named_autoconf_and_caching' do


### PR DESCRIPTION
Prior to this `named::resolv` made reference to `Service['named']`,
causing errors in cases where the named servce was not called "named."
This commit changes the reference to `Class['named']` to abstract out
the service name and any other potential starup quirks.

Change-Id: I139580eeb977ce9a8852a51781e003f180175186
