### PR TITLE
(SIMP-3358) Deprecate & convert Puppet 3 functions part 4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,10 +50,19 @@ unit-test-ruby-2.3:
   script:
     - bundle install
     - bundle exec rake spec
-acceptance-test:
+
+acceptance-test-no-fips:
   stage: test
   tags:
     - beaker
   script:
     - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+    - bundle exec rake beaker:suites
+
+acceptance-test-fips:
+  stage: test
+  tags:
+    - beaker
+  script:
+    - bundle install --no-binstubs --path=vendor
+    - BEAKER_fips=yes bundle exec rake beaker:suites

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,11 @@
   -  simplib::validate_deep_hash replaced validate_deep_hash.
 - In simplib::validate_deep_hash, fixed validate_deep_hash bug in
   which unknown keys in the Hash to check were not detected.
+
+* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Thu Oct 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Add Simplib::Macaddress data type
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
@@ -24,9 +29,7 @@
   Simplib::Umask data type
 - Deprecate validate_macaddresses(), advising the user to convert
   to the Simplib::Macaddress data type
-
-* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.8.0-0
-- Fixes split failure when "findmnt" does not exist on Linux
+- Fix bug in which simplib_deprecation() used the wrong environment variable.
 
 * Tue Sep 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.6.0-0
 - Convert all 'sysctl' 'kernel.shm*' entries to Strings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,4 @@
-* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
-- Fixes split failure when "findmnt" does not exist on Linux
-* Thu Oct 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+* Wed Nov 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.1-0
 - Add Simplib::Macaddress data type
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
@@ -12,6 +10,16 @@
   Simplib::Umask data type
 - Deprecate validate_macaddresses(), advising the user to convert
   to the Simplib::Macaddress data type
+
+* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
+- Fixes split failure when "findmnt" does not exist on Linux
+
+* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::validate_array_member() replaces
+    deprecated validate_array_member()
+  - simplib::validate_bool() replaces deprecated validate_bool_simp()
 
 * Tue Sep 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.6.0-0
 - Convert all 'sysctl' 'kernel.shm*' entries to Strings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,29 +28,6 @@
 * Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.8.0-0
 - Fixes split failure when "findmnt" does not exist on Linux
 
-* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
-- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
-  simplib deprecation warning when the Puppet 3 versions are called:
-  - simplib::validate_array_member() replaces
-    deprecated validate_array_member()
-  - simplib::validate_bool() replaces deprecated validate_bool_simp()
-
-* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
-- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
-  simplib deprecation warning when the Puppet 3 versions are called:
-  - simplib::nets2ddq() replaces deprecated nets2ddq().
-  - simplib::validate_array_member() replaces
-    deprecated validate_array_member()
-  - simplib::validate_between() replaces deprecated validate_between().
-    The new version fails validation, instead of returning false.
-    This behavior consistent with both how the method is used by SIMP
-    modules and the error behavior of all other simplib validate
-    functions.
-  - simplib::validate_bool() replaces deprecated validate_bool_simp()
-  -  simplib::validate_deep_hash replaced validate_deep_hash.
-- In simplib::validate_deep_hash, fixed validate_deep_hash bug in
-  which unknown keys in the Hash to check were not detected.
-
 * Tue Sep 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.6.0-0
 - Convert all 'sysctl' 'kernel.shm*' entries to Strings
   - shmall and shmmax were causing Facter and newer versions of Puppet to crash

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,13 @@
 * Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::validate_array_member() replaces
+    deprecated validate_array_member()
+  - simplib::validate_bool() replaces deprecated validate_bool_simp()
+
+* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
   - simplib::nets2ddq() replaces deprecated nets2ddq().
   - simplib::validate_array_member() replaces
     deprecated validate_array_member()

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,9 +17,18 @@
 * Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::nets2ddq() replaces deprecated nets2ddq().
   - simplib::validate_array_member() replaces
     deprecated validate_array_member()
+  - simplib::validate_between() replaces deprecated validate_between().
+    The new version fails validation, instead of returning false.
+    This behavior consistent with both how the method is used by SIMP
+    modules and the error behavior of all other simplib validate
+    functions.
   - simplib::validate_bool() replaces deprecated validate_bool_simp()
+  -  simplib::validate_deep_hash replaced validate_deep_hash.
+- In simplib::validate_deep_hash, fixed validate_deep_hash bug in
+  which unknown keys in the Hash to check were not detected.
 
 * Tue Sep 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.6.0-0
 - Convert all 'sysctl' 'kernel.shm*' entries to Strings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,22 @@
 * Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::nets2ddq() replaces deprecated nets2ddq().
+  - simplib::validate_array_member() replaces
+    deprecated validate_array_member()
+  - simplib::validate_between() replaces deprecated validate_between().
+    The new version fails validation, instead of returning false.
+    This behavior consistent with both how the method is used by SIMP
+    modules and the error behavior of all other simplib validate
+    functions.
+  - simplib::validate_bool() replaces deprecated validate_bool_simp()
+  -  simplib::validate_deep_hash replaced validate_deep_hash.
+- In simplib::validate_deep_hash, fixed validate_deep_hash bug in
+  which unknown keys in the Hash to check were not detected.
+
+* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
   - simplib::validate_array_member() replaces
     deprecated validate_array_member()
   - simplib::validate_bool() replaces deprecated validate_bool_simp()

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,4 @@
-* Wed Nov 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.1-0
-- Add Simplib::Macaddress data type
-- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
-  simplib deprecation warning when the Puppet 3 versions are called:
-  - simplib::join_mount_opts() replaces deprected join_mount_opts()
-  - simplib::nets2cidr() replaces deprecated nets2cidr()
-  - simplib::validate_re_array() replaces deprecated validate_re_array()
-  - simplib::validate_sysctl_value() replaces deprecated validate_sysctl_value()
-- Deprecate validate_umask(), advising the user to convert to the
-  Simplib::Umask data type
-- Deprecate validate_macaddresses(), advising the user to convert
-  to the Simplib::Macaddress data type
-
-* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
-- Fixes split failure when "findmnt" does not exist on Linux
-
-* Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+* Mon Nov 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.8.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:
   - simplib::nets2ddq() replaces deprecated nets2ddq().
@@ -29,6 +13,20 @@
   -  simplib::validate_deep_hash replaced validate_deep_hash.
 - In simplib::validate_deep_hash, fixed validate_deep_hash bug in
   which unknown keys in the Hash to check were not detected.
