### PR TITLE
(SIMP-1695) Ensure that the data type tests run

### DIFF
--- a/spec/unit/data_types/dynamicport_spec.rb
+++ b/spec/unit/data_types/dynamicport_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_unprivilegedport', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::DynamicPort $port
+        ){ }
+
+        class { '#{class_name}':
+          port => #{port}
+        }
+      )}
+
+      context 'with valid ports' do
+        [49152,56789,65535].each do |port|
+          let(:port){ port }
+
+          it "should work with port #{port}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid ports' do
+        [0,49151,65536,'22',true].each do |port|
+          let(:port){ port }
+
+          it "should fail on port #{port}" do
+            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/dynamicport_spec.rb
+++ b/spec/unit/data_types/dynamicport_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_unprivilegedport', type: :class do
+  describe 'Simplib::DynamicPort', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/emailaddress_spec.rb
+++ b/spec/unit/data_types/emailaddress_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_emailaddress', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::EmailAddress $param
+        ){ }
+
+        class { '#{class_name}':
+          param => '#{param}'
+        }
+      )}
+
+      context 'with valid addresses' do
+        [
+          'foo@bar.baz',
+          'foo@bar',
+          'foo@bar-baz.com',
+          'foobar@bar-baz.com',
+          'foo+bar@bar-baz.com',
+          'foo.bar@bar-baz.com'
+        ].each do |param|
+          let(:param){ param }
+
+          it "should accept #{param}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid addresses' do
+        [ 'foo' ].each do |param|
+          let(:param){ param }
+
+          it "should accept #{param}" do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/emailaddress_spec.rb
+++ b/spec/unit/data_types/emailaddress_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_emailaddress', type: :class do
+  describe 'Simplib::EmailAddress', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/port_spec.rb
+++ b/spec/unit/data_types/port_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_port', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::Port $port
+        ){ }
+
+        class { '#{class_name}':
+          port => #{port}
+        }
+      )}
+
+      context 'with valid ports' do
+        [0,80,1024,65535].each do |port|
+          let(:port){ port }
+
+          it "should work with port #{port}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid ports' do
+        [-1,65536,12345678910,'22',true].each do |port|
+          let(:port){ port }
+
+          it "should fail on port #{port}" do
+            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/port_spec.rb
+++ b/spec/unit/data_types/port_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_port', type: :class do
+  describe 'Simplib::Port', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/randomport_spec.rb
+++ b/spec/unit/data_types/randomport_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_randomport', type: :class do
+  describe 'Simplib::RandomPort', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/randomport_spec.rb
+++ b/spec/unit/data_types/randomport_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_randomport', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::RandomPort $port
+        ){ }
+
+        class { '#{class_name}':
+          port => #{port}
+        }
+      )}
+
+      context 'with valid ports' do
+        [0].each do |port|
+          let(:port){ port }
+
+          it "should work with port #{port}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid ports' do
+        [1,1025,'22',true].each do |port|
+          let(:port){ port }
+
+          it "should fail on port #{port}" do
+            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/systemport_spec.rb
+++ b/spec/unit/data_types/systemport_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_privilegedport', type: :class do
+  describe 'Simplib::SystemPort', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/systemport_spec.rb
+++ b/spec/unit/data_types/systemport_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_privilegedport', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::SystemPort $port
+        ){ }
+
+        class { '#{class_name}':
+          port => #{port}
+        }
+      )}
+
+      context 'with valid ports' do
+        [1,80,1024].each do |port|
+          let(:port){ port }
+
+          it "should work with port #{port}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid ports' do
+        [0,1025,'22',true].each do |port|
+          let(:port){ port }
+
+          it "should fail on port #{port}" do
+            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/umask_spec.pp
+++ b/spec/unit/data_types/umask_spec.pp
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_umask', type: :class do
+  describe 'Simplib::Umask', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/umask_spec.pp
+++ b/spec/unit/data_types/umask_spec.pp
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_umask', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::Umask $param
+        ){ }
+
+        class { '#{class_name}':
+          param => '#{param}'
+        }
+      )}
+
+      context 'with valid umask' do
+        [
+          '0000',
+          '0240',
+          '1111'
+        ].each do |param|
+          let(:param){ param }
+
+          it "should accept #{param}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid umask' do
+        [
+          '12345',
+          'bob'
+        ].each do |param|
+          let(:param){ param }
+
+          it "should reject #{param}" do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/uri_spec.rb
+++ b/spec/unit/data_types/uri_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_uri', type: :class do
+  describe 'Simplib::URI', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (

--- a/spec/unit/data_types/uri_spec.rb
+++ b/spec/unit/data_types/uri_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_uri', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::URI $param
+        ){ }
+
+        class { '#{class_name}':
+          param => '#{param}'
+        }
+      )}
+
+      context 'with valid URI' do
+        [
+          'foo://bar',
+          'f00://bar',
+          'foo+bar://baz',
+          'foo.bar-baz+aaa://bbb'
+        ].each do |param|
+          let(:param){ param }
+
+          it "should accept #{param}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid URI' do
+        [
+          'foo',
+          'foo@bar://baz',
+          '1foo://bar'
+        ].each do |param|
+          let(:param){ param }
+
+          it "should reject #{param}" do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/userport_spec.rb
+++ b/spec/unit/data_types/userport_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'simplib_unprivilegedport', type: :class do
+    describe 'valid handling' do
+      let(:pre_condition) {%(
+        class #{class_name} (
+          Simplib::UserPort $port
+        ){ }
+
+        class { '#{class_name}':
+          port => #{port}
+        }
+      )}
+
+      context 'with valid ports' do
+        [1025,2345,49151].each do |port|
+          let(:port){ port }
+
+          it "should work with port #{port}" do
+            is_expected.to compile
+          end
+        end
+      end
+
+      context 'with invalid ports' do
+        [0,1024,49152,'22',true].each do |port|
+          let(:port){ port }
+
+          it "should fail on port #{port}" do
+            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/userport_spec.rb
+++ b/spec/unit/data_types/userport_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 if Puppet.version.to_f >= 4.5
-  describe 'simplib_unprivilegedport', type: :class do
+  describe 'Simplib::UserPort', type: :class do
     describe 'valid handling' do
       let(:pre_condition) {%(
         class #{class_name} (


### PR DESCRIPTION
The previous location was not executed by default even though it was
copied from puppetlabs-stdlib.

SIMP-1695 #close Update spec test location for data types