### PR TITLE
(SIMP-2547) Add fips_ciphers fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jan 27 2017 Nick Miller <nick.miller@onyxpoint.com> - 3.2.0
+- Added openssl_ciphers fact to list avaiable OpenSSL ciphers
+
 * Fri Jan 20 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.2.0-0
 - Added type for the server distribution of puppet being used
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ documentation.
    hash
   * **defaultgatewayiface**  -  Return the default gw interface of the system
   * **defaultgateway**       -  Return the default gateway of the system
+  * **fips_ciphers**         -  Returns a list of available OpenSSL ciphers
   * **fips_enabled**         -  Determine whether or not FIPS is enabled on
    this system
   * **fullrun**              -  Determine whether or not to do an intensive run

--- a/lib/facter/fips_ciphers.rb
+++ b/lib/facter/fips_ciphers.rb
@@ -4,6 +4,6 @@ Facter.add('fips_ciphers') do
   confine :kernel => 'Linux'
 
   setcode do
-    Facter::Core::Execution.exec(`openssl ciphers FIPS:!LOW`).split(':')
+    Facter::Core::Execution.exec('openssl ciphers FIPS:!LOW').split(':')
   end
 end

--- a/lib/facter/fips_ciphers.rb
+++ b/lib/facter/fips_ciphers.rb
@@ -1,0 +1,9 @@
+# List available FIPS-compatible OpenSSL ciphers on the system
+# Returns: Array[String]
+Facter.add('fips_ciphers') do
+  confine :kernel => 'Linux'
+
+  setcode do
+    Facter::Core::Execution.exec(`openssl ciphers FIPS:!LOW`).split(':')
+  end
+end


### PR DESCRIPTION
The fips_ciphers fact returns the available OpenSSL FIPS ciphers on the
system. This will be used as the default ciphers set for OpenLDAP,
because it doesn't like the FIPS shortcut.

SIMP-2546 #comment added the fact
SIMP-2547 #close