### PR TITLE
(SIMP-1697) validate_net_list regex & IPv6 errors

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,14 +18,20 @@ fixtures:
       branch: 'simp-master'
     iptables:
       repo: 'https://github.com/simp/pupmod-simp-iptables'
+    logrotate:
+      repo: 'https://github.com/simp/pupmod-simp-logrotate'
     named:
       repo: 'https://github.com/simp/pupmod-simp-named'
     oddjob:
       repo: 'https://github.com/simp/pupmod-simp-oddjob'
     pam:
       repo: 'https://github.com/simp/pupmod-simp-pam'
+    pki:
+      repo: 'https://github.com/simp/pupmod-simp-pki'
     rsync:
       repo: 'https://github.com/simp/pupmod-simp-rsync'
+    rsyslog:
+      repo: 'https://github.com/simp/pupmod-simp-rsyslog'
     simpcat:
       repo: 'https://github.com/simp/pupmod-simp-simpcat'
     stdlib:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Oct 14 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 1.3.4-0
+- Fix errors when validate_net_list uses regex strings and
+  is validating IPv6.
+
 * Tue Oct 11 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 1.3.3-0
 - Prior to this `named::resolv` made reference to `Service['named']`,
   causing errors in cases where the named servce was not called "named."

--- a/lib/puppet/parser/functions/validate_net_list.rb
+++ b/lib/puppet/parser/functions/validate_net_list.rb
@@ -15,8 +15,8 @@ module Puppet::Parser::Functions
       $client_nets = '10.10.10.0/24'
       validate_net_list($client_nets)
 
-      $client_nets = ['10.10.10.0/24','1.2.3.4','any','ALL']
-      validate_net_list($client_nets,'^(any|ALL)$')
+      $client_nets = ['10.10.10.0/24','1.2.3.4','%any','ALL']
+      validate_net_list($client_nets,'^(%any|ALL)$')
 
     The following values will fail:
 
@@ -41,7 +41,7 @@ module Puppet::Parser::Functions
     str_match = args.shift
 
     if str_match
-      str_match = Regexp.new(Regexp.escape(str_match))
+      str_match = Regexp.new(str_match)
       net_list.delete_if{|x| str_match.match(x)}
     end
 
@@ -52,21 +52,27 @@ module Puppet::Parser::Functions
     Puppet::Parser::Functions.autoloader.loadall
 
     net_list.each do |net|
+      # Do we have a port?
+      host,port = PuppetX::SIMP::Simplib.split_port(net)
+      function_validate_port(Array(port)) if (port && !port.empty?)
+
+      # Valid quad-dotted IPv4 addresses will validate as hostnames.
+      # So check for IP addresses first
       begin
-        # Do we have a port?
-        host,port = PuppetX::SIMP::Simplib.split_port(net)
-        function_validate_port(Array(port)) if (port && !port.empty?)
-
-        # Just skip it if it's a hostname.
-        next if PuppetX::SIMP::Simplib.hostname?(host)
-
         ip = IPAddr.new(host)
-        unless (ip.ipv4? || ip.ipv6?)
-         # This is just here to re-use the rescue below.
-         raise ArgumentError
+      rescue IPAddr::Error => e
+        # if looks like quad-dotted set of decimal numbers, most likely
+        # it is not an oddly-named host, but a bad IPv4 address in which
+        # one or more of the octets is out of range (configuration
+        # fat-finger....)
+        if host.match(/^([0-9]+)(\.[0-9]+){3}$/)
+          raise Puppet::ParseError,("validate_net_list(): '#{net}' is not a valid network.")
         end
-      rescue ArgumentError
-        raise Puppet::ParseError,("validate_net_list(): '#{net}' is not a valid network.")
+
+        # assume OK if this looks like hostname
+        unless PuppetX::SIMP::Simplib.hostname_only?(host)
+          raise Puppet::ParseError,("validate_net_list(): '#{net}' is not a valid network.")
+        end
       end
     end
   end

--- a/lib/puppetx/simp/simplib.rb
+++ b/lib/puppetx/simp/simplib.rb
@@ -18,7 +18,11 @@ module PuppetX
       end
 
       # Determine whether or not the passed value is a valid hostname.
