### PR TITLE
(SIMP-2426) Clean up salt generation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jan 09 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.2.0-0
+- fixed how passgen generated salts to restrict it to non-special characters
+
 * Mon Jan 02 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.1.0-0
 - Added additional syslog data types and added tests for all syslog data types
   - Syslog::CFacility

--- a/lib/puppet/parser/functions/passgen.rb
+++ b/lib/puppet/parser/functions/passgen.rb
@@ -186,7 +186,7 @@ module Puppet::Parser::Functions
                     if options.key?('salt')
                         salt = options['salt']
                     else
-                        salt = self.gen_random_pass(16,options['complexity'], options['complex_only'])
+                        salt = self.gen_random_pass(16,0, options['complex_only'])
                     end
                     saltfile.puts(salt)
                     saltfile.close
@@ -229,7 +229,7 @@ module Puppet::Parser::Functions
                 if options.key?('salt')
                     salt = options['salt']
                 else
-                    salt = self.gen_random_pass(16,options['complexity'], options['complex_only'])
+                    salt = self.gen_random_pass(16,0, options['complex_only'])
                 end
                 tgt_hash.puts(salt)
                 tgt_hash.rewind

--- a/spec/functions/passgen_spec.rb
+++ b/spec/functions/passgen_spec.rb
@@ -199,6 +199,10 @@ describe 'passgen' do
         value = parse_modular_crypt(subject.call(['spectest', shared_options]));
         expect(value['algorithm_code']).to eql(object['code'])
       end
+      it 'should contain a salt of complexity 0' do
+        value = parse_modular_crypt(subject.call(['spectest', shared_options]));
+        expect(value['salt']).to match(/^(#{default_chars.join('|')})+$/)
+      end
       it 'should contain a base64 hash' do
         value = parse_modular_crypt(subject.call(['spectest', shared_options]));
         expect(value['hash_base64']).to match(/#{base64_regex}/)


### PR DESCRIPTION
Only use characters in complexity mode 0 (a-zA-Z0-9.\) for
salts. While this hasn't seemed to have broken RHEL's shadow
handling, it has the potential to break other platforms
and libraries,  so clean it up anyway.

SIMP-2426 #close