### PR TITLE
(SIMP-3143) Create 'simplib::filtered' data_hash hiera v5 backend

### DIFF
--- a/lib/puppet/functions/simplib/filtered.rb
+++ b/lib/puppet/functions/simplib/filtered.rb
@@ -1,0 +1,47 @@
+# vim: set expandtab ts=2 sw=2:
+Puppet::Functions.create_function(:'simplib::filtered') do
+  dispatch :filtered do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+  dispatch :filtered_lookup_key do
+    param 'String', :key
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+  def filtered(options, context)
+    backend = call_function(options["function"], options, context)
+    data = {}
+    backend.each do |key, value|
+      check_filter(key, options["filter"]) do |nkey|
+        data[nkey] = value
+      end
+    end
+    data
+  end
+  def filtered_lookup_key(key, options, context)
+    retval = nil
+    check_filter(key, options["filter"]) do |key|
+      retval = call_function(options["function"], key, options, context)
+      if (retval == nil)
+        context.not_found
+      end
+    end
+    if (retval == nil)
+      context.not_found
+    else
+      retval
+    end
+  end
+  def check_filter(key, filter, &block)
+    filtered = false
+    filter.each do |keyname|
+      if (key =~ Regexp.new(keyname))
+        filtered = true
+      end
+    end
+    if (filtered == false)
+      yield key
+    end
+  end
+end

--- a/lib/puppet/functions/simplib/mock_data.rb
+++ b/lib/puppet/functions/simplib/mock_data.rb
@@ -1,0 +1,40 @@
+# vim: set expandtab ts=2 sw=2:
+Puppet::Functions.create_function(:'simplib::mock_data') do
+  dispatch :mock_data do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+  dispatch :mock_data_lookup_key do
+    param 'String', :key
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+  def mock_data(options, context)
+    case options["path"]
+    when "/path/1"
+      {
+        "profiles::test1::variable" => "goodvar",
+        "profiles::test2::variable" => "badvar",
+        "profiles::test::test1::variable" => "goodvar",
+        "apache::sync" => "badvar",
+        "user::root_password" => "badvar",
+      }
+    when "/path/2"
+      {
+        "profiles::test1::variable" => "goodvar",
+        "profiles::test2::variable" => "badvar",
+        "profiles::test::test1::variable" => "goodvar",
+      }
+    else
+      {}
+    end
+  end
+  def mock_data_lookup_key(key, options, context)
+    data = mock_data(options, context)
+    if (data.key?(key))
+      data[key]
+    else
+      context.not_found
+    end
+  end
+end

--- a/spec/functions/simplib/filtered_spec.rb
+++ b/spec/functions/simplib/filtered_spec.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby -S rspec
+# vim: set expandtab ts=2 sw=2:
+require 'spec_helper'
+require 'semantic_puppet'
+puppetver = SemanticPuppet::Version.parse(Puppet.version)
+requiredver = SemanticPuppet::Version.parse("4.9.0")
+if (puppetver > requiredver)
+  describe 'simplib::filtered' do
+    shared_options = {
+      "function" => "simplib::mock_data",
+    }
+    context  "using data_hash dispatch" do
+      it 'should run successfully' do
+        result = subject.execute(shared_options.dup.merge({"path" => "nofile"}), Puppet::Pops::Lookup::Context.new('rp_env', 'simplib'))
+        expect(result).to eql({})
+      end
+      {
+        "with no filters" => {
+          "all_results" => true,
+          "filter" => [],
+        },
+        "with simple filter" => {
+          "all_results" => false,
+          "filter" => [
+            'profiles::test2::variable',
+            'apache::sync',
+            'user::root_password',
+          ],
+        },
+        "with regex filter" => {
+          "all_results" => false,
+          "filter" => [
+            '^profiles::test2::.*$',
+            '^apache::.*$',
+            '^user.*root_password$',
+          ],
+        },
+      }.each do |key, value|
+            context key do
+              {
+                "with path = 'nofile'" => {
+                  "path" => "nofile",
+                  "retval" => {},
+                },
+                "with path = '/path/1'" => {
+                  "path" => "/path/1",
+                  "retval" => {"profiles::test1::variable"=>"goodvar", "profiles::test2::variable"=>"badvar", "profiles::test::test1::variable"=>"goodvar", "apache::sync"=>"badvar", "user::root_password"=>"badvar"},
+                },
+                "with path = '/path/2'" => {
+                  "path" => "/path/2",
+                  "retval" => {"profiles::test1::variable"=>"goodvar", "profiles::test2::variable"=>"badvar", "profiles::test::test1::variable"=>"goodvar"},
+                },
+              }.each do |name, data|
+                  context name do
+                    if (value["all_results"] == true)
+                      it 'should return all results' do
+                        result = subject.execute(shared_options.dup.merge({"path" => data["path"], "filter" => value["filter"]}), Puppet::Pops::Lookup::Context.new('rp_env', 'simplib'))
+                        expect(result).to eql(data["retval"])
+                      end
+                    end
+                    if (value["all_results"] == false)
+                      it 'should not return all results' do
+                        result = subject.execute(shared_options.dup.merge({"path" => data["path"], "filter" => value["filter"]}), Puppet::Pops::Lookup::Context.new('rp_env', 'simplib'))
+                        if (data["retval"] == {})
+                          expect(result).to eql(data["retval"])
+                        else
+                          expect(result).to_not eql(data["retval"])
+                        end
+                      end
+                    end
+                  end
+                end
+            end
+          end
+    end
+  end
+end


### PR DESCRIPTION
Create a 'simplib::filtered' data_hash hiera v5 function that allows for passing through data_hash lookups, but only returns keys that match the filter list.

SIMP-3143 #close