### PR TITLE
(SIMP-3280) Add SHA256-based algorithm option to ip_to_cron/rand_cron

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,21 @@
+* Mon Sep 11 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.5.0-0
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::ip_to_cron() replaces deprecated ip_to_cron()
+  - simplib::rand_cron() replaces deprecated rand_cron()
+- Add algorithm options to simplib::ip_to_cron() and
+  simplib::rand_cron() to allow the user to select the transformation
+  algorithm, instead of defaulting to an IP number modulus, when the
+  entity to be transformed is an IP address.  The IP number modulus
+  algorithm produces undesirable clustering when used to randomize IP
+  addresses in a system for which the number of IPs to be transformed
+  is less than the range over which the randomization is requested.
+
 * Tue Aug 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.5.0-0
 - Add simplib-specific deprecation functions for both Puppet 3 functions
   (simplib_deprecation()) and Puppet 4 functions (simplib::deprecation()).
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
-  simplib deprecation warning when the Puppet 3 versions is called:
+  simplib deprecation warning when the Puppet 3 versions are called:
   - simplib::inspect() replaces deprecated inspect()
   - simplib::ipaddresses() replaces deprecated ipaddresses()
   - simplib::parse_hosts() replaces deprecated parse_hosts()

--- a/lib/puppet/functions/simplib/ip_to_cron.rb
+++ b/lib/puppet/functions/simplib/ip_to_cron.rb
@@ -4,7 +4,7 @@
 Puppet::Functions.create_function(:'simplib::ip_to_cron') do
 
   local_types do
-    type "IpToCronAlgorithm = Enum['ip_mod', 'rand']"
+    type "IpToCronAlgorithm = Enum['ip_mod', 'sha256']"
   end
 
   # @param occurs
@@ -22,7 +22,7 @@ Puppet::Functions.create_function(:'simplib::ip_to_cron') do
   #   exceeds the `max_value` and the hosts have largely, linearly-
   #   assigned IP addresses.
   #
-  #   When 'rand', a random number generated using the IP number is the
+  #   When 'sha256', a random number generated using the IP number is the
   #   basis for the returned values.  This algorithm works well to create
   #   cron job intervals for multiple hosts, when the number of hosts
   #   is less than the `max_value` or the hosts do not have linearly-
@@ -39,9 +39,9 @@ Puppet::Functions.create_function(:'simplib::ip_to_cron') do
   #   ip_to_cron()
   #
   # @example Generate 2 values for the `hour` cron interval, using the
-  #   'rand' algorithm and a provided IP address
+  #   'sha256' algorithm and a provided IP address
   #
-  #   ip_to_cron(2,23,'rand','10.0.23.45')
+  #   ip_to_cron(2,23,'sha256','10.0.23.45')
   #
 
   dispatch :ip_to_cron do
@@ -59,8 +59,7 @@ Puppet::Functions.create_function(:'simplib::ip_to_cron') do
       ipaddr = ip.dup
     end
 
-    alg = (algorithm == 'ip_mod') ? 'ip_mod' : 'sha256'
-    call_function('simplib::rand_cron', ipaddr, alg, occurs, max_value)
+    call_function('simplib::rand_cron', ipaddr, algorithm, occurs, max_value)
   end
 end
 