-      def self.hostname?(obj)
+      # Returns false if is not comprised of ASCII letters (upper or lower case),
+      # digits, hypens (except at the beginning and end), and dots (except at
+      # beginning and end)
+      # NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+      def self.hostname_only?(obj)
         # This regex shamelessly lifted from
         # http://stackoverflow.com/questions/106179/regular-expression-to-match-hostname-or-ip-address
         hname_regex = Regexp.new(/^
@@ -29,25 +33,55 @@ module PuppetX
           (
             [A-Za-z0-9]|
             [A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]
+          )$/x)
+
+        !hname_regex.match(obj).nil?
+      end
+
+      # Determine whether or not the passed value is a valid hostname optionally
+      # postpended with ':<number>' or '/<number>'.
+      # Returns false if is not comprised of ASCII letters (upper or lower case),
+      # digits, hypens (except at the beginning and end), and dots (except at
+      # beginning and end), optional pluss ':<number>' or '/<number>'
+      # NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+      def self.hostname?(obj)
+        # This regex shamelessly lifted from
+        # http://stackoverflow.com/questions/106179/regular-expression-to-match-hostname-or-ip-address
+        # and then augmented for postpends
+        hname_regex = Regexp.new(/^
+          (
+            ([a-zA-Z0-9]|
+            [a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.
+          )*
+          (
+            [A-Za-z0-9]|
+            [A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]
           )((:|\/)?(\d+))?$/x)
 
-        hname_regex.match(obj)
+        !hname_regex.match(obj).nil?
       end
 
       # Return a host/port pair
       def self.split_port(host_string)
-        host_pair = nil
+        return [nil,nil] if host_string.nil? or host_string.empty?
+
+        # CIDR addresses do not have ports
+        return [host_string, nil] if host_string.include?('/')
+
         # IPv6 Easy
         if host_string.include?(']')
           host_pair = host_string.split(/\]:?/)
           host_pair[0] = host_pair[0] + ']'
+          host_pair[1] = nil if host_pair.size == 1
         # IPv6 Fallback
         elsif host_string.count(':') > 1
           # Normalize IPv6 addresses to have '[]' for clarity
           host_pair = [%([#{host_string}]),nil]
         # Everything Else
-        else
+        elsif host_string.include?(':')
           host_pair = host_string.split(':')
+        else
+          host_pair = [host_string,nil]
         end
 
         host_pair

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "simp",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib_spec.rb
+++ b/spec/functions/simplib_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+$: << File.join(File.dirname(__FILE__), '..', '..', 'lib')
+
+require 'puppetx/simp/simplib'
+
+describe 'PuppetX::SIMP::Simplib' do
+  context 'PuppetX::SIMP::Simplib.hostname?' do
+    it 'returns true for hostname without domain' do
+      expect(PuppetX::SIMP::Simplib.hostname?('myhost')).to eq true
+    end
+
+    it 'returns true for fully-qualified hostname' do
+      expect(PuppetX::SIMP::Simplib.hostname?('my-host.test.local')).to eq true
+    end
+
+    it 'returns true for hostname followed by :<number>' do
+      expect(PuppetX::SIMP::Simplib.hostname?('myhost:80')).to eq true
+    end
+
+    it 'returns true for hostname followed by /<number>' do
+      expect(PuppetX::SIMP::Simplib.hostname?('myhost/80')).to eq true
+    end
+
+    it 'returns false for nil' do
+      expect(PuppetX::SIMP::Simplib.hostname?(nil)).to eq false
+    end
+
+    it 'returns false when special characters are present' do
+      expect(PuppetX::SIMP::Simplib.hostname?('my:host.test.local')).to eq false
+    end
+
+    it 'returns false when starts with dot' do
+      expect(PuppetX::SIMP::Simplib.hostname?('.host.test.local')).to eq false
+    end
+
+    it 'returns false when ends with dot' do
+      expect(PuppetX::SIMP::Simplib.hostname?('host.test.local.')).to eq false
+    end
+
+    it 'returns false when starts with dash' do
+      expect(PuppetX::SIMP::Simplib.hostname?('-host.test.local')).to eq false
+    end
+
+    it 'returns false when ends with dash' do
+      expect(PuppetX::SIMP::Simplib.hostname?('host.test.local-')).to eq false
+    end
+
+    it 'returns false when contains space' do
+      expect(PuppetX::SIMP::Simplib.hostname?('host test.local')).to eq false
+    end
+
+    # this abides by RFC 1123, but would not be used in real systems
+    it 'returns true for an IP address' do
+      expect(PuppetX::SIMP::Simplib.hostname?('1.2.3.4')).to eq true
+    end
+  end
+
+  context 'PuppetX::SIMP::Simplib.hostname_only?' do
+    it 'returns true for hostname without domain' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('myhost')).to eq true
+    end
+
+    it 'returns true for fully-qualified hostname' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('my-host.test.local')).to eq true
+    end
+
+    it 'returns false for hostname followed by :<number>' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('myhost:80')).to eq false
+    end
+
+    it 'returns false for hostname followed by /<number>' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('myhost/80')).to eq false
+    end
+
+    it 'returns false for nil' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?(nil)).to eq false
+    end
+
+    it 'returns false when special characters are present' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('my:host.test.local')).to eq false
+    end
+
+    it 'returns false when starts with dot' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('.host.test.local')).to eq false
+    end
+
+    it 'returns false when ends with dot' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('host.test.local.')).to eq false
+    end
+
+    it 'returns false when starts with dash' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('-host.test.local')).to eq false
+    end
+
+    it 'returns false when ends with dash' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('host.test.local-')).to eq false
+    end
+
+    it 'returns false when contains space' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('host test.local')).to eq false
+    end
+
+    # this abides by RFC 1123, but would not be used in real systems
+    it 'returns true for an IPv4 address' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('1.2.3.4')).to eq true
+    end
+
+    it 'returns false for an IPv4 CIDR address' do
+      expect(PuppetX::SIMP::Simplib.hostname_only?('1.2.3.0/24')).to eq false
+    end
+  end
+
+  context 'PuppetX::SIMP::Simplib.split_port' do
+    it 'extracts nothing from nil' do
+      expect(PuppetX::SIMP::Simplib.split_port(nil)).to eq [nil, nil]
+    end
+
+    it 'extracts nothing from empty string' do
+      expect(PuppetX::SIMP::Simplib.split_port('')).to eq [nil, nil]
+    end
+
+    it 'extracts IPv4 address and port' do
+      expect(PuppetX::SIMP::Simplib.split_port('1.2.3.4:255')).to eq ['1.2.3.4', '255']
+    end
+
+    it 'extracts IPv4 quad-dotted address without port' do
+      expect(PuppetX::SIMP::Simplib.split_port('1.2.3.4')).to eq ['1.2.3.4', nil]
+    end
+
+    it 'extracts IPv4 CIDR address' do
+      expect(PuppetX::SIMP::Simplib.split_port('1.2.3.0/24')).to eq ['1.2.3.0/24', nil]
+    end
+
+    it 'extracts IPv6 address and port' do
+      expect(PuppetX::SIMP::Simplib.split_port('[2001:0db8:85a3:0000:0000:8a2e:0370]:7334')).to eq ['[2001:0db8:85a3:0000:0000:8a2e:0370]', '7334']
+    end
+
+    it 'extracts IPv6 address and port' do
+      expect(PuppetX::SIMP::Simplib.split_port('[2001:0db8:85a3:0000:0000:8a2e:0370]:')).to eq ['[2001:0db8:85a3:0000:0000:8a2e:0370]', nil]
+    end
+
+    it 'extracts IPv6 address without port' do
+      expect(PuppetX::SIMP::Simplib.split_port('2001:0db8:85a3:0000:0000:8a2e:0370')).to eq ['[2001:0db8:85a3:0000:0000:8a2e:0370]', nil]
+    end
+
+    it 'extracts IPv6 CIDR address' do
+      expect(PuppetX::SIMP::Simplib.split_port('2001:0db8:a::/64')).to eq ['2001:0db8:a::/64', nil]
+    end
+  end
+end

