### PR TITLE
(SIMP-3302) Move simp::knockout functionality into simplib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Jun 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.4.0-0
+- Due to lack of support for knockout_prefix for arrays in older versions
+  of Puppet, simp::knockout functionality has been moved to
+  simplib::knockout because multiple modules are using the function.
+- A wrapper has been put around simp::knockout for backwards-compatibility
+  in our code.
+
 * Thu May 18 2017 Nick Miller <nick.miller@onyxpoint.com> - 3.4.0-0
 - Add data type for catalyst `package_ensure`
 

--- a/functions/knockout.pp
+++ b/functions/knockout.pp
@@ -1,0 +1,28 @@
+# uses the knockout prefix of '--' to remove elements from an array.
+# @param array The array to knockout
+# @return [Array] Resulting array.
+# @example Using knockout
+#   array = [
+#     'ssh',
+#     'sudo',
+#     '--ssh',
+#   ]
+#   result = simplib::knockout(array)
+#
+#   result => [
+#              'sudo'
+#             ]
+function simplib::knockout(Array $array) {
+  $included = $array.filter |$data| {
+    $data !~ /^--/
+  }
+
+  $excluded_filter = $array.filter |$data| {
+    $data =~ /^--/
+  }
+  $excluded = $excluded_filter.map |$data| {
+    delete($data, '--')
+  }
+
+  ($included - $excluded)
+}

--- a/spec/functions/knockout_spec.rb
+++ b/spec/functions/knockout_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+shared_examples 'simplib::knockout()' do |input_array, return_value|
+  it { is_expected.to run.with_params(input_array).and_return(return_value) }
+end
+
+describe 'simplib::knockout' do
+  context 'when a simple array is passed' do
+    it_behaves_like 'simplib::knockout()',
+                    %w(socrates plato aristotle),
+                    %w(socrates plato aristotle)
+  end
+
+  context 'when passed a mixed array' do
+    it_behaves_like 'simplib::knockout()',
+                    %w(socrates plato aristotle --socrates),
+                    %w(plato aristotle)
+  end
+
+  context 'when passed a mixed array where everything is knocked out' do
+    it_behaves_like 'simplib::knockout()',
+                    %w(socrates plato aristotle --plato --aristotle --socrates),
+                    []
+  end
+end


### PR DESCRIPTION
- Due to lack of support for knockout_prefix for arrays in older versions
  of Puppet, simp::knockout functionality has been moved to
  simplib::knockout because multiple modules are using the function.
- A wrapper has been put around simp::knockout for backwards-compatibility
  in our code.

SIMP-3302 #comment Moved functionality into simplib