### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,39 +1,50 @@
+---
 fixtures:
   repositories:
     auditd:
-      repo: 'https://github.com/simp/pupmod-simp-auditd'
+      repo: https://github.com/simp/pupmod-simp-auditd
+      branch: 5.X
     augeasproviders_core:
-      repo:   'https://github.com/simp/augeasproviders_core'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_core
     augeasproviders_grub:
-      repo:   'https://github.com/simp/augeasproviders_grub'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_grub
     augeasproviders_sysctl:
-      repo:   'https://github.com/simp/augeasproviders_sysctl'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_sysctl
     compliance_markup:
-      repo: 'https://github.com/simp/pupmod-simp-compliance_markup'
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
     gpasswd:
-      repo:   'https://github.com/simp/puppet-gpasswd'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/puppet-gpasswd
     iptables:
-      repo: 'https://github.com/simp/pupmod-simp-iptables'
+      repo: https://github.com/simp/pupmod-simp-iptables
+      branch: 5.X
     named:
-      repo: 'https://github.com/simp/pupmod-simp-named'
+      repo: https://github.com/simp/pupmod-simp-named
+      branch: 5.X
     oddjob:
-      repo: 'https://github.com/simp/pupmod-simp-oddjob'
+      repo: https://github.com/simp/pupmod-simp-oddjob
+      branch: 5.X
     pam:
-      repo: 'https://github.com/simp/pupmod-simp-pam'
+      repo: https://github.com/simp/pupmod-simp-pam
+      branch: 5.X
     rsync:
-      repo: 'https://github.com/simp/pupmod-simp-rsync'
+      repo: https://github.com/simp/pupmod-simp-rsync
+      branch: 5.X
     simpcat:
-      repo: 'https://github.com/simp/pupmod-simp-simpcat'
+      repo: https://github.com/simp/pupmod-simp-simpcat
+      branch: 5.X
     stdlib:
-      repo:   'https://github.com/simp/puppetlabs-stdlib'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
     sudo:
-      repo: 'https://github.com/simp/pupmod-simp-sudo'
+      repo: https://github.com/simp/pupmod-simp-sudo
+      branch: 5.X
     upstart:
-      repo: 'https://github.com/simp/pupmod-simp-upstart'
+      repo: https://github.com/simp/pupmod-simp-upstart
+      branch: 5.X
   symlinks:
     simplib: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in simplib