+- Add Simplib::Macaddress data type
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::join_mount_opts() replaces deprected join_mount_opts()
+  - simplib::nets2cidr() replaces deprecated nets2cidr()
+  - simplib::validate_re_array() replaces deprecated validate_re_array()
+  - simplib::validate_sysctl_value() replaces deprecated validate_sysctl_value()
+- Deprecate validate_umask(), advising the user to convert to the
+  Simplib::Umask data type
+- Deprecate validate_macaddresses(), advising the user to convert
+  to the Simplib::Macaddress data type
+
+* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.8.0-0
+- Fixes split failure when "findmnt" does not exist on Linux
 
 * Fri Oct 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a

--- a/lib/puppet/functions/simplib/nets2ddq.rb
+++ b/lib/puppet/functions/simplib/nets2ddq.rb
@@ -1,0 +1,83 @@
+# Tranforms a list of networks into an equivalent array in
+# dotted quad notation.
+#
+# CIDR networks are converted to dotted quad notation networks.
+# IP addresses and hostnames are left untouched.
+
+Puppet::Functions.create_function(:'simplib::nets2ddq') do
+
+  # @param networks The networks to convert
+  # @return Array[String] Converted input
+  # @raise RuntimeError if any input item is not a valid network
+  #   or hostname
+  #
+  # @example Convert Array input
+  #
+  #   $foo = [ '10.0.1.0/24',
+  #            '10.0.2.0/255.255.255.0',
+  #            '10.0.3.25',
+  #            'myhost' ]
+  #
+  #   $bar = simplib::nets2ddq($foo)
+  #
+  #   $bar contains:[ '10.0.1.0/255.255.255.0',
+  #                   '10.0.2.0/255.255.255.0',
+  #                   '10.0.3.25',
+  #                   'myhost' ]
+  #
+  dispatch :nets2ddq do
+    required_param 'Array', :networks
+  end
+
+  # @param networks_string String containing the list of networks to
+  #   convert; list elements are separated by spaces, commas or semicolons.
+  # @return Array[String] Converted input
+  # @raise RuntimeError if any input item is not a valid network
+  #   or hostname
+  #
+  # @example Convert String input
+  #
+  #   $foo = '10.0.1.0/24 10.0.2.0/255.255.255.0 10.0.3.25 myhost'
+  #
+  #   $bar = simplib::nets2ddq($foo)
+  #
+  #   $bar contains:[ '10.0.1.0/255.255.255.0',
+  #                   '10.0.2.0/255.255.255.0',
+  #                   '10.0.3.25',
+  #                   'myhost' ]
+  #
+  dispatch :nets2ddq_string_input do
+    required_param 'String', :networks_string
+  end
+
+  def nets2ddq_string_input(networks_string)
+    networks = networks_string.split(/\s|,|;/).delete_if{ |y| y.empty? }
+    nets2ddq(networks)
+  end
+
+  def nets2ddq(networks)
+    require 'ipaddr'
+    require File.expand_path(File.dirname(__FILE__) + '/../../../puppetx/simp/simplib.rb')
+
+    retval = Array.new
+    networks.each do |lnet|
+      begin
+        ipaddr = IPAddr.new(lnet)
+      rescue
+        if PuppetX::SIMP::Simplib.hostname?(lnet) then
+          retval << lnet
+          next
+        end
+        fail("simplib::nets2ddq(): '#{lnet}' is not a valid network.")
+      end
+
+      # Just add it if it doesn't have a specified netmask.
+      if lnet =~ /\// then
+        retval << "#{ipaddr.to_s}/#{ipaddr.inspect.split('/').last.chop}"
+      else
+        retval << lnet
+      end
+    end
+    retval
+  end
+end

--- a/lib/puppet/functions/simplib/nets2ddq.rb
+++ b/lib/puppet/functions/simplib/nets2ddq.rb
@@ -7,7 +7,7 @@
 Puppet::Functions.create_function(:'simplib::nets2ddq') do
 
   # @param networks The networks to convert
-  # @return Array[String] Converted input
+  # @return [Array[String]] Converted input
   # @raise RuntimeError if any input item is not a valid network
   #   or hostname
   #
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:'simplib::nets2ddq') do
 
   # @param networks_string String containing the list of networks to
   #   convert; list elements are separated by spaces, commas or semicolons.
-  # @return Array[String] Converted input
+  # @return [Array[String]] Converted input
   # @raise RuntimeError if any input item is not a valid network
   #   or hostname
   #

--- a/lib/puppet/functions/simplib/validate_array_member.rb
+++ b/lib/puppet/functions/simplib/validate_array_member.rb
@@ -1,0 +1,66 @@
+# Validate that an single input is a member of another `Array` or an
+# `Array` input is a subset of another `Array`. The comparison
+# can optionally ignore the case of `String` elements.
+Puppet::Functions.create_function(:'simplib::validate_array_member') do
+
+  local_types do
+    type 'SimpleTypes = Variant[String,Numeric,Boolean]'
+  end
+
+  # @param input Input to find within the target
+  # @param target
+  # @param modifier Modification to be made to the comparison
+  #   operation.  Currently, 'i', string case invariance is the only
+  #   supported modifier.
+  # @return [Nil]
+  # @raise RuntimeError if validation fails
+  #   
+  # @example Validating single input
+  #
+  #   validate_array_member('foo',['foo','bar'])     # succeeds
+  #   validate_array_member('foo',['FOO','BAR'])     # fails
+  #   validate_array_member('foo',['FOO','BAR'],'i') # succeeds
+  #
+  # @example Validating array input
+  #
+  #   validate_array_member(['foo','bar'],['foo','bar','baz'])      # succeeds
+  #   validate_array_member(['foo','bar'],['FOO','BAR','BAZ'])      # fails
+  #   validate_array_member(['foo','bar'],['FOO','BAR','BAZ'], 'i') # succeeds
+  #
+  dispatch :validate_array_member do
+    required_param 'Variant[SimpleTypes,Array[SimpleTypes]]',:input
+    required_param 'Array[SimpleTypes]',:target
+    optional_param "Enum['i']", :modifier
+  end
+
+  def validate_array_member(input, target, modifier=nil)
+    to_compare = Array(input).dup
+    target_array = target.dup
+
+    if modifier
+      if modifier == 'i'
+        to_compare.map!{ |x|
+         if x.is_a?(String)
+           x.downcase
+         else
+           x
+         end
+        }
+
+        target_array.map!{ |x|
+         if x.is_a?(String)
+           x.downcase
+         else
+           x
+         end
+        }
+      end
+    end
+
+    unless (to_compare - target_array).empty?
+      fail("simplib::validate_array_member(): '#{target}' does not contain '#{input}'")
+    end
+
+  end
+
+end

