### PR TITLE
(SIMP-2994) Use uppercase for LDAP DN strings in simplib::ldap::domain_to_dn

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Apr 07 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.3.1-0
+- Change case of simplib::ldap::domain_to_dn to be upper case
+
 * Fri Apr 07 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.3.0-0
 - Added a 'simplib::inspect' debugging function for dumping parameters during
   Puppet runs.

--- a/functions/ldap/domain_to_dn.pp
+++ b/functions/ldap/domain_to_dn.pp
@@ -2,5 +2,5 @@
 function simplib::ldap::domain_to_dn (
   String $domain = $facts['domain']
 ) {
-  join(split($domain,'\.').map |$x| { "dc=${x}" }, ',')
+  join(split($domain,'\.').map |$x| { "DC=${x}" }, ',')
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Use uppercase 'DC=' instead of lowercase 'dc=' so systems like active
  directory can handle the output.

SIMP-2994 #close