### PR TITLE
(SIMP-2469) Ensure that lookup is safe

### DIFF
--- a/lib/puppet/functions/simplib/lookup.rb
+++ b/lib/puppet/functions/simplib/lookup.rb
@@ -61,7 +61,21 @@ Puppet::Functions.create_function(:'simplib::lookup') do
           end
         end
       else
-        global_param = closure_scope.find_global_scope.lookupvar(param)
+        # Save the state of the strict vars setting. Ignore it here since we do
+        # legitimate global scope lookups but make sure to restore it.
+        strict_vars = nil
+        begin
+          if Puppet[:strict]
+            strict_vars = Puppet[:strict]
+            Puppet[:strict] = :off
+          end
+
+          global_param = closure_scope.find_global_scope.lookupvar(param)
+        ensure
+          if strict_vars
+            Puppet[:strict] = strict_vars
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Lookup would complain on systems that it could not find variables at
global scope. This disables the warning prior to the global lookup
being performed.

SIMP-2469 #comment Fix global lookup issue found during testing