### PR TITLE
(SIMP-3434) Added slapd_version fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jul 31 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.4.1-0
+- Added slapd_version fact. Primary use is in the simp_openldap module,
+  which configures TLS options based on the version of slapd.
+
 * Tue Jul 18 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.4.1-0
 - Fix ipv6_enabled fact, so that it is confined only to linux systems
 

--- a/lib/facter/slapd_version.rb
+++ b/lib/facter/slapd_version.rb
@@ -1,0 +1,17 @@
+# Set a fact to return the version of slapd that is installed
+#
+Facter.add("slapd_version") do
+  if ['RedHat','CentOS'].include?(Facter.value(:operatingsystem))
+    if Facter.value(:operatingsystemmajrelease) < '7'
+      $slapd_bin = '/usr/sbin/slapd'
+    else
+      $slapd_bin = '/sbin/slapd'
+    end
+    confine { File.exist?($slapd_bin) && File.executable?($slapd_bin) }
+    setcode do
+      out = `/sbin/slapd -VV 2>&1`
+      version = out.match(/slapd (\d+\.\d+\.\d+)/)
+      $1
+    end
+  end
+end


### PR DESCRIPTION
Added slapd_version fact. Primary use is in the simp_openldap module,
which configures TLS options based on the version of slapd.

SIMP-3434