### PR TITLE
(SIMP-1506) Add support for nss-myhostname

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Oct 13 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.3.4-0
+- EL 7 machines now default nsswitch hosts to 'files','myhostname','dns'
+  in an attempt to mitigate https://bugs.centos.org/view.php?id=10635
+
 * Tue Oct 11 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 1.3.3-0
 - Prior to this `named::resolv` made reference to `Service['named']`,
   causing errors in cases where the named servce was not called "named."

--- a/manifests/nsswitch.pp
+++ b/manifests/nsswitch.pp
@@ -91,7 +91,7 @@ class simplib::nsswitch (
   $shadow =  ['files'],
   $group =  ['files'],
   $initgroups =  [],
-  $hosts =  ['files','dns'],
+  $hosts =  $::simplib::params::nsswitch_hosts,
   $bootparams =  ['nisplus [NOTFOUND=return]','files'],
   $ethers =  ['files'],
   $netmasks =  ['files'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,13 @@ class simplib::params {
       $install_tmpwatch = false
     }
 
+    if versioncmp($::operatingsystemmajrelease,'6') > 0 {
+      $nsswitch_hosts = ['files','myhostname','dns']
+    }
+    else {
+      $nsswitch_hosts = ['files','dns']
+    }
+
   }
   else {
     fail("${::operatingsystem} not yet supported by ${module_name}")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -27,12 +27,31 @@ describe 'simplib::nsswitch' do
                 automount: files nisplus
                 aliases: files nisplus
                 EOM
-            else
+            elsif facts[:operatingsystemrelease] >= '6.7' and facts[:operatingsystemmajrelease] < '7'
               is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
                 passwd: files [!NOTFOUND=return] sss
                 shadow: files [!NOTFOUND=return] sss
                 group: files [!NOTFOUND=return] sss
                 hosts: files dns
+                bootparams: nisplus [NOTFOUND=return] files
+                ethers: files
+                netmasks: files
+                networks: files
+                protocols: files
+                rpc: files
+                services: files
+                sudoers: files [!NOTFOUND=return] sss
+                netgroup: files [!NOTFOUND=return] sss
+                publickey: nisplus
+                automount: files nisplus
+                aliases: files nisplus
+                EOM
+            else
+              is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                passwd: files [!NOTFOUND=return] sss
+                shadow: files [!NOTFOUND=return] sss
+                group: files [!NOTFOUND=return] sss
+                hosts: files myhostname dns
                 bootparams: nisplus [NOTFOUND=return] files
                 ethers: files
                 netmasks: files
@@ -75,13 +94,33 @@ describe 'simplib::nsswitch' do
                   automount: files nisplus
                   aliases: files nisplus
                   EOM
-              else
+              elsif facts[:operatingsystemrelease] >= '6.7' and facts[:operatingsystemmajrelease] < '7'
                 is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
                   passwd: files [!NOTFOUND=return] sss
                   shadow: files [!NOTFOUND=return] sss
                   group: files [!NOTFOUND=return] sss
                   initgroups: files
                   hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files [!NOTFOUND=return] sss
+                  netgroup: files [!NOTFOUND=return] sss
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              else
+                is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files [!NOTFOUND=return] sss
+                  shadow: files [!NOTFOUND=return] sss
+                  group: files [!NOTFOUND=return] sss
+                  initgroups: files
+                  hosts: files myhostname dns
                   bootparams: nisplus [NOTFOUND=return] files
                   ethers: files
                   netmasks: files
@@ -124,12 +163,31 @@ describe 'simplib::nsswitch' do
                   automount: files nisplus
                   aliases: files nisplus
                   EOM
-              else
+              elsif facts[:operatingsystemrelease] >= '6.7' and facts[:operatingsystemmajrelease] < '7'
                 is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
                   passwd: files [!NOTFOUND=return] sss
                   shadow: files [!NOTFOUND=return] sss
                   group: files [!NOTFOUND=return] sss
                   hosts: files dns
+                  bootparams: nisplus [NOTFOUND=return] files
+                  ethers: files
+                  netmasks: files
+                  networks: files
+                  protocols: files
+                  rpc: files
+                  services: files
+                  sudoers: files [!NOTFOUND=return] sss
+                  netgroup: files [!NOTFOUND=return] sss
+                  publickey: nisplus
+                  automount: files nisplus
+                  aliases: files nisplus
+                  EOM
+              else
+                is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+                  passwd: files [!NOTFOUND=return] sss
+                  shadow: files [!NOTFOUND=return] sss
+                  group: files [!NOTFOUND=return] sss
+                  hosts: files myhostname dns
                   bootparams: nisplus [NOTFOUND=return] files
                   ethers: files
                   netmasks: files
@@ -154,25 +212,47 @@ describe 'simplib::nsswitch' do
             :use_sssd => true
           }}
 
