### PR TITLE
(SIMP-2937) Use PATH lookup for simp_version's rpm call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Sun Mar 25 2017 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 3.2.2-0
+- Use PATH lookup for simp_version's rpm call
+
 * Mon Mar 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.2.1-0
 - move passgen to Puppet[:vardir]
 

--- a/lib/puppet/parser/functions/simp_version.rb
+++ b/lib/puppet/parser/functions/simp_version.rb
@@ -10,7 +10,7 @@ module Puppet::Parser::Functions
     begin
       retval = File.read('/etc/simp/simp.version').gsub('simp-','')
     rescue
-      tmpval = %x{/bin/rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp}
+      tmpval = %x{PATH='/usr/local/bin:/usr/bin:/bin'; rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp}
       $?.success? and retval = tmpval
     end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
The `simp_version` fact executes `rpm(8)` to find the version for SIMP.
Previously this was done with a hard-coded path, `/bin/rpm`, but this
broke on systems where the executable was installed elsewhere.  This
changes the call to set up PATH in the subshell before executing the
command.

SIMP-2937 #close