--- a/lib/puppet/functions/simplib/ip_to_cron.rb
+++ b/lib/puppet/functions/simplib/ip_to_cron.rb
@@ -1,0 +1,66 @@
+#  Transforms an IP address to one or more interval values for `cron`.
+#  This can be used to avoid starting a certain cron job at the same
+#  time on all servers.
+Puppet::Functions.create_function(:'simplib::ip_to_cron') do
+
+  local_types do
+    type "IpToCronAlgorithm = Enum['ip_mod', 'rand']"
+  end
+
+  # @param occurs
+  #   The occurrence within an interval, i.e., the number of values to
+  #   be generated for the interval.
+  #
+  # @param max_value
+  #   The maximum value for the interval.  The values generated will
+  #   be in the inclusive range [0, max_value].
+  #
+  # @param algorithm
+  #   When 'ip_mod', the modulus of the IP number is used as the basis
+  #   for the returned values.  This algorithm works well to create
+  #   cron job intervals for multiple hosts, when the number of hosts
+  #   exceeds the `max_value` and the hosts have largely, linearly-
+  #   assigned IP addresses.
+  #
+  #   When 'rand', a random number generated using the IP number is the
+  #   basis for the returned values.  This algorithm works well to create
+  #   cron job intervals for multiple hosts, when the number of hosts
+  #   is less than the `max_value` or the hosts do not have linearly-
+  #   assigned IP addresses.
+  #
+  # @param ip
+  #   The IP address to use as the basis for the generated values.
+  #   When `nil`, the 'ipaddress' fact (IPv4) is used.
+  #
+  # @return [Array[Integer]] Array of integers suitable for use in the
+  #   ``minute`` or ``hour`` cron field.
+  #
+  # @example Generate one value for the `minute` cron interval
+  #   ip_to_cron()
+  #
+  # @example Generate 2 values for the `hour` cron interval, using the
+  #   'rand' algorithm and a provided IP address
+  #
+  #   ip_to_cron(2,23,'rand','10.0.23.45')
+  #
+
+  dispatch :ip_to_cron do
+    optional_param 'Integer[1]',        :occurs
+    optional_param 'Integer[1]',        :max_value
+    optional_param 'IpToCronAlgorithm', :algorithm
+    optional_param 'Simplib::IP',       :ip
+  end
+
+  def ip_to_cron(occurs = 1, max_value = 59, algorithm = 'ip_mod', ip = nil)
+    if ip.nil?
+      scope = closure_scope
+      ipaddr = scope['facts']['ipaddress']
+    else
+      ipaddr = ip.dup
+    end
+
+    alg = (algorithm == 'ip_mod') ? 'ip_mod' : 'sha256'
+    call_function('simplib::rand_cron', ipaddr, alg, occurs, max_value)
+  end
+end
+

--- a/lib/puppet/functions/simplib/rand_cron.rb
+++ b/lib/puppet/functions/simplib/rand_cron.rb
@@ -98,22 +98,9 @@ Puppet::Functions.create_function(:'simplib::rand_cron') do
   end
 
   def generate_sha256_number(input_string)
-    require 'ipaddr'
     require 'digest'
 
-    ip_num = nil
-    begin
-     ip_num = IPAddr.new(input_string).to_i
-    rescue IPAddr::Error
-    end
-
-    num = nil
-    if ip_num.nil?
-      num = Digest::SHA256.hexdigest(input_string).hex
-    else
-      num = Digest::SHA256.hexdigest(ip_num.to_s).hex
-    end
-    num
+    Digest::SHA256.hexdigest(input_string).hex
   end
 
   # @param modifier Input string to be transformed to an Integer