-          it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files [!NOTFOUND=return] sss
-            shadow: files [!NOTFOUND=return] sss
-            group: files [!NOTFOUND=return] sss
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files [!NOTFOUND=return] sss
-            netgroup: files [!NOTFOUND=return] sss
-            publickey: nisplus
-            automount: files nisplus
-            aliases: files nisplus
-            EOM
-          }
+          if facts[:operatingsystemmajrelease] < '7'
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] sss
+              shadow: files [!NOTFOUND=return] sss
+              group: files [!NOTFOUND=return] sss
+              hosts: files dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files [!NOTFOUND=return] sss
+              netgroup: files [!NOTFOUND=return] sss
+              publickey: nisplus
+              automount: files nisplus
+              aliases: files nisplus
+              EOM
+            }
+          else
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] sss
+              shadow: files [!NOTFOUND=return] sss
+              group: files [!NOTFOUND=return] sss
+              hosts: files myhostname dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files [!NOTFOUND=return] sss
+              netgroup: files [!NOTFOUND=return] sss
+              publickey: nisplus
+              automount: files nisplus
+              aliases: files nisplus
+              EOM
+            }
+          end
         end
 
         context 'with_ldap_and_not_sssd' do
@@ -181,25 +261,47 @@ describe 'simplib::nsswitch' do
             :use_sssd => false
           }}
 
-          it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files [!NOTFOUND=return] ldap
-            shadow: files [!NOTFOUND=return] ldap
-            group: files [!NOTFOUND=return] ldap
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files
-            netgroup: files [!NOTFOUND=return] ldap
-            publickey: nisplus
-            automount: files [!NOTFOUND=return] nisplus ldap
-            aliases: files nisplus
-            EOM
-          }
+          if facts[:operatingsystemmajrelease] < '7'
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] ldap
+              shadow: files [!NOTFOUND=return] ldap
+              group: files [!NOTFOUND=return] ldap
+              hosts: files dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files
+              netgroup: files [!NOTFOUND=return] ldap
+              publickey: nisplus
+              automount: files [!NOTFOUND=return] nisplus ldap
+              aliases: files nisplus
+              EOM
+            }
+          else
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] ldap
+              shadow: files [!NOTFOUND=return] ldap
+              group: files [!NOTFOUND=return] ldap
+              hosts: files myhostname dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files
+              netgroup: files [!NOTFOUND=return] ldap
+              publickey: nisplus
+              automount: files [!NOTFOUND=return] nisplus ldap
+              aliases: files nisplus
+              EOM
+            }
+          end
         end
 
         context 'with_sssd_and_ldap' do
@@ -208,25 +310,47 @@ describe 'simplib::nsswitch' do
             :use_sssd => true
           }}
 
-          it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
-            passwd: files [!NOTFOUND=return] sss
-            shadow: files [!NOTFOUND=return] sss
-            group: files [!NOTFOUND=return] sss
-            hosts: files dns
-            bootparams: nisplus [NOTFOUND=return] files
-            ethers: files
-            netmasks: files
-            networks: files
-            protocols: files
-            rpc: files
-            services: files
-            sudoers: files [!NOTFOUND=return] sss
-            netgroup: files [!NOTFOUND=return] sss
-            publickey: nisplus
-            automount: files nisplus
-            aliases: files nisplus
-            EOM
-          }
+          if facts[:operatingsystemmajrelease] < '7'
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] sss
+              shadow: files [!NOTFOUND=return] sss
+              group: files [!NOTFOUND=return] sss
+              hosts: files dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files [!NOTFOUND=return] sss
+              netgroup: files [!NOTFOUND=return] sss
+              publickey: nisplus
+              automount: files nisplus
+              aliases: files nisplus
+              EOM
+            }
+          else
+            it { is_expected.to create_file('/etc/nsswitch.conf').with_content(<<-EOM.gsub(/^\s+/,''))
+              passwd: files [!NOTFOUND=return] sss
+              shadow: files [!NOTFOUND=return] sss
+              group: files [!NOTFOUND=return] sss
+              hosts: files myhostname dns
+              bootparams: nisplus [NOTFOUND=return] files
+              ethers: files
+              netmasks: files
+              networks: files
+              protocols: files
+              rpc: files
+              services: files
+              sudoers: files [!NOTFOUND=return] sss
+              netgroup: files [!NOTFOUND=return] sss
+              publickey: nisplus
+              automount: files nisplus
+              aliases: files nisplus
+              EOM
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
EL 7 machines now default nsswitch hosts to 'files','myhostname','dns'
in an attempt to mitigate https://bugs.centos.org/view.php?id=10635.

SIMP-1506 #close
