### PR TITLE
(SIMP-3138) Added new root_dir_uuid fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,13 +6,16 @@
   relevant to SIMP installations.
 - Fixed a bug in the `puppet_settings` fact in the case where `facter` was run
   standalone
+- Added a 'root_dir_uuid' fact so that it can be compared against the `/boot`
+  partition in the fips module. Facter used to have a data structure of all
+  mountpoints but it was removed for performance reasons.
 
-* Wed Apr 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.2-0
+* Wed Apr 12 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.3.0-0
 - Use the standard ip utility to determine default gateway information,
   instead of the netstat utility. This removes a dependency on the
   net-tools package.
 
-* Fri Apr 07 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.3.1-0
+* Fri Apr 07 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.3.0-0
 - Change case of simplib::ldap::domain_to_dn to be upper case
 
 * Fri Apr 07 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.3.0-0

--- a/lib/facter/boot_dir_uuid.rb
+++ b/lib/facter/boot_dir_uuid.rb
@@ -6,7 +6,7 @@ Facter.add('boot_dir_uuid') do
     df_cmd = Facter::Util::Resolution.which('df')
     blkid_cmd = Facter::Util::Resolution.which('blkid')
 
-    partition = Facter::Core::Execution.exec("#{df_cmd} -T /boot").strip.split("\n").last.split(' ').first
+    partition = Facter::Core::Execution.exec("#{df_cmd} -P /boot").strip.split("\n").last.split(' ').first
 
     uuid = Facter::Core::Execution.exec("#{blkid_cmd} -s UUID -o value #{partition}").strip
 

--- a/lib/facter/root_dir_uuid.rb
+++ b/lib/facter/root_dir_uuid.rb
@@ -1,12 +1,12 @@
-# Return the UUID of the partition holding the /boot directory
-Facter.add('boot_dir_uuid') do
+# Return the UUID of the partition holding the / directory
+Facter.add('root_dir_uuid') do
   confine :kernel => 'Linux'
 
   setcode do
     df_cmd = Facter::Util::Resolution.which('df')
     blkid_cmd = Facter::Util::Resolution.which('blkid')
 
-    partition = Facter::Core::Execution.exec("#{df_cmd} -T /boot").strip.split("\n").last.split(' ').first
+    partition = Facter::Core::Execution.exec("#{df_cmd} -T /").strip.split("\n").last.split(' ').first
 
     uuid = Facter::Core::Execution.exec("#{blkid_cmd} -s UUID -o value #{partition}").strip
 

--- a/lib/facter/root_dir_uuid.rb
+++ b/lib/facter/root_dir_uuid.rb
@@ -6,7 +6,7 @@ Facter.add('root_dir_uuid') do
     df_cmd = Facter::Util::Resolution.which('df')
     blkid_cmd = Facter::Util::Resolution.which('blkid')
 
-    partition = Facter::Core::Execution.exec("#{df_cmd} -T /").strip.split("\n").last.split(' ').first
+    partition = Facter::Core::Execution.exec("#{df_cmd} -P /").strip.split("\n").last.split(' ').first
 
     uuid = Facter::Core::Execution.exec("#{blkid_cmd} -s UUID -o value #{partition}").strip
 


### PR DESCRIPTION
* Cleaned up the boot_dir_uuid fact
* Reverted the version number for the module since the last release was
  3.2.0

SIMP-3138 #comment Added supporting root_dir_uuid fact for the fips module