### PR TITLE
(SIMP-1694) Add the simplib::lookup function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Dec 07 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.1.0-0
+- Added a simplib::lookup() function that returns a globally scoped variable if
+  it exists before calling the traditional lookup() function.
+
 * Tue Nov 29 2016 Nick Miller <nick.miller@onyxpoint.com> - 2.0.0-0
 - Renamed the file containing the puppet_settings fact to deconflict with
   puppetlabs/puppetlabs-stdlib. They don't create any facts with the name

--- a/lib/puppet/functions/simplib/lookup.rb
+++ b/lib/puppet/functions/simplib/lookup.rb
@@ -1,0 +1,50 @@
+# A function for falling back to global scope variable lookups when the
+# Puppet 4 ``lookup()`` function cannot find a value.
+#
+# While ``lookup()`` will stop at the back-end data sources, ``lookup()`` will
+# check the global scope first to see if the variable has been defined.
+#
+# This means that you can pre-declare a class and/or use an ENC and look up the
+# variable whether it is declared this way or via Hiera or some other back-end.
+#
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+Puppet::Functions.create_function(:'simplib::lookup') do
+  # @param param [String] The parameter that you wish to look up
+  #
+  # @param options [Hash] Hash of options for regular ``lookup()``
+  #
+  #   * This **must** follow the syntax rules for the
+  #   Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+  #   * No other formats are supported!
+  #
+  # @see https://docs.puppet.com/puppet/latest/function.html#lookup - Lookup Function
+  #
+  # @return [Any] The value that is found in the system for the passed
+  #   parameter.
+  #
+  # @example No defaults
+  #   simplib::lookup('foo::bar::baz')
+  #
+  # @example With a default
+  #   simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana' })
+  #
+  # @example With a typed default
+  #   simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana', 'value_type' => String })
+  #
+  dispatch :lookup do
+    param          'String', :param
+    optional_param 'Any',    :options
+  end
+
+  def lookup(param, options = nil)
+    global_param = closure_scope.find_global_scope.lookupvar(param)
+
+    return global_param if global_param
+
+    if options
+      return call_function('lookup', param, options )
+    else
+      return call_function('lookup', param )
+    end
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/lookup_spec.rb
+++ b/spec/functions/simplib/lookup_spec.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::lookup' do
+  let(:pre_condition){%{
+    class test::class (
+      $param1 = 'foo'
+     ) {
+       notify { $param1: }
+     }
+
+     include 'test::class'
+  }}
+
+  it 'should run successfully' do
+    is_expected.to run.with_params('test::class::param1')
+  end
+
+  it 'should fail via lookup() when trying to find an unknown value' do
+    is_expected.to run.with_params('what_is_this').and_raise_error(
+      Puppet::DataBinding::LookupError,
+      /did not find a value for.*what_is_this.*/
+    )
+  end
+end


### PR DESCRIPTION
This enhances the inbuilt lookup() function to check and see if the
passed value is defined in the global scope as a variable prior to
falling back to a normal lookup.

This means that any value that is set via an ENC or a standard class
declaration will be properly found.

SIMP-1694 #close