### PR TITLE
(SIMP-2992) Added simplib::inspect debugger

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Apr 07 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.3.0-0
+- Added a 'simplib::inspect' debugging function for dumping parameters during
+  Puppet runs.
+
 * Sun Mar 25 2017 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 3.2.2-0
 - Use PATH lookup for simp_version's rpm call
 

--- a/functions/inspect.pp
+++ b/functions/inspect.pp
@@ -1,0 +1,23 @@
+# Prints the passed variable's Ruby type and value for debugging purposes
+#
+# This uses a ``Notify`` resource to print the information during the client
+# run.
+#
+# @param var_name
+#   The actual name of the variable, fully scoped, as a ``String``
+#
+# @param output_type
+#   The format that you wish to use to display the output during the run
+#
+function simplib::inspect (
+  String $var_name,
+  Enum['json','yaml'] $output_type = 'json'
+) {
+
+  $var_value = inline_template("<%= scope[@var_name].to_${output_type} %>")
+  $var_class = inline_template('<%= scope[@var_name].class %>')
+
+  notify { "DEBUG_INSPECT_${var_name}":
+    message => "Type => ${var_class}\nContent =>\n${var_value}"
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/inspect_spec.rb
+++ b/spec/functions/inspect_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+shared_examples 'simplib::inspect()' do ||
+  it { is_expected.to run.with_params(input_array).and_return(return_value) }
+end
+
+describe 'simplib::inspect' do
+  context 'when a parameter is passed' do
+    let(:pre_condition) {%{
+      $foo = 'test_value'
+    }}
+
+    it { is_expected.to run.with_params('foo') }
+
+    it {
+      is_expected.to run.with_params('foo')
+
+      expect(catalogue.resource('Notify[DEBUG_INSPECT_foo]')).not_to be_nil
+    }
+
+    it {
+      is_expected.to run.with_params('foo')
+
+      resource = catalogue.resource('Notify[DEBUG_INSPECT_foo]')
+
+      expect(resource[:message]).to match(/Type => String/)
+    }
+
+    it {
+      is_expected.to run.with_params('foo')
+
+      resource = catalogue.resource('Notify[DEBUG_INSPECT_foo]')
+
+      expect(resource[:message]).to match(/Content =>.*test_value/m)
+    }
+  end
+end
+# vim: set expandtab ts=2 sw=2:


### PR DESCRIPTION
The original inspect() function is no longer user-friendly enough for
debugging.

This function has been added to actually print the value during the
Puppet run as a notify resource.

Care was taken to try to make it easy to note that this is for
debugging.

SIMP-2992 #comment Needed during debugging of array sets