### PR TITLE
(SIMP-3447) ipv6_enabled is not confined properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jul 18 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.4.1-0
+- Fix ipv6_enabled fact, so that it is confined only to linux systems
+
 * Tue Jun 13 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.4.0-0
 - Due to lack of support for knockout_prefix for arrays in older versions
   of Puppet, simp::knockout functionality has been moved to

--- a/lib/facter/ipv6_enabled.rb
+++ b/lib/facter/ipv6_enabled.rb
@@ -4,9 +4,10 @@
 # Known to work on 2.4.6 kernels.
 #
 Facter.add("ipv6_enabled") do
+  confine :kernel => 'Linux'
   setcode do
     retval = false
-    ipv6_enabled = Facter::Core::Execution.exec('/sbin/sysctl -n -e net.ipv6.conf.all.disable_ipv6')
+    ipv6_enabled = Facter::Core::Execution.exec('/sbin/sysctl -n -e net.ipv6.conf.all.disable_ipv6 2>/dev/null')
 
     # we have observed this exec non-deterministically populate $? with
     # nil, although the exec succeeds.  This will happen with %x, ``, or

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
ipv6_enabled runs on all kernels, when the sysctl in question
is linux specific. This causes spurious errors on non-linux
systems

SIMP-3447 #close SIMP-1388 #close