--- a/spec/functions/validate_net_list_spec.rb
+++ b/spec/functions/validate_net_list_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+describe 'validate_net_list' do
+  context 'IPv4' do
+    describe 'valid IPv4 string' do
+      it 'validates address-only' do
+        expect { subject.call(['1.2.3.4']) }.to_not raise_error
+      end
+
+      it 'validates address plus port' do
+        expect { subject.call(['1.2.3.4:5678']) }.to_not raise_error
+      end
+
+      it 'validates CIDR with numeric network mask' do
+        expect { subject.call(['1.2.0.0/16']) }.to_not raise_error
+      end
+
+      it 'validates CIDR with quad-dotted network mask' do
+        expect { subject.call(['1.2.0.0/255.255.0.0']) }.to_not raise_error
+      end
+    end
+
+    describe 'invalid IPv4 string' do
+      it 'rejects invalid octet' do
+        expect { subject.call(['1.2.3.256']) }.to raise_error(Puppet::ParseError, /'1.2.3.256' is not a valid network/)
+      end
+
+      it 'rejects CIDR missing network mask' do
+        pending "IPAddr allows empty network mask '1.2.3.4/'"
+        expect { subject.call(['1.2.3.4/']) }.to raise_error
+      end
+
+      it 'rejects CIDR with invalid numeric network mask' do
+        expect { subject.call(['1.2.3.4/33']) }.to raise_error(Puppet::ParseError, /'1.2.3.4\/33' is not a valid network/)
+      end
+
+      it 'rejects CIDR with invalid quad-dotted network mask' do
+        expect { subject.call(['1.2.3.4/256.255.0.0']) }.to raise_error(Puppet::ParseError, /'1.2.3.4\/256.255.0.0' is not a valid network/)
+      end
+
+      it 'rejects invalid port' do
+        expect { subject.call(['1.2.3.4:66000']) }.to raise_error(Puppet::ParseError, /'66000' is not a valid port/)
+      end
+    end
+  end
+
+  context 'IPv6' do
+    describe 'valid IPv6 string' do
+      it 'validates fully-specified, address-only' do
+        expect { subject.call(['2001:0db8:85a3:0000:0000:8a2e:0370:7334']) }.to_not raise_error
+      end
+
+      it 'validates abbreviated, address-only' do
+        expect { subject.call(['2001:0db8:85a3::0000:8a2e:0370:7334']) }.to_not raise_error
+      end
+
+      it 'validates address plus port' do
+        expect { subject.call(['[2001:db8:a::]:64']) }.to_not raise_error
+      end
+
+      it 'validates CIDR with numeric network mask' do
+        expect { subject.call(['2001:db8:a::/64']) }.to_not raise_error
+      end
+
+      it 'validates CIDR with hex network mask' do
+        expect { subject.call(['2001:0db8:030a:4000:0360:ff00:0042:0000/FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:0000']) }.to_not raise_error
+      end
+    end
+
+    describe 'invalid IPv6 string' do
+      it 'rejects invalid octet' do
+        expect { subject.call(['20011:db8:a::']) }.to raise_error(Puppet::ParseError, /'20011:db8:a::' is not a valid network/)
+      end
+
+      it 'rejects CIDR missing network mask' do
+        pending "IPAddr allows empty network mask '2001:db8:a::/'"
+        expect { subject.call(['2001:db8:a::/']) }.to raise_error
+      end
+
+      it 'rejects CIDR with invalid numeric network mask' do
+        expect { subject.call(['20011:db8:a::/129']) }.to raise_error(Puppet::ParseError, /'20011:db8:a::\/129' is not a valid network/)
+      end
+
+      it 'rejects CIDR with invalid hex network mask' do
+        expect { subject.call(['2001:0db8:030a:4000:0360:ff00:0042:0000/FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFFFFF:0000']) }.to raise_error(Puppet::ParseError, /'2001:0db8:030a:4000:0360:ff00:0042:0000\/FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFFFFF:0000' is not a valid network/)
+      end
+
+      it 'rejects invalid port' do
+        expect { subject.call(['[2001:db8:a::]:66000']) }.to raise_error(Puppet::ParseError, /'66000' is not a valid port/)
+      end
+    end
+  end
+
+  context 'hostname' do
+    describe 'valid hostname string' do
+      it 'validates hostname without domain' do
+        expect { subject.call(['myhost']) }.to_not raise_error
+      end
+
+      it 'validates hostname with domain' do
+        expect { subject.call(['myhost.test.local']) }.to_not raise_error
+      end
+
+      it 'validates hostname with domain and port' do
+        expect { subject.call(['myhost.test.local:8080']) }.to_not raise_error
+      end
+    end
+
+    describe 'invalid hostname string' do
+      it 'rejects invalid hostname' do
+        expect { subject.call(['my$bad$hostname']) }.to raise_error(Puppet::ParseError, /'my\$bad\$hostname' is not a valid network/)
+      end
+
+      it 'rejects invalid port' do
+        expect { subject.call(['myhostname:-10']) }.to raise_error(Puppet::ParseError, /'-10' is not a valid port/)
+      end
+    end
+  end
+
+  context 'regex match' do
+    describe 'valid match for pattern that cannot be a hostname' do
+      it { expect { subject.call([['%any'], '%any']) }.to_not raise_error }
+      it { expect { subject.call([['%any'], '^(%any|%none)$']) }.to_not raise_error }
+      it { expect { subject.call([['case/requiring/escapes'], '^case\/requiring\/escapes$']) }.to_not raise_error }
+    end
+  end
+
+  context 'array' do
+    describe 'valid array' do
+      it 'validates when all elements are valid' do
+        expect { subject.call([['1.2.3.4:5678', '[2001:db8:a::]:64', 'myhost']]) }.to_not raise_error
+        expect { subject.call([['1.2.3.4:10', '[2001:db8:a::]:64', 'my?host'], '^my\?host$']) }.to_not raise_error
+      end
+    end
+ 
+    describe 'invalid array' do
+     it 'rejects when any element is invalid' do
+        expect { subject.call([['1.2.3.4:-10', '[2001:db8:a::]:64', 'myhost']]) }.to raise_error(Puppet::ParseError, /is not a valid/)
+        expect { subject.call([['1.2.3.4:10', '[2001:db8:a ::]:64', 'myhost']]) }.to raise_error(Puppet::ParseError, /is not a valid/)
+        expect { subject.call([['1.2.3.4:10', '[2001:db8:a::]:64', 'my?host']]) }.to raise_error(Puppet::ParseError, /is not a valid/)
+        expect { subject.call([['1.2.3.4:10', '[2001:db8:a::]:64', 'my?host '], '^my\?host$']) }.to raise_error(Puppet::ParseError, /is not a valid/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix errors when validate_net_list uses regex strings and
is validating IPv6.