--- a/lib/puppet/functions/simplib/rand_cron.rb
+++ b/lib/puppet/functions/simplib/rand_cron.rb
@@ -1,0 +1,125 @@
+#  Transforms an input string to one or more interval values for `cron`.
+#  This can be used to avoid starting a certain cron job at the same
+#  time on all servers.
+
+Puppet::Functions.create_function(:'simplib::rand_cron') do
+
+  local_types do
+    type "RandCronAlgorithm = Enum['crc32', 'ip_mod', 'sha256']"
+  end
+
+  # @param modifier
+  #   The input string to use as the basis for the generated values.
+  #
+  # @param algorithm
+  #   Randomization algorithm to apply to transform the input string.
+  #
+  #   When 'sha256' and the input string is not an IP address, a random
+  #   number generated from the input string via sha256 is used as the
+  #   basis for the returned values.
+  #
+  #   When 'sha256' and the input string is an IP address, a random
+  #   number generated from the numeric IP via sh256 is used as the
+  #   basis for the returned values.  This algorithm works well to
+  #   create cron job intervals for multiple hosts, when the number
+  #   of hosts is less than the `max_value` or the hosts do not have
+  #   linearly-assigned IP addresses.
+  #
+  #   When 'ip_mod' and the input string is an IP address, the modulus
+  #   of the numeric IP is used as the basis for the returned values.
+  #   This algorithm works well to create cron job intervals for
+  #   multiple hosts, when the number of hosts exceeds the `max_value`
+  #   and the hosts have linearly-assigned IP addresses.
+  #
+  #   When 'crc32', the crc32 of the input string will be used as the
+  #   basis for the returned values.
+  #
+  # @param occurs
+  #   The occurrence within an interval, i.e., the number of values to
+  #   be generated for the interval. Defaults to `1`.
+  #
+  # @param max_value
+  #   The maximum value for the interval.  The values generated will
+  #   be in the inclusive range [0, max_value]. Defaults to `60` for
+  #   use in the `minute` cron field.
+  #
+  # @return [Array[Integer]] Array of integers suitable for use in the
+  #   ``minute`` or ``hour`` cron field.
+  #
+  # @example Generate one value for the `minute` cron interval using
+  #   the 'sha256' algorithm
+  #
+  #   rand_cron('sha256','myhost.test.local')
+  #
+  # @example Generate 2 values for the `minute` cron interval using
+  #   the 'sha256' algorithm applied to the numeric representation of
+  #   an IP
+  #
+  #   rand_cron('sha256','10.0.23.45')
+  #
+  # @example Generate 2 values for the `hour` cron interval, using the
+  #   'ip_mod' algorithm
+  #
+  #   rand_cron('ip_mod', '10.0.6.78', 2, 23)
+  #
+  dispatch :rand_cron do
+    required_param 'String',            :modifier
+    required_param 'RandCronAlgorithm', :algorithm
+    optional_param 'Integer[1]',        :occurs
+    optional_param 'Integer[1]',        :max_value
+  end
+
+  # +param+: modifier Input string to be transformed to an Integer
+  # +param+: algorithm Algorithm to apply to transform input string into
+  #   an Integer
+  #
+  # +return+: Integer to be used as a basis for generated cron values
+  def generate_numeric_modifier(modifier, algorithm)
+    range_modifier = nil
+    if algorithm == 'crc32'
+      require 'zlib'
+      range_modifier = Zlib.crc32(modifier)
+    else  # 'sha256' or 'ip_mod'
+      require 'ipaddr'
+      require 'digest'
+
+      ip_num = nil
+      begin
+        ip_num = IPAddr.new(modifier).to_i
+      rescue IPAddr::Error
+      end
+
+      if ip_num.nil?
+        if algorithm == 'ip_mod'
+          fail("simplib::rand_cron: '#{modifier}' is not a valid IP address")
+        else
+          range_modifier = Digest::SHA256.hexdigest(modifier).hex
+        end
+      else
+        if algorithm == 'ip_mod'
+          range_modifier = ip_num
+        else
+          range_modifier = Digest::SHA256.hexdigest(ip_num.to_s).hex
+        end
+      end
+    end
+    range_modifier
+  end
+
+  def rand_cron(modifier, algorithm, occurs = 1, max_value = 59)
+    range_modifier = generate_numeric_modifier(modifier, algorithm)
+    modulus = max_value + 1
+    base = range_modifier % modulus
+
+    values = []
+    if occurs == 1
+      values << base
+    else
+      values = Array.new
+      (1..occurs).each do |i|
+        values << ((base - (modulus / occurs * i)) % modulus)
+      end
+    end
+    return values.sort
+  end
+end

--- a/lib/puppet/parser/functions/ip_to_cron.rb
+++ b/lib/puppet/parser/functions/ip_to_cron.rb
@@ -23,6 +23,8 @@ module Puppet::Parser::Functions
     @return [Variant[Integer[0,59], Array[Integer[0,59], Integer[0,23]]]]
     ENDHEREDOC
 
+    function_simplib_deprecation(['ip_to_cron', 'ip_to_cron is deprecated, please use simplib::ip_to_cron'])
+
     Puppet::Parser::Functions.autoloader.loadall
     function_rand_cron([lookupvar('::ipaddress'),args[0],args[1]])
   end

--- a/lib/puppet/parser/functions/rand_cron.rb
+++ b/lib/puppet/parser/functions/rand_cron.rb
@@ -34,7 +34,9 @@ module Puppet::Parser::Functions
     @return [Variant[Integer[0,59], Array[Integer[0,59], Integer[0,23]]]]
     ENDHEREDOC
 
+    function_simplib_deprecation(['rand_cron', 'rand_cron is deprecated, please use simplib::rand_cron'])
     modifier = Array(args[0]).flatten.first
+
     occurs   = (args[1] || 1).to_i
     scope    = (args[2] || 60).to_i
 

--- a/spec/functions/simplib/ip_to_cron_spec.rb
+++ b/spec/functions/simplib/ip_to_cron_spec.rb
@@ -17,15 +17,15 @@ describe 'simplib::ip_to_cron' do
   end
 
   context 'occurs, max_value, and algorithm specified' do
