### PR TITLE
(SIMP-3115) Added wrapper stages to simplib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 - Added a pre and post stage that wrap around the stdlib stages to ensure that
   all SIMP components have proper buffers around the rest of the stdlib stages
   that other users might be using.
+- Added a `simplib_sysctl` fact to provide values that are particularly
+  relevant to SIMP installations.
+- Fixed a bug in the `puppet_settings` fact in the case where `facter` was run
+  standalone
 
 * Wed Apr 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.2-0
 - Use the standard ip utility to determine default gateway information,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Apr 27 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.4.0-0
+- Added a pre and post stage that wrap around the stdlib stages to ensure that
+  all SIMP components have proper buffers around the rest of the stdlib stages
+  that other users might be using.
+
 * Wed Apr 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.2-0
 - Use the standard ip utility to determine default gateway information,
   instead of the netstat utility. This removes a dependency on the

--- a/lib/facter/simp_puppet_settings.rb
+++ b/lib/facter/simp_puppet_settings.rb
@@ -9,7 +9,7 @@ Facter.add(:puppet_settings) do
   setcode do
     retval = {}
 
-    if Object.const_defined?('Puppet')
+    if Object.const_defined?('Puppet') && Puppet.respond_to?(:settings)
       puppet_settings = Hash[Puppet.settings.map{|k,v| [k,v]}]
 
       puppet_settings.each_pair do |name, obj|

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -1,0 +1,40 @@
+# _Description_
+#
+# Returns a hash of sysctl values that are particularly relevant to SIMP
+#
+# We don't grab the entire output due to the sheer size of it
+#
+Facter.add("simplib_sysctl") do
+  setcode do
+    relevant_entries = [
+      'crypto.fips_enabled',
+      'kernel.ctrl-alt-del',
+      'kernel.modules_disabled',
+      'kernel.shmall',
+      'kernel.shmmax',
+      'kernel.shmmni',
+      'kernel.tainted',
+      'kernel.threads-max',
+      'vm.swappiness'
+    ]
+
+    retval = {}
+
+    relevant_entries.each do |entry|
+      module_value = Facter::Core::Execution.exec("sysctl -n -e #{entry}")
+
+      # we have observed this exec non-deterministically populate $? with
+      # nil, although the exec succeeds.  This will happen with %x, ``, or
+      # Facter.*.exec.
+      #
+      # For now we test around the issue by checking the output if $? is nil:
+      if ($?.nil? && module_value) ||
+          (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?)
+      then
+        retval[entry] = module_value
+      end
+    end
+
+    retval
+  end
+end

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -31,6 +31,12 @@ Facter.add("simplib_sysctl") do
       if ($?.nil? && module_value) ||
           (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?)
       then
+        module_value.strip!
+
+        if module_value =~ /^\d+$/
+          module_value = module_value.to_i
+        end
+
         retval[entry] = module_value
       end
     end

--- a/manifests/stages.pp
+++ b/manifests/stages.pp
@@ -1,0 +1,19 @@
+# This class expands on the Puppet Stdlib stages to add a few levels that we
+# found necessary when developing various SIMP modules that had global
+# ramifications.
+#
+# Primarily, we wanted to ensure that anyone using the stdlib stages was not
+# tripped up by any of our modules that may enable, or disable, various system,
+# components; particularly ones that require a reboot.
+#
+# Added Stages:
+#
+#   * ``simp_prep`` -> Comes before stdlib's ``setup``
+#   * ``simp_finalize`` -> Comes after stdlib's ``deploy``
+#
+class simplib::stages {
+  include stdlib::stages
+
+  stage { 'simp_prep': before      => Stage['setup'] }
+  stage { 'simp_finalize': require => Stage['deploy'] }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
There have been several situations where various SIMP components really
needed to be wrapped in a Puppet stage to protect the rest of the
system from a particularly aggressive action (usually one that requires
a reboot).

This change adds a couple of SIMP stages that wrap the stdlib stages to
provide a buffer zone for SIMP-specific activities. This is not a
perfect solution but it will work better than just trying to tag onto
the existing stages that don't actually map to our use cases.

SIMP-3115 #comment Added buffer stages for module locking