### PR TITLE
(SIMP-3490) Updated the fips_ciphers fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-* Sun Jul 23 2-17 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.4.2-0
+* Thu Aug 03 2017 Nick Markowski <nmarkowski@keywcorp.com> - 3.4.2-0
+- The fips_ciphers fact returns nil if the openssl binary is not available
+
+* Sun Jul 23 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.4.2-0
 - Updated puppet-strings documentation
 - Updated CONTRIBUTING.md
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
 end
 
 group :development do

--- a/lib/facter/fips_ciphers.rb
+++ b/lib/facter/fips_ciphers.rb
@@ -1,9 +1,11 @@
 # List available FIPS-compatible OpenSSL ciphers on the system
 # Returns: Array[String]
 Facter.add('fips_ciphers') do
+
   confine :kernel => 'Linux'
+  openssl_bin = Facter::Core::Execution.which('openssl')
 
   setcode do
-    Facter::Core::Execution.exec('openssl ciphers FIPS:!LOW').split(':')
+    Facter::Core::Execution.exec("#{openssl_bin} ciphers FIPS:-LOW").split(':') if openssl_bin
   end
 end

--- a/spec/unit/facter/fips_ciphers_spec.rb
+++ b/spec/unit/facter/fips_ciphers_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'fips_ciphers' do
+
+  before :each do
+    Facter.clear
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+  end
+
+  context 'openssl command exists' do
+    it 'returns FIPS ciphers' do
+      Facter::Core::Execution.stubs(:which).with('openssl').returns('/bin/openssl')
+      Facter::Core::Execution.stubs(:exec).with('/bin/openssl ciphers FIPS:-LOW').returns("ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA")
+      expect(Facter.fact('fips_ciphers').value).to eq(["ECDHE-RSA-AES256-GCM-SHA384","ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA"])
+    end
+  end
+
+  context 'openssl command does not exist' do
+    it 'returns nil' do
+      Facter::Core::Execution.stubs(:which).with('openssl').returns(nil)
+      expect(Facter.fact('fips_ciphers').value).to eq(nil)
+    end
+  end
+
+end


### PR DESCRIPTION
- Returns nil if the openssl binary is not available
- Addresses https://github.com/simp/pupmod-simp-simp_grafana/issues/28

SIMP-3490 #close