-    it { is_expected.to run.with_params(2,23,'sha256').and_return([0,12]) }
+    it { is_expected.to run.with_params(2,23,'sha256').and_return([5,17]) }
   end
 
   context 'occurs, max_value, algorithm, and IPv4 specified' do
-    it { is_expected.to run.with_params(2,23,'sha256', '10.0.20.35').and_return([1,13]) }
+    it { is_expected.to run.with_params(2,23,'sha256', '10.0.20.35').and_return([4,16]) }
   end
 
   context 'occurs, max_value, algorithm, and IPv6 specified' do
-    it { is_expected.to run.with_params(2,23,'sha256','2001:0db8:85a3:0000:0000:8a2e:0370:7395').and_return([8,20]) }
+    it { is_expected.to run.with_params(2,23,'sha256','2001:0db8:85a3:0000:0000:8a2e:0370:7395').and_return([6,18]) }
   end
 
   context 'invalid ip specified' do

--- a/spec/functions/simplib/ip_to_cron_spec.rb
+++ b/spec/functions/simplib/ip_to_cron_spec.rb
@@ -17,18 +17,18 @@ describe 'simplib::ip_to_cron' do
   end
 
   context 'occurs, max_value, and algorithm specified' do
-    it { is_expected.to run.with_params(2,23,'rand').and_return([0,12]) }
+    it { is_expected.to run.with_params(2,23,'sha256').and_return([0,12]) }
   end
 
   context 'occurs, max_value, algorithm, and IPv4 specified' do
-    it { is_expected.to run.with_params(2,23,'rand', '10.0.20.35').and_return([1,13]) }
+    it { is_expected.to run.with_params(2,23,'sha256', '10.0.20.35').and_return([1,13]) }
   end
 
   context 'occurs, max_value, algorithm, and IPv6 specified' do
-    it { is_expected.to run.with_params(2,23,'rand','2001:0db8:85a3:0000:0000:8a2e:0370:7395').and_return([8,20]) }
+    it { is_expected.to run.with_params(2,23,'sha256','2001:0db8:85a3:0000:0000:8a2e:0370:7395').and_return([8,20]) }
   end
 
   context 'invalid ip specified' do
-    it { is_expected.to run.with_params(2,23,'rand', '300.0.20.35').and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params(2,23,'sha256', '300.0.20.35').and_raise_error(ArgumentError) }
   end
 end

--- a/spec/functions/simplib/ip_to_cron_spec.rb
+++ b/spec/functions/simplib/ip_to_cron_spec.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::ip_to_cron' do
+  let(:facts) {{ :ipaddress => '10.0.10.154' }}
+
+  context 'with default parameters' do
+    it { is_expected.to run.with_params().and_return([54]) }
+  end
+
+  context 'occurs specified' do
+    it { is_expected.to run.with_params(2).and_return([24,54]) }
+  end
+
+  context 'occurs and max_value specified' do
+    it { is_expected.to run.with_params(2,23).and_return([6,18]) }
+  end
+
+  context 'occurs, max_value, and algorithm specified' do
+    it { is_expected.to run.with_params(2,23,'rand').and_return([0,12]) }
+  end
+
+  context 'occurs, max_value, algorithm, and IPv4 specified' do
+    it { is_expected.to run.with_params(2,23,'rand', '10.0.20.35').and_return([1,13]) }
+  end
+
+  context 'occurs, max_value, algorithm, and IPv6 specified' do
+    it { is_expected.to run.with_params(2,23,'rand','2001:0db8:85a3:0000:0000:8a2e:0370:7395').and_return([8,20]) }
+  end
+
+  context 'invalid ip specified' do
+    it { is_expected.to run.with_params(2,23,'rand', '300.0.20.35').and_raise_error(ArgumentError) }
+  end
+end

