### PR TITLE
(SIMP-1486) Remove netstat from defaultgateway/defaultgatewayiface facts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Apr 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.2-0
+- Use the standard ip utility to determine default gateway information,
+  instead of the netstat utility. This removes a dependency on the
+  net-tools package.
+
 * Fri Apr 07 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.3.1-0
 - Change case of simplib::ldap::domain_to_dn to be upper case
 

--- a/lib/facter/defaultgateway.rb
+++ b/lib/facter/defaultgateway.rb
@@ -1,17 +1,23 @@
 # _Description_
 #
-# Return the default gateway of the system
+# Return the default IPv4 gateway of the system
 #
 Facter.add(:defaultgateway) do
   confine :kernel => 'Linux'
 
   setcode do
-    netstat = %x{/bin/netstat -rn}
     gw = "unknown"
-    if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
-      gw = $1.split(/\s+/).first
+    ip_cmd = Facter::Util::Resolution.which('ip')
+    if ip_cmd
+      route_lines = Facter::Core::Execution.exec("#{ip_cmd} route").split("\n")
+      gw_lines = route_lines.delete_if { |line| !line.match(/^default\s+via\s+/) }
+      unless gw_lines.empty?
+        match = gw_lines.last.match(/default\s+via\s+([0-9\.]*)\s+dev\s+/)
+        if match
+          gw = match[1]
+        end
+      end
     end
-
     gw
   end
 end

--- a/lib/facter/defaultgatewayiface.rb
+++ b/lib/facter/defaultgatewayiface.rb
@@ -1,17 +1,23 @@
 # _Description_
 #
-# Return the default gw interface of the system.
+# Return the default IPv4 gw interface of the system.
 #
 Facter.add(:defaultgatewayiface) do
   confine :kernel => 'Linux'
+
   setcode do
-
-    netstat = %x{/bin/netstat -rn}
     gw_iface = "unknown"
-    if netstat =~ /^0\.0\.0\.0\s+(.*)/ then
-      gw_iface = $1.split(/\s+/).last
+    ip_cmd = Facter::Util::Resolution.which('ip')
+    if ip_cmd
+      route_lines = Facter::Core::Execution.exec("#{ip_cmd} route").split("\n")
+      gw_lines = route_lines.delete_if { |line| !line.match(/^default\s+via\s+/) }
+      unless gw_lines.empty?
+        match = gw_lines.last.match(/\s+dev\s+(\S+)/)
+        if match
+          gw_iface = match[1]
+        end
+      end
     end
-
     gw_iface
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/facter/defaultgateway_spec.rb
+++ b/spec/unit/facter/defaultgateway_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+
+describe "defaultgateway" do
+  before :each do
+    Facter.clear
+  end
+
+  let(:ipv4route) { <<EOM
+192.168.221.0/24 dev eth0  proto kernel  scope link  src 192.168.221.200 
+169.254.0.0/16 dev eth0  scope link  metric 1002 
+default via 192.168.221.1 dev eth0 
+EOM
+  }
+
+  context 'ip command exists' do
+    before :each do
+      Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+      Facter::Util::Resolution.stubs(:which).with('ip').returns('/usr/bin/ip')
+    end
+
+    it 'returns IP address of valid default route' do
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(ipv4route)
+      expect(Facter.fact(:defaultgateway).value).to eq('192.168.221.1')
+    end
+
+    it 'returns IP address of last valid default route' do
+      multiple_defaults = ipv4route + "default via 10.0.2.1 dev eth1"
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(multiple_defaults)
+      expect(Facter.fact(:defaultgateway).value).to eq('10.0.2.1')
+    end
+
+    it "returns 'unknown' when no default line exists" do
+      bad_route = ipv4route.gsub('default', 'oops ')
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter.fact(:defaultgateway).value).to eq('unknown')
+    end
+
+    it "returns 'unknown' when IP address could not be extracted from the default line" do
+      bad_route = ipv4route.gsub('default via 192.168.221.1 ', 'default via some.fqdn ')
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter.fact(:defaultgateway).value).to eq('unknown')
+    end
+  end
+
+  context 'ip command does not exist' do
+    it "returns 'unknown'" do
+      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter.fact(:defaultgateway).value).to eq('unknown')
+    end
+  end
+end

--- a/spec/unit/facter/defaultgatewayiface_spec.rb
+++ b/spec/unit/facter/defaultgatewayiface_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+
+describe "defaultgatewayiface" do
+  before :each do
+    Facter.clear
+  end
+
+  let(:ipv4route) { <<EOM
+192.168.221.0/24 dev eth0  proto kernel  scope link  src 192.168.221.200 
+169.254.0.0/16 dev eth0  scope link  metric 1002 
+default via 192.168.221.1 dev eth0 
+EOM
+  }
+
+  context 'ip command exists' do
+    before :each do
+      Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+      Facter::Util::Resolution.stubs(:which).with('ip').returns('/usr/bin/ip')
+    end
+
+    it 'returns IP address of valid default route' do
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(ipv4route)
+      expect(Facter.fact(:defaultgatewayiface).value).to eq('eth0')
+    end
+
+    it 'returns IP address of last valid default route' do
+      multiple_defaults = ipv4route + "default via 10.0.2.1 dev eth1"
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(multiple_defaults)
+      expect(Facter.fact(:defaultgatewayiface).value).to eq('eth1')
+    end
+
+    it "returns 'unknown' when no default line exists" do
+      bad_route = ipv4route.gsub('default', 'oops ')
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
+    end
+
+    it "returns 'unknown' when device could not be extracted from the default line" do
+      bad_route = ipv4route.gsub('dev eth0', 'dev ')
+      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
+    end
+  end
+
+  context 'ip command does not exist' do
+    it "returns 'unknown'" do
+      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
+    end
+  end
+end


### PR DESCRIPTION
Implemented defaultgateway and defaultgatewayiface facts using
standard ip command to eliminate dependency on net-tools package.

SIMP-1486 #close