### PR TITLE
(SIMP-1694) Added 'simp_opt' function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Sun Nov 27 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.1.0-0
+- Added a 'simp_opt' function for retrieving SIMP6-style global catalysts.
+
 * Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.0.0-0
 - Updated to compliance_markup version 2
 

--- a/lib/puppet/parser/functions/simp_opt.rb
+++ b/lib/puppet/parser/functions/simp_opt.rb
@@ -1,0 +1,49 @@
+module Puppet::Parser::Functions
+  newfunction(:simp_opt, :type => :rkey, :arity => 1, :doc => <<-EOS
+    Retrieve a SIMP global catalyst.
+
+    Any variable that is passed into this function will look up a variable
+    ``simp_opt::<variable>``.
+
+    Example:
+
+    simp_opt('foo::bar') will return the value in the variable ``$simp_opt::foo::bar``
+    EOS
+  ) do |arguments|
+
+    key = arguments[0]
+
+    unless key.is_a?(String)
+      raise(Puppet::ParseError, "simp_opt(): The argument must be a String, got '#{key.class}'")
+    end
+
+    key = ['simp_opt', key].join('::')
+
+    # Hack around the inablilty to silence global warnings.
+    def self.lookup_global_silent(param)
+      find_global_scope.to_hash(param)
+    end
+
+    value = lookup_global_silent(key)
+
+    if (!value || value.empty?)
+      if self.respond_to?(:call_function)
+        begin
+          value = call_function('lookup',[key, nil])
+        # 3.X doesn't work with the lookup function
+        rescue NoMethodError, Puppet::ParseError
+          begin
+            value = call_function('hiera',[key, nil])
+          rescue  NoMethodError
+            value = nil
+          end
+        end
+      else
+        # Puppet 3.X only
+        value = function_hiera([key, nil])
+      end
+    end
+
+    value
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
The simp_opt function is designed for retrieving SIMP 6-style global
catalysts from any viable source.

SIMP-1694 #close