### PR TITLE
(SIMP-1833) Refine puppet_settings fact on SIMP6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 script:
-  - bundle exec rake test
+  - bundle exec rake syntax lint spec metadata
 notifications:
   email: false
 rvm:

--- a/lib/facter/puppet_settings.rb
+++ b/lib/facter/puppet_settings.rb
@@ -36,8 +36,9 @@ Facter.add(:puppet_settings) do
 
         next if (!Puppet[key] || (Puppet[key].respond_to?(:empty?) && Puppet[key].empty?))
 
-        retval[params.section] ||= {}
-        retval[params.section][params.name] = Puppet[key]
+        # For older versions of Facter, no hash keys/values can be symbols
+        retval[params.section.to_s] ||= {}
+        retval[params.section.to_s][params.name.to_s] = Puppet[key].to_s
       end
     end
 

--- a/spec/unit/facter/puppet_settings_spec.rb
+++ b/spec/unit/facter/puppet_settings_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+#require 'facter/puppet_settings'
+
+describe "custom fact puppet_settings" do
+
+  before(:each) do
+    if Facter.collection.respond_to?(:load)
+      Facter.collection.load(:puppet_settings)
+    else
+      Facter.collection.loader.load(:puppet_settings)
+    end
+  end
+
+  it 'should return hash of puppet settings' do
+      settings = Facter.fact(:puppet_settings).value
+      expect(settings).to include('main')
+      keys_of_interest = [
+        'certdir',
+        'confdir', 
+        'environment',
+        'environmentpath',
+        'libdir',
+        'logdir',
+        'path',
+        'rundir',
+        'ssldir',
+        'vardir'
+      ]
+      expect(settings['main']).to include(*keys_of_interest)
+  end
+end


### PR DESCRIPTION
Adjusted puppet_settings fact to work with older versions of Facter.
Added a spec test for this fact.
Converted to single threaded spec test to try to debug missing
cpuinfo fact problem in Travis.