--- a/spec/functions/simplib/rand_cron_spec.rb
+++ b/spec/functions/simplib/rand_cron_spec.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::rand_cron' do
+  context "with a non-IP modifier and 'sha256'" do
+    it { is_expected.to run.with_params('myhost.test.local', 'sha256').and_return([9]) }
+  end
+
+  context "with an IPv4 modifier and 'sha256'" do
+    it { is_expected.to run.with_params('10.0.10.154','sha256').and_return([12]) }
+  end
+
+  context "with an IPv6 modifier and 'sha256'" do
+    it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7395','sha256').and_return([44]) }
+  end
+
+  context "with an IPv4 modifier and 'ip_mod'" do
+    it { is_expected.to run.with_params('10.0.10.154','ip_mod').and_return([54]) }
+  end
+
+  context "with an IPv6 modifier and 'ip_mod'" do
+    it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7395','ip_mod').and_return([9]) }
+  end
+
+  context "with 'crc32'" do
+    it { is_expected.to run.with_params('myhost.test.local','crc32').and_return([32]) }
+  end
+
+  context 'with occurs specified' do
+    it { is_expected.to run.with_params('10.0.10.154','sha256',2).and_return([12,42]) }
+  end
+
+  context 'with occurs and max_value specified' do
+    it { is_expected.to run.with_params('10.0.10.154','sha256',2,23).and_return([0,12]) }
+  end
+
+  context "with an invalid IP address and 'ip_mod'" do
+    it { is_expected.to run.with_params('300.0.20.35','ip_mod').and_raise_error(/'300.0.20.35' is not a valid IP address/) }
+  end
+end

--- a/spec/functions/simplib/rand_cron_spec.rb
+++ b/spec/functions/simplib/rand_cron_spec.rb
@@ -7,11 +7,11 @@ describe 'simplib::rand_cron' do
   end
 
   context "with an IPv4 modifier and 'sha256'" do
-    it { is_expected.to run.with_params('10.0.10.154','sha256').and_return([12]) }
+    it { is_expected.to run.with_params('10.0.10.154','sha256').and_return([5]) }
   end
 
   context "with an IPv6 modifier and 'sha256'" do
-    it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7395','sha256').and_return([44]) }
+    it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7395','sha256').and_return([18]) }
   end
 
   context "with an IPv4 modifier and 'ip_mod'" do
@@ -32,11 +32,11 @@ describe 'simplib::rand_cron' do
   end
 
   context 'with occurs specified' do
-    it { is_expected.to run.with_params('10.0.10.154','sha256',2).and_return([12,42]) }
+    it { is_expected.to run.with_params('10.0.10.154','sha256',2).and_return([5,35]) }
   end
 
   context 'with occurs and max_value specified' do
-    it { is_expected.to run.with_params('10.0.10.154','sha256',2,23).and_return([0,12]) }
+    it { is_expected.to run.with_params('10.0.10.154','sha256',2,23).and_return([5,17]) }
   end
 
 end

--- a/spec/functions/simplib/rand_cron_spec.rb
+++ b/spec/functions/simplib/rand_cron_spec.rb
@@ -22,6 +22,11 @@ describe 'simplib::rand_cron' do
     it { is_expected.to run.with_params('2001:0db8:85a3:0000:0000:8a2e:0370:7395','ip_mod').and_return([9]) }
   end
 
+  context "with an invalid IP address and 'ip_mod'" do
+    # matching legacy behavior, uses crc32 algorithm, instead
+    it { is_expected.to run.with_params('300.0.20.35','ip_mod').and_return([17]) }
+  end
+
   context "with 'crc32'" do
     it { is_expected.to run.with_params('myhost.test.local','crc32').and_return([32]) }
   end
@@ -34,7 +39,4 @@ describe 'simplib::rand_cron' do
     it { is_expected.to run.with_params('10.0.10.154','sha256',2,23).and_return([0,12]) }
   end
 
-  context "with an invalid IP address and 'ip_mod'" do
-    it { is_expected.to run.with_params('300.0.20.35','ip_mod').and_raise_error(/'300.0.20.35' is not a valid IP address/) }
-  end
 end


### PR DESCRIPTION
SIMP-3280 specifies to replace the IP-modulus-based algorithm in rand_cron (and thus ip_to_cron)
with a SHA256-based algorithm. This request was specifically meant to address a deficiency with
the randomness of client puppet agent runs scheduled by pupmod::agent::cron in certain
circumstances. (By default, pupmod::agent::cron uses rand_cron to determine the cron minute
for client's puppet agent run from the client's IP address.)

Since, empirical analysis of both the original and proposed algorithms for sets of servers in which both
the number of IP addresses is larger than the cron range and the IP addresses are assigned linearly,
the IP-modulus algorithm provides a better distribution across minutes in an hour, this PR instead
provides both algorithms and allows the user to select the algorithm appropriate for their site. A
corresponding change will be made to pupmod-simp-pupmod, to expose the new option.

Note that the crc32-based algorithm for non-IP input to rand_cron will still be available, for backward
compatibility.