### PR TITLE
(SIMP-2180) Added simplib::ldap::domain_to_dn

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jan 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.2.0-0
+- Added a simplib::ldap::domain_to_dn function for generating a reasonable Base
+  DN from the domain fact
+
 * Mon Jan 09 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.2.0-0
 - fixed how passgen generated salts to restrict it to non-special characters
 

--- a/functions/ldap/domain_to_dn.pp
+++ b/functions/ldap/domain_to_dn.pp
@@ -1,0 +1,6 @@
+# Provides a reasonable LDAP Base DN as generated from the ``domain`` fact
+function simplib::ldap::domain_to_dn (
+  String $domain = $facts['domain']
+) {
+  join(split($domain,'\.').map |$x| { "dc=${x}" }, ',')
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is to support the OpenLDAP rewrite as well as any other modules
that may need a reasonable base DN

SIMP-2180 #comment Added function for converting from domain to DN