### PR TITLE
(SIMP-1833) Add puppet_settings fact to SIMP 4/5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 script:
-  - bundle exec rake test
+  - bundle exec rake syntax lint spec metadata
 notifications:
   email: false
 rvm:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> Liz Nemsick <lnemsick.simp@gmail.com> - 1.3.3-0
+- Added a 'puppet_settings' fact that will provide a hash of *all* puppet
+  settings on the client system.
+
 * Tue Oct 11 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 1.3.3-0
 - Prior to this `named::resolv` made reference to `Service['named']`,
   causing errors in cases where the named servce was not called "named."

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
 end
 
 group :development do
-  gem "travis"
+#  gem "travis"
   gem "travis-lint"
   gem "travish"
   gem "puppet-blacksmith"

--- a/lib/facter/puppet_settings.rb
+++ b/lib/facter/puppet_settings.rb
@@ -1,0 +1,47 @@
+# This facter fact returns a hash of all Puppet settings for the node running
+# puppet or puppet agent. The intent is to enable Puppet modules to
+# automatically be able to use the various aspects of the puppet system
+# regardless of the node's platform.
+#
+# Each entry is under a hash entry of its associated section
+
+begin
+  require 'facter/util/puppet_settings'
+rescue LoadError => e
+  # puppet apply does not add module lib directories to the $LOAD_PATH (See
+  # #4248). It should (in the future) but for the time being we need to be
+  # defensive which is what this rescue block is doing.
+  rb_file = File.join(File.dirname(__FILE__), 'util', 'puppet_settings.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+
+Facter.add(:puppet_settings) do
+  setcode do
+    retval = {}
+    # This will be nil if Puppet is not available.
+    Facter::Util::PuppetSettings.with_puppet do
+      Puppet.settings.each do |setting|
+        key, params = setting
+
+        # Apparently, accessing these is deprecated
+        deprecated_access = [
+          :req_bits,
+          :ignorecache,
+          :configtimeout
+        ]
+        next if deprecated_access.include?(key)
+
+        # This is nonsensical
+        next if (key == :name) && (params.section == :main)
+
+        next if (!Puppet[key] || (Puppet[key].respond_to?(:empty?) && Puppet[key].empty?))
+
+        # For older versions of Facter, no hash keys/values can be symbols
+        retval[params.section.to_s] ||= {}
+        retval[params.section.to_s][params.name.to_s] = Puppet[key].to_s
+      end
+    end
+
+    retval
+  end
+end

--- a/spec/unit/facter/puppet_settings_spec.rb
+++ b/spec/unit/facter/puppet_settings_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+#require 'facter/puppet_settings'
+
+describe "custom fact puppet_settings" do
+
+  before(:each) do
+    if Facter.collection.respond_to?(:load)
+      Facter.collection.load(:puppet_settings)
+    else
+      Facter.collection.loader.load(:puppet_settings)
+    end
+  end
+
+  it 'should return hash of puppet settings' do
+      settings = Facter.fact(:puppet_settings).value
+      expect(settings).to include('main')
+      keys_of_interest = [
+        'certdir',
+        'confdir', 
+        'environment',
+        'environmentpath',
+        'libdir',
+        'logdir',
+        'path',
+        'rundir',
+        'ssldir',
+        'vardir'
+      ]
+      expect(settings['main']).to include(*keys_of_interest)
+  end
+end


### PR DESCRIPTION
Added puppet_settings fact code already implemented for SIMP 6.
Adjusted to work with old Facter.
Added a unit test.
