### PR TITLE
(SIMP-1694) Restrict lookup scope

### DIFF
--- a/spec/functions/simplib/lookup_spec.rb
+++ b/spec/functions/simplib/lookup_spec.rb
@@ -3,9 +3,13 @@ require 'spec_helper'
 
 describe 'simplib::lookup' do
   let(:pre_condition){%{
+    $global_var = 'global'
+
     class test::class (
       $param1 = 'foo'
      ) {
+       $internal_param = 'bar'
+
        notify { $param1: }
      }
 
@@ -13,7 +17,18 @@ describe 'simplib::lookup' do
   }}
 
   it 'should run successfully' do
-    is_expected.to run.with_params('test::class::param1')
+    is_expected.to run.with_params('test::class::param1').and_return('foo')
+  end
+
+  it 'should look up a global variable when it is present' do
+    is_expected.to run.with_params('global_var').and_return('global')
+  end
+
+  it 'should not look up a variable when it is inside class scope' do
+    is_expected.to run.with_params('test_class::internal_param').and_raise_error(
+      Puppet::DataBinding::LookupError,
+      /did not find a value for.*test_class::internal_param.*/
+    )
   end
 
   it 'should fail via lookup() when trying to find an unknown value' do


### PR DESCRIPTION
Per conversations with Henrik Lindberg, changed the scope to only lookup
global settings and actual parameters that have been assigned to
classes.

Note: This will only find assigned parameters that have *already* been
processed by the compiler, so order matters!