--- a/lib/puppet/functions/simplib/validate_between.rb
+++ b/lib/puppet/functions/simplib/validate_between.rb
@@ -1,0 +1,36 @@
+# Validate that the first value is between the second and third values
+# numerically. The range is inclusive.
+Puppet::Functions.create_function(:'simplib::validate_between') do
+
+  # @param value Value to validate
+  # @param min_value Minimum value that is valid
+  # @param max_value Maximum value that is valid
+  # @return [Nil]
+  #
+  # @example Passing
+  #   simplib::validate_between('-1', -3, 0)
+  #   simplib::validate_between(7, 0, 60)
+  #   simplib::validate_between(7.6, 7.1, 8.4)
+  #
+  # #example Failing
+  #   simplib::validate_between('-1', 0, 3)
+  #   simplib::validate_between(0, 1, 60)
+  #   simplib::validate_between(7.6, 7.7, 8.4)
+  #
+  dispatch :validate_between do
+    required_param 'Variant[String[1],Numeric]', :value
+    required_param 'Numeric', :min_value
+    required_param 'Numeric', :max_value
+  end
+
+  def validate_between(value, min_value, max_value)
+    numeric_value = value.to_f
+    unless numeric_value >= min_value and numeric_value <= max_value
+      # The original method was used in SIMP modules as if it raised an 
+      # exception, so this implementation will work as expected.
+      err_msg = "simplib::validate_between: '#{value}' is not between" + 
+        " '#{min_value}' and '#{max_value}'"
+      fail(err_msg)
+    end
+  end
+end

--- a/lib/puppet/functions/simplib/validate_bool.rb
+++ b/lib/puppet/functions/simplib/validate_bool.rb
@@ -1,0 +1,33 @@
+# Validate that all passed values are either `true`, 'true',
+# `false` or 'false'.
+Puppet::Functions.create_function(:'simplib::validate_bool') do
+
+  # @param values_to_validate One or more values to validate
+  # @return [Nil]
+  # @example Passing validation
+  #
+  #     $iamtrue = true
+  #     validate_bool(true)
+  #     validate_bool("false")
+  #     validate_bool("true")
+  #     validate_bool(true, 'true', false, $iamtrue)
+  #
+  # @example Failing validation
+  #     $some_array = [ true ]
+  #     validate_bool($some_array)
+  #     validate_bool('True')
+  #     validate_bool('TRUE')
+  #
+  dispatch :validate_bool do
+    required_repeated_param 'Variant[String,Boolean]', :values_to_validate
+  end
+
+  def validate_bool(*values_to_validate)
+    valid_entries = [true, false, 'true', 'false']
+    values_to_validate.each do |value|
+      unless valid_entries.include?(value) then
+        fail("simplib::validate_bool: '#{value}' is not a boolean.")
+      end
+    end
+  end
+end

--- a/lib/puppet/functions/simplib/validate_deep_hash.rb
+++ b/lib/puppet/functions/simplib/validate_deep_hash.rb
@@ -1,0 +1,152 @@
+# Perform a deep validation on two passed `Hashes`.
+#
+# All keys must be defined in the reference `Hash` that is being
+# validated against.
+#
+# Unknown keys in the `Hash` being compared will cause a failure in
+# validation
+#
+# All values in the final leaves of the 'reference 'Hash' must
+# be a String, Boolean, or nil.
+#
+# All values in the final leaves of the `Hash` being compared must
+# support a to_s() method.
+Puppet::Functions.create_function(:'simplib::validate_deep_hash') do
+
+  # @param reference Hash to validate against. Keys at all levels of
+  #   the hash define the structure of the hash and the value at each
+  #   final leaf in the hash tree contains a regular expression string,
+  #   a boolean or nil for value validation:
+  #
+  #   * When the validation value is a regular expression string,
+  #     the string representation of the to_check value (from the
+  #     to_s() method) will be compared to the regular expression
+  #     contained in the reference string.
+  #
+  #   * When the validation value is a Boolean, the string
+  #     representation of the to_check value will be compared
+  #     with the string representation of the Boolean (as provided
+  #     by the to_s() method).
+  #
+  #   * When the validation value is a `nil` or 'nil', no value
+  #     validation will be done for the key.
+  #
+  #   * When the to_check value contains an `Array` of values for a
+  #     key, the validation for that key will be applied to each
+  #     element in that array.
+  #
+  # @param to_check Hash to be validated against the reference
+  # @return [Nil]
+  #
+  # @example Passing Examples
+  #   reference = {
+  #     'foo' => {
+  #       'bar' => {
+  #         #NOTE: Use quotes for regular expressions instead of '/'
+  #         'baz' => '^\d+$',
+  #         'abc' => '^\w+$',
+  #         'def' => nil
+  #       },
+  #       'baz' => {
+  #         'qrs' => false
+  #         'xyz' => '^true|false$'
+  #       }
+  #     }
+  #   }
+  #
+  #   to_check = {
+  #     'foo' => {
+  #       'bar' => {
+  #         'baz' => ['123', 45]
+  #         'abc' => [ 'these', 'are', 'words' ],
+  #         'def' => 'Anything will work here!'
+  #       },
+  #       'baz' => {
+  #         'qrs' => false
+  #         'xyz' => true
+  #       }
+  #     }
+  #   }
+  #
+  #   validate_deep_hash(reference, to_check)
+  #
+  # @example Failing Examples
+  #   reference => { 'foo' => '^\d+$' }
+  #   to_check  => { 'foo' => 'abc' }
+  #
+  #   validate_deep_hash(reference, to_check)
+  #
+  dispatch :validate_deep_hash do
+    required_param 'Hash', :reference
+    required_param 'Hash', :to_check
+  end
+
+  def validate_deep_hash(reference, to_check)
+    invalid = deep_validate(reference, to_check)
+
+    if invalid.size > 0 then
+      err_msg = "simplib::validate_deep_hash failed validation:\n  "
+      err_msg += invalid.join("\n  ")
+      fail(err_msg)
+    end
+  end
+
+  def valid_value(value)
+    [String, TrueClass, FalseClass, Numeric, NilClass].each do |allowed_class|
+      return true if value.is_a?(allowed_class)
+    end
+    return false
+  end
+
+  def compare(ref_value, to_check_value)
+    return :invalid_ref_type unless valid_value(ref_value)
+
+    ref_string = ref_value.to_s
+
+    Array(to_check_value).each do |value|
+      return :invalid_check_type unless value.respond_to?(:to_s)
+      return :failed_check unless Regexp.new(ref_string).match(value.to_s)
+    end
+    return :success
+  end
+
+  def deep_validate(reference, to_check, level="TOP", invalid = Array.new)
+    to_check.each do |key,value|
+      if reference.has_key?(key)
+        # skip over keys for which further validation has been disabled
+        next if reference[key].nil? or reference[key] == 'nil'
+
+        # Step down a level if value is another hash
+        if value.is_a?(Hash)
+          if reference[key].is_a?(Hash)
+            ref_key_hash = reference[key]
+            deep_validate(ref_key_hash, value, level+"-->#{key}", invalid)
+          else
+            invalid << level + "-->#{key} should not be a Hash"
+          end
+        # Compare regular expressions since we are at the bottom level
+        # (leaf in the Hash tree)
+        else
+          result = compare(reference[key], to_check[key])
+          case result
+          when :invalid_ref_type
+            err_msg = "simplib::validate_deep_hash(): Check for " +
+              level + "-->#{key} has invalid type '#{reference[key].class}'"
+            raise ArgumentError.new(err_msg)
+
+          when :invalid_check_type
+            invalid << level + "-->#{key} #{to_check[key].class} cannot" +
+              " be converted to string for comparison"
+
+          when :failed_check
+            invalid << level + "-->#{key} '#{to_check[key]}' must" +
+              " validate against '/#{reference[key]}/'"
+          end
+        end
+      else
+        invalid << (level+"-->#{key} not in reference hash")
+      end
+    end
+    return invalid
+  end
+end

--- a/lib/puppet/parser/functions/nets2ddq.rb
+++ b/lib/puppet/parser/functions/nets2ddq.rb
@@ -14,6 +14,8 @@ module Puppet::Parser::Functions
     @return [Variant[Array[String], String]]
     EOM
 
+    function_simplib_deprecation(['nets2ddq', 'nets2ddq is deprecated, please use simplib::nets2ddq'])
+
     require File.expand_path(File.dirname(__FILE__) + '/../../../puppetx/simp/simplib.rb')
 
     networks = Array(args.dup).flatten

--- a/lib/puppet/parser/functions/simplib_deprecation.rb
+++ b/lib/puppet/parser/functions/simplib_deprecation.rb
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
     key = arguments[0]
     message = arguments[1]
 
-    unless ENV['STDLIB_LOG_DEPRECATIONS'] == "false"
+    unless ENV['SIMPLIB_LOG_DEPRECATIONS'] == "false"
       Puppet.deprecation_warning(message, key)
     end
   end

--- a/lib/puppet/parser/functions/validate_array_member.rb
+++ b/lib/puppet/parser/functions/validate_array_member.rb
@@ -17,6 +17,8 @@ module Puppet::Parser::Functions
     @return [Boolean]
     ENDHEREDOC
 
+    function_simplib_deprecation(['validate_array_member', 'validate_array_member is deprecated, please use simplib::validate_array_member'])
+
     unless args.length == 2 or args.length == 3
       raise Puppet::ParseError, ("validate_array_member(): expects two or three arguments. Got '#{args.length}'")
     end

--- a/lib/puppet/parser/functions/validate_between.rb
+++ b/lib/puppet/parser/functions/validate_between.rb
@@ -8,6 +8,9 @@ module Puppet::Parser::Functions
     @return [Boolean]
     ENDHEREDOC
 
+    function_simplib_deprecation(['validate_between', 'validate_between is deprecated, please use simplib::validate_between'])
+
+
     args[0].to_s.between?(args[1].to_s, args[2].to_s)
   end
 

--- a/lib/puppet/parser/functions/validate_bool_simp.rb
+++ b/lib/puppet/parser/functions/validate_bool_simp.rb
@@ -25,6 +25,8 @@ module Puppet::Parser::Functions
     @return [Nil]
     ENDHEREDOC
 
+    function_simplib_deprecation(['validate_bool_simp', 'validate_bool_simp is deprecated, please use simplib::validate_bool'])
+
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_bool(): wrong number of arguments (#{args.length}; must be > 0)")
     end

--- a/lib/puppet/parser/functions/validate_deep_hash.rb
+++ b/lib/puppet/parser/functions/validate_deep_hash.rb
@@ -94,6 +94,8 @@ module Puppet::Parser::Functions
       return invalid
     end
 
+    function_simplib_deprecation(['validate_deep_hash', 'validate_deep_hash is deprecated, please use simplib::validate_deep_hash'])
+
     if args.length != 2 then
       raise Puppet::ParseError, ("validate_deep_hash(): wrong number of arguments (#{args.length}; must be 2)")
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/nets2ddq_spec.rb
+++ b/spec/acceptance/suites/default/nets2ddq_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper_acceptance'
+
+test_name 'nets2ddq function'
+
+describe 'nets2ddq function' do
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when nets2ddq' do
+      let (:manifest) {
+        <<-EOS
+        $var1 = [ '10.0.1.0/24', '10.0.2.0/255.255.255.0', '10.0.3.25', 'myhost' ]
+        $var2 = nets2ddq($var1)
+
+        simplib::inspect('var2')
+        EOS
+      }
+
+      it 'should return a converted array and log a single deprecation warning' do
+        results = apply_manifest_on(server, manifest)
+
+        expected_regex = %r{\["10.0.1.0\/255.255.255.0","10.0.2.0\/255.255.255.0","10.0.3.25","myhost"\]}
+        expect(results.output).to match(expected_regex)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('nets2ddq is deprecated, please use simplib::nets2ddq')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+    end
+
+    context 'when simplib::nets2ddq' do
+      let (:manifest) {
+        <<-EOS
+        $var1 = [ '10.0.1.0/24', '10.0.2.0/255.255.255.0', '10.0.3.25', 'myhost' ]
+        $var2 = simplib::nets2ddq($var1)
+
+        simplib::inspect('var2')
+        EOS
+      }
+
+      it 'should return a converted array without logging a deprecation warning' do
+        results = apply_manifest_on(server, manifest)
+
+        expected_regex = %r{\["10.0.1.0\/255.255.255.0","10.0.2.0\/255.255.255.0","10.0.3.25","myhost"\]}
+        expect(results.output).to match(expected_regex)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('nets2ddq is deprecated, please use simplib::nets2ddq')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/to_integer_spec.rb
+++ b/spec/acceptance/suites/default/to_integer_spec.rb
@@ -16,7 +16,7 @@ describe 'to_integer function' do
         EOS
       }
 
-      it 'should return IP addresses and log a single deprecation warning' do
+      it 'should return an integer and log a single deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
         expect(results.output).to match(/Notice: Type => Fixnum Content => 10/)
@@ -41,7 +41,7 @@ describe 'to_integer function' do
         EOS
       }
 
-      it 'should return IP addresses without logging a deprecation warning' do
+      it 'should return an integer without logging a deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
         expect(results.output).to match(/Notice: Type => Fixnum Content => -1/)

--- a/spec/acceptance/suites/default/to_string_spec.rb
+++ b/spec/acceptance/suites/default/to_string_spec.rb
@@ -16,7 +16,7 @@ describe 'to_string function' do
         EOS
       }
 
-      it 'should return IP addresses and log a single deprecation warning' do
+      it 'should return a string and log a single deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
         expect(results.output).to match(/Notice: Type => String Content => "10"/)
@@ -41,7 +41,7 @@ describe 'to_string function' do
         EOS
       }
 
-      it 'should return IP addresses without logging a deprecation warning' do
+      it 'should return a string without logging a deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
         expect(results.output).to match(/Notice: Type => String Content => "-1"/)

--- a/spec/acceptance/suites/default/validate_array_member_spec.rb
+++ b/spec/acceptance/suites/default/validate_array_member_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper_acceptance'
+
+test_name 'validate_array_member function'
+
+describe 'validate_array_member function' do
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when validate_array_member called' do
+
+      it 'should accept element that is in array' do
+        manifest = <<-EOS
+        $var1 = 'foo'
+        validate_array_member($var1, ['foo', 'FOO'])
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+
+      it 'should reject element that is not in array' do
+        manifest = <<-EOS
+        $var1 = 'foo'
+        validate_array_member($var1, ['bar', 'BAR'])
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+    end
+
+    context 'when simplib::validate_array_member' do
+      it 'should accept element that is in array' do
+        manifest = <<-EOS
+        $var1 = 'foo'
+        simplib::validate_array_member($var1, ['foo', 'FOO'])
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+
+      it 'should reject element that is not in array' do
+        manifest = <<-EOS
+        $var1 = 'foo'
+        simplib::validate_array_member($var1, ['bar', 'BAR'])
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/validate_between_spec.rb
+++ b/spec/acceptance/suites/default/validate_between_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_acceptance'
+
+test_name 'validate_between function'
+
+describe 'validate_between function' do
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when validate_between called' do
+
+      it 'should accept element within range' do
+        manifest = <<-EOS
+        $var1 = 7
+        validate_between($var1, 0, 60)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_between is deprecated, please use simplib::validate_between')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+
+      it 'should allow element outside of range because of bug' do
+        manifest = <<-EOS
+        $var1 = 70
+        validate_between($var1, 0, 60)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [0])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_between is deprecated, please use simplib::validate_between')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+    end
+
+    context 'when simplib::validate_between' do
+      it 'should accept element within range' do
+        manifest = <<-EOS
+        $var1 = 7
+        simplib::validate_between($var1, 0, 60)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_between is deprecated, please use simplib::validate_between')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+
+      # bug in original code...returned false
+      it 'should reject element outside of range' do
+        manifest = <<-EOS
+        $var1 = 70
+        simplib::validate_between($var1, 0, 60)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_between is deprecated, please use simplib::validate_between')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/validate_bool_simp_spec.rb
+++ b/spec/acceptance/suites/default/validate_bool_simp_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper_acceptance'
+
+test_name 'validate_bool function'
+
+describe 'validate_bool_simp function' do
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when validate_bool_simp called' do
+
+      it 'should accept valid bool equivalent' do
+        manifest = <<-EOS
+        $var1 = "true"
+        validate_bool_simp($var1)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+
+      it 'should reject invalid bool equivalent' do
+        manifest = <<-EOS
+        $var1 = "true"
+        validate_bool_simp($var1)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+    end
+
+    context 'when simplib::validate_bool' do
+      it 'should accept valid bool equivalent' do
+        manifest = <<-EOS
+        $var1 = "true"
+        simplib::validate_bool($var1)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+
+      it 'should reject invalid bool equivalent' do
+        manifest = <<-EOS
+        $var1 = "True"
+        simplib::validate_bool($var1)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/validate_deep_hash_spec.rb
+++ b/spec/acceptance/suites/default/validate_deep_hash_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper_acceptance'
+
+test_name 'validate_deep_hash function'
+
+describe 'validate_deep_hash function' do
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when validate_deep_hash called' do
+
+      it 'should accept valid hash' do
+        manifest = <<-EOS
+        $var1 = { 'server' => 'foo.bar.com' }
+        validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+
+      it 'should reject invalid hash' do
+        manifest = <<-EOS
+        $var1 = { 'server' => 'foo.baz.com' }
+        validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
+        end
+
+        expect(deprecation_lines.size).to eq 1
+      end
+    end
+
+    context 'when simplib::validate_deep_hash' do
+      it 'should accept valid hash' do
+        manifest = <<-EOS
+        $var1 = { 'server' => 'foo.bar.com' }
+        simplib::validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
+        EOS
+        results = apply_manifest_on(server, manifest)
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+
+      it 'should reject invalid hash' do
+        manifest = <<-EOS
+        $var1 = { 'server' => 'foo.baz.com' }
+        simplib::validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
+        EOS
+        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+
+        deprecation_lines = results.output.split("\n").delete_if do |line|
+          !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
+        end
+
+        expect(deprecation_lines.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/functions/simplib/nets2cidr_spec.rb
+++ b/spec/functions/simplib/nets2cidr_spec.rb
@@ -40,7 +40,7 @@ describe 'simplib::nets2cidr' do
 
     context 'multiple hostnames/networks/addresses' do
       let(:expected_output) do
-        [ 
+        [
           'myhost-test.local',
           '1.2.3.0/24',
           '2001:db8:85a3::8a2e:370:0/112'

--- a/spec/functions/simplib/nets2ddq_spec.rb
+++ b/spec/functions/simplib/nets2ddq_spec.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::nets2ddq' do
+  context 'should return converted values when conversion is possible' do
+    it 'converts an Array of networks' do
+      input = [
+        '10.0.1.0/24',
+        '10.0.2.0/255.255.255.0',
+        '10.0.3.25',
+        'myhost'
+      ]
+      expected_output = [
+        '10.0.1.0/255.255.255.0',
+        '10.0.2.0/255.255.255.0',
+        '10.0.3.25',
+        'myhost'
+      ]
+  
+      is_expected.to run.with_params(input).and_return(expected_output)
+    end
+
+    it 'converts a String of space-separated networks' do
+      input = '10.0.1.0/24 10.0.2.0/255.255.255.0   10.0.3.25 myhost'
+      expected_output = [
+        '10.0.1.0/255.255.255.0',
+        '10.0.2.0/255.255.255.0',
+        '10.0.3.25',
+        'myhost'
+      ]
+      is_expected.to run.with_params(input).and_return(expected_output)
+    end
+
+    it 'converts a String of comma-separated networks' do
+      input = '10.0.1.0/24,,10.0.2.0/255.255.255.0,10.0.3.25,myhost,'
+      expected_output = [
+        '10.0.1.0/255.255.255.0',
+        '10.0.2.0/255.255.255.0',
+        '10.0.3.25',
+        'myhost'
+      ]
+      is_expected.to run.with_params(input).and_return(expected_output)
+    end
+
+    it 'converts a String of semi-colon-separated networks' do
+      input = ';10.0.1.0/24;10.0.2.0/255.255.255.0;10.0.3.25;myhost'
+      expected_output = [
+        '10.0.1.0/255.255.255.0',
+        '10.0.2.0/255.255.255.0',
+        '10.0.3.25',
+        'myhost'
+      ]
+      is_expected.to run.with_params(input).and_return(expected_output)
+    end
+
+    it 'returns an empty Array when no networks specified' do
+      input_string = '  '
+      expected_output = []
+      is_expected.to run.with_params(input_string).and_return(expected_output)
+
+      input_array = [] 
+      expected_output = []
+      is_expected.to run.with_params(input_array).and_return(expected_output)
+    end
+
+  end
+
+  context 'should fail when conversion is not possible' do
+   it {
+     input = ['myhost', '-bad.']
+     is_expected.to run.with_params(input).and_raise_error(/'-bad.' is not a valid network./)
+   }
+  end
+end

--- a/spec/functions/simplib/nets2ddq_spec.rb
+++ b/spec/functions/simplib/nets2ddq_spec.rb
@@ -16,7 +16,7 @@ describe 'simplib::nets2ddq' do
         '10.0.3.25',
         'myhost'
       ]
-  
+
       is_expected.to run.with_params(input).and_return(expected_output)
     end
 
@@ -58,7 +58,7 @@ describe 'simplib::nets2ddq' do
       expected_output = []
       is_expected.to run.with_params(input_string).and_return(expected_output)
 
-      input_array = [] 
+      input_array = []
       expected_output = []
       is_expected.to run.with_params(input_array).and_return(expected_output)
     end

--- a/spec/functions/simplib/passgen_spec.rb
+++ b/spec/functions/simplib/passgen_spec.rb
@@ -269,35 +269,41 @@ describe 'simplib::passgen' do
           }
         end
 
-        it 'should parse as modular crypt' do
-          result = subject.execute('spectest', shared_options);
-          expect(parse_modular_crypt(result)).to_not eql(nil)
-        end
+        if File.exist?('/proc/sys/crypto/fips_enabled') && 
+            File.open('/proc/sys/crypto/fips_enabled', &:readline)[0].chr == '1' &&
+            hash_selection == 'md5'
+          puts 'Skipping md5, as not available on this FIPS-compliant server'
+        else
+          it 'should parse as modular crypt' do
+            result = subject.execute('spectest', shared_options);
+            expect(parse_modular_crypt(result)).to_not eql(nil)
+          end
 
-        it "should use #{object['code']} as the algorithm code" do
-          value = parse_modular_crypt(subject.execute('spectest', shared_options));
-          expect(value['algorithm_code']).to eql(object['code'])
-        end
+          it "should use #{object['code']} as the algorithm code" do
+            value = parse_modular_crypt(subject.execute('spectest', shared_options));
+            expect(value['algorithm_code']).to eql(object['code'])
+          end
 
-        it 'should contain a salt of complexity 0' do
-          value = parse_modular_crypt(subject.execute('spectest', shared_options));
-          expect(value['salt']).to match(/^(#{default_chars.join('|')})+$/)
-        end
+          it 'should contain a salt of complexity 0' do
+            value = parse_modular_crypt(subject.execute('spectest', shared_options));
+            expect(value['salt']).to match(/^(#{default_chars.join('|')})+$/)
+          end
 
-        it 'should contain a base64 hash' do
-          value = parse_modular_crypt(subject.execute('spectest', shared_options));
-          expect(value['hash_base64']).to match(/#{base64_regex}/)
-        end
+          it 'should contain a base64 hash' do
+            value = parse_modular_crypt(subject.execute('spectest', shared_options));
+            expect(value['hash_base64']).to match(/#{base64_regex}/)
+          end
 
-        it "should contain a valid #{hash_selection} hash after decoding" do
-          result = subject.execute('spectest', shared_options);
-          value = parse_modular_crypt(result);
-          expect(value['hash_bitlength']).to eql(object['bits'])
-        end
+          it "should contain a valid #{hash_selection} hash after decoding" do
+            result = subject.execute('spectest', shared_options);
+            value = parse_modular_crypt(result);
+            expect(value['hash_bitlength']).to eql(object['bits'])
+          end
 
-        it "should return exactly #{object['end_hash']} when salt and password are specified" do
-          result = subject.execute('spectest',specific_options)
-          expect(result).to eql(object['end_hash'])
+          it "should return exactly #{object['end_hash']} when salt and password are specified" do
+            result = subject.execute('spectest',specific_options)
+            expect(result).to eql(object['end_hash'])
+          end
         end
       end
     end

--- a/spec/functions/simplib/validate_array_member_spec.rb
+++ b/spec/functions/simplib/validate_array_member_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'simplib::validate_array_member' do
+  context 'with single input' do
+    describe 'validates input contained in array' do
+      it { is_expected.to run.with_params('foo',['foo','bar']) }
+      it { is_expected.to run.with_params(1, [1, 2]) }
+      it { is_expected.to run.with_params(true, [true, false, 'yes', 'no']) }
+      it { is_expected.to run.with_params('foo',['FOO','BAR'],'i') }
+    end
+
+    describe 'rejects input not contained in array' do
+      it do
+        is_expected.to run.with_params('foo',['FOO','BAR']).and_raise_error(
+         /'\["FOO", "BAR"\]' does not contain 'foo'/ )
+      end
+
+      it do
+        is_expected.to run.with_params(1, [2, 3]).and_raise_error(
+         /'\[2, 3\]' does not contain '1'/ )
+      end
+
+      it do
+        is_expected.to run.with_params(true, ['yes', 'no']).and_raise_error(
+         /'\["yes", "no"\]' does not contain 'true'/ )
+      end
+    end
+  end
+
+  context 'with array input' do
+    describe 'validates input contained in array' do
+      it { is_expected.to run.with_params(['foo', 'baz'],['foo', 'bar', 'baz']) }
+      it { is_expected.to run.with_params([3, 2], [1, 2, 3]) }
+      it { is_expected.to run.with_params([true, 'yes'], [true, false, 'yes', 'no']) }
+      it { is_expected.to run.with_params(['foo', 'baz'],['FOO', 'BAR', 'BAZ'], 'i') }
+    end
+
+    describe 'rejects input not contained in array' do
+      it do
+        is_expected.to run.with_params(['foo', 'baz'],['FOO', 'BAR', 'BAZ'],).and_raise_error(
+         /'\["FOO", "BAR", "BAZ"\]' does not contain '\["foo", "baz"\]'/ )
+      end
+
+      it do
+        is_expected.to run.with_params([2, 4], [2, 3]).and_raise_error(
+         /'\[2, 3\]' does not contain '\[2, 4\]'/ )
+      end
+
+      it do
+        is_expected.to run.with_params([true, false], ['yes', 'no']).and_raise_error(
+         /'\["yes", "no"\]' does not contain '\[true, false\]'/ )
+      end
+    end
+  end
+end

--- a/spec/functions/simplib/validate_between_spec.rb
+++ b/spec/functions/simplib/validate_between_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'simplib::validate_between' do
+  context 'validates input contained in range' do
+    it { is_expected.to run.with_params('-1',-3, 0) }
+    it { is_expected.to run.with_params(7, 0, 60) }
+    it { is_expected.to run.with_params(7.6, 7.1, 8.4) }
+  end
+
+  context 'rejects input not contained in range' do
+    it do
+      is_expected.to run.with_params('-1', 0, 3).and_raise_error(
+       /'-1' is not between '0' and '3'/ )
+    end
+
+    it do
+      is_expected.to run.with_params(0, 1, 60).and_raise_error(
+       /'0' is not between '1' and '60'/ )
+    end
+
+    it do
+      is_expected.to run.with_params(7.6, 7.7, 8.4).and_raise_error(
+       /'7.6' is not between '7.7' and '8.4'/ )
+    end
+  end
+end

--- a/spec/functions/simplib/validate_bool.rb
+++ b/spec/functions/simplib/validate_bool.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'simplib::validate_bool' do
+  context 'with single input' do
+    describe 'accepts valid input' do
+      it { is_expected.to run.with_params(true) }
+      it { is_expected.to run.with_params('true') }
+      it { is_expected.to run.with_params(false) }
+      it { is_expected.to run.with_params('false') }
+    end
+
+    describe 'rejects invalid input' do
+      it do
+        is_expected.to run.with_params('True').and_raise_error(
+         /'True' is not a boolean/ )
+      end
+
+      it do
+        is_expected.to run.with_params('FALSE').and_raise_error(
+         /'FALSE' is not a boolean/ )
+      end
+    end
+  end
+
+  context 'with multiple inputs' do
+    describe 'accepts valid input' do
+      it { is_expected.to run.with_params(true, 'true', false, 'false') }
+    end
+
+    describe 'rejects invalid input' do
+      it do
+        is_expected.to run.with_params(true, 'TRUE', false, 'false').and_raise_error(
+         /'TRUE' is not a boolean/ )
+      end
+    end
+  end
+end

--- a/spec/functions/simplib/validate_deep_hash_spec.rb
+++ b/spec/functions/simplib/validate_deep_hash_spec.rb
@@ -1,0 +1,230 @@
+require 'spec_helper'
+
+describe 'simplib::validate_deep_hash' do
+
+  context 'with valid 1-level input' do
+   let(:ref_hash) do
+     {
+        'string_value'        => '^\w+$',
+        'boolean_true_value'  => '^true|false$',
+        'boolean_false_value' => '^true|false$',
+        'numeric_value_1'     => '^\d+$',
+        'numeric_value_2'     => '^\d+\.\d+$',
+        'unused_key'          => '^\w+$'
+      }
+    end
+
+    let(:test_hash) do
+      {
+        'string_value'        => 'value',
+        'boolean_true_value'  => true,
+        'boolean_false_value' => false,
+        'numeric_value_1'     => 23,
+        'numeric_value_2'     => '4.56'
+      }
+    end
+
+    it 'validates input containing exact matches of allowed ref types' do
+      is_expected.to run.with_params(test_hash, test_hash)
+    end
+
+    it 'validates input containing regex matches of allowed ref types' do
+      is_expected.to run.with_params(ref_hash, test_hash)
+    end
+
+    it 'validates input containing arrays' do
+      test_hash_with_array = test_hash.dup
+     test_hash_with_array['numeric_value_1'] = [1, 2, 34]
+      is_expected.to run.with_params(ref_hash, test_hash_with_array)
+    end
+
+    it "skips validation of elements specified by nil or 'nil'" do
+      ref_hash_with_nil = ref_hash.dup
+      ref_hash_with_nil['string_value'] = nil
+      ref_hash_with_nil['numeric_value_1'] = 'nil'
+      is_expected.to run.with_params(ref_hash_with_nil, test_hash)
+    end
+  end
+
+  context 'valid multi-level input' do
+    let(:ref_hash) do
+      {
+        'level1' =>  {
+          'string_value_1' => '^\w+$',
+          'level2' => {
+            'level3' => {
+              'boolean_true_value' => '^true|false$',
+              'level4' => {
+                'boolean_false_value' => '^true|false$',
+              },
+              'numeric_value_1'=> '^\d+$',
+            },
+            'numeric_value_2' => '^\d+\.\d+$'
+          }
+        },
+        'string_value_2' => 'value'
+      }
+    end
+
+    let(:test_hash) do
+      {
+        'level1' =>  {
+          'string_value_1' => 'value1',
+          'level2' => {
+            'level3' => {
+              'boolean_true_value'  => true,
+              'level4' => {
+                'boolean_false_value' => false,
+              },
+              'numeric_value_1'     => '23'
+            },
+            'numeric_value_2'     => 4.56
+          }
+        },
+        'string_value_2' => 'string value 2'
+      }
+    end
+
+    it 'validates input containing exact matches of allowed ref types' do
+      is_expected.to run.with_params(test_hash, test_hash)
+    end
+
+    it 'validates input containing regex matches of allowed ref types' do
+      is_expected.to run.with_params(ref_hash, test_hash)
+    end
+
+    it 'validates input containing arrays' do
+      test_hash_with_array = test_hash.dup
+      test_hash_with_array['level1']['string_value_1'] = ['one', 'two', 'three']
+      is_expected.to run.with_params(ref_hash, test_hash_with_array)
+    end
+
+    it "skips validation of elements specified by nil or 'nil'" do
+      ref_hash_with_nil = ref_hash.dup
+      ref_hash_with_nil['level1']['level2']['level3']['level4']['boolean_false_value'] = nil
+      ref_hash_with_nil['level1']['level2']['numeric_value_2'] = 'nil'
+      is_expected.to run.with_params(ref_hash_with_nil, test_hash)
+    end
+  end
+
+  context 'with invalid 1-layer input' do
+    let(:ref_hash) do
+      {
+        'string_value'  => '^\w+$',
+        'boolean_value' => '^true|false$',
+        'numeric_value' => '^\d+\.\d+$'
+       }
+    end
+
+    let(:test_hash) do
+      {
+        'string_value'  => 'value',
+        'boolean_value' => true,
+        'numeric_value' => 4.56
+      }
+    end
+
+    it 'rejects ref values with invalid class types' do
+      invalid_ref_hash = ref_hash.dup
+      invalid_ref_hash['string_value'] = ['a', 'bad', 'ref', 'value']
+      is_expected.to run.with_params(invalid_ref_hash, test_hash).and_raise_error(
+        /Check for TOP-->string_value has invalid type 'Array'/ )
+    end
+
+    it 'rejects input having keys not found in reference hash' do
+      input_extra_key = test_hash.dup
+      input_extra_key['extra_key'] = 'extra value'
+      err_msg = "simplib::validate_deep_hash failed validation:\n" + 
+        "  TOP-->extra_key not in reference hash"
+      is_expected.to run.with_params(ref_hash, input_extra_key).and_raise_error(
+        err_msg)
+    end
+
+    it 'rejects input not matching reference and reports all failures' do
+      invalid_input = test_hash.dup
+      invalid_input['string_value'] = 1
+      invalid_input['boolean_value'] = 'TRUE'
+      invalid_input['numeric_value'] = 'infinity'
+      err_msg = "simplib::validate_deep_hash failed validation:\n" +
+        "  TOP-->boolean_value 'TRUE' must validate against '/^true|false$/'\n" +
+        "  TOP-->numeric_value 'infinity' must validate against '/^\\d+\\.\\d+$/'"
+
+      is_expected.to run.with_params(ref_hash, invalid_input).and_raise_error(
+        err_msg )
+    end
+  end
+
+  context 'invalid multi-level input' do
+    let(:ref_hash) do
+      {
+        'level1' =>  {
+          'string_value_1' => '^\w+$',
+          'level2' => {
+            'level3' => {
+              'boolean_true_value' => '^true|false$',
+              'level4' => {
+                'boolean_false_value' => '^true|false$',
+              },
+              'numeric_value_1'=> '^\d+$',
+            },
+            'numeric_value_2' => '^\d+\.\d+$'
+          }
+        },
+        'string_value_2' => 'value'
+      }
+    end
+
+    let(:test_hash) do
+      {
+        'level1' =>  {
+          'string_value_1' => 'value1',
+          'level2' => {
+            'level3' => {
+              'boolean_true_value'  => true,
+              'level4' => {
+                'boolean_false_value' => false,
+              },
+              'numeric_value_1'     => '23'
+            },
+            'numeric_value_2'     => 4.56
+          }
+        },
+        'string_value_2' => 'string value 2'
+      }
+    end
+
+    it 'rejects ref values with invalid class types' do
+      invalid_ref_hash = ref_hash.dup
+      invalid_ref_hash['level1']['string_value_1'] = ['a', 'bad', 'ref', 'value']
+      is_expected.to run.with_params(invalid_ref_hash, test_hash).and_raise_error(
+        /Check for TOP-->level1-->string_value_1 has invalid type 'Array'/ )
+    end
+
+    it 'rejects input having keys not found in reference hash' do
+      input_extra_key = test_hash.dup
+      input_extra_key['level1']['level2']['extra_key'] = 'extra value'
+      err_msg = "simplib::validate_deep_hash failed validation:\n" + 
+        "  TOP-->level1-->level2-->extra_key not in reference hash"
+      is_expected.to run.with_params(ref_hash, input_extra_key).and_raise_error(
+        err_msg)
+    end
+
+    it 'rejects input not matching reference and reports all failures' do
+      invalid_input = test_hash.dup
+      invalid_input['level1']['string_value_1'] = {'unexpected' => 'hash'}
+      invalid_input['level1']['level2']['numeric_value_2'] = 'not a numeric'
+      invalid_input['level1']['level2']['level3']['boolean_true_value'] = 'TRUE'
+      invalid_input['level1']['level2']['level3']['level4']['boolean_false_value'] = 'FALSE'
+
+      err_msg = "simplib::validate_deep_hash failed validation:\n" +
+        "  TOP-->level1-->string_value_1 should not be a Hash\n" +
+        "  TOP-->level1-->level2-->level3-->boolean_true_value 'TRUE' must validate against '/^true|false$/'\n" +
+        "  TOP-->level1-->level2-->level3-->level4-->boolean_false_value 'FALSE' must validate against '/^true|false$/'\n" +
+        "  TOP-->level1-->level2-->numeric_value_2 'not a numeric' must validate against '/^\\d+\\.\\d+$/'"
+
+      is_expected.to run.with_params(ref_hash, invalid_input).and_raise_error(
+        err_msg )
+    end
+  end
+
+end

--- a/spec/functions/simplib/validate_deep_hash_spec.rb
+++ b/spec/functions/simplib/validate_deep_hash_spec.rb
@@ -134,7 +134,7 @@ describe 'simplib::validate_deep_hash' do
     it 'rejects input having keys not found in reference hash' do
       input_extra_key = test_hash.dup
       input_extra_key['extra_key'] = 'extra value'
-      err_msg = "simplib::validate_deep_hash failed validation:\n" + 
+      err_msg = "simplib::validate_deep_hash failed validation:\n" +
         "  TOP-->extra_key not in reference hash"
       is_expected.to run.with_params(ref_hash, input_extra_key).and_raise_error(
         err_msg)
@@ -203,7 +203,7 @@ describe 'simplib::validate_deep_hash' do
     it 'rejects input having keys not found in reference hash' do
       input_extra_key = test_hash.dup
       input_extra_key['level1']['level2']['extra_key'] = 'extra value'
-      err_msg = "simplib::validate_deep_hash failed validation:\n" + 
+      err_msg = "simplib::validate_deep_hash failed validation:\n" +
         "  TOP-->level1-->level2-->extra_key not in reference hash"
       is_expected.to run.with_params(ref_hash, input_extra_key).and_raise_error(
         err_msg)


### PR DESCRIPTION
- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
  simplib deprecation warning when the Puppet 3 versions as called:
  - simplib::nets2ddq() replaces deprecated nets2ddq().
  - simplib::validate_array_member() replaces deprecated
    validate_array_member().
  - simplib::validate_between() replaces deprecated validate_between().
    The new version fails validation, instead of returning false.
    This behavior consistent with both how the method is used by SIMP
    modules and the error behavior of all other simplib validate
    functions.
  - simplib::validate_bool() replaces deprecated validate_bool_simp().
  - simplib::validate_deep_hash replaced validate_deep_hash.
- In simplib::validate_deep_hash, fixed validate_deep_hash bug in
  which unknown keys in the Hash to check were not detected.

SIMP-3358 #comment 5 more functions converted
SIMP-3904 #close
SIMP-3905 #close
SIMP-3906 #close
SIMP-3907 #close
SIMP-3908 #close