### PR TITLE
(SIMP-3910) Create MAC address type and test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 25 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
+- Deprecate Puppet 3 validate_macaddresses()
+- Add Simplib::Macaddress custom type to replace validate_macaddresses()
+
 * Tue Sep 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.6.0-0
 - Convert all 'sysctl' 'kernel.shm*' entries to Strings
   - shmall and shmmax were causing Facter and newer versions of Puppet to crash

--- a/lib/puppet/parser/functions/validate_macaddress.rb
+++ b/lib/puppet/parser/functions/validate_macaddress.rb
@@ -13,6 +13,8 @@ module Puppet::Parser::Functions
     @return [Nil]
     ENDHEREDOC
 
+    function_simplib_deprecation(['validate_macaddresses', 'validate_macaddresses is deprecated, please use the Simplib::Macaddress custom type'])
+
     unless args.length > 0 then
       raise Puppet::ParseError, ("validate_macaddress(): wrong number of arguments (#{args.length}; must be > 0)")
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/type_aliases/simplib_macddress_spec.rb
+++ b/spec/type_aliases/simplib_macddress_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'Simplib::Macaddress' do
+  context 'with valid MAC addresses' do
+    it { is_expected.to allow_value('CA:FE:BE:EF:00:11') }
+    it { is_expected.to allow_value('ca:fe:be:ef:00:11') }
+    it { is_expected.to allow_value('12:34:56:78:90:11') }
+    it { is_expected.to allow_value('Ca:fE:0e:F1:00:11') }
+    it { is_expected.to allow_value('0:1:2:3:4:5') }
+    it { is_expected.to allow_value('A0:B:2C:D:E4:F') }
+  end
+
+  context 'with invalid MAC addresses' do
+    it { is_expected.not_to allow_value('CA:FE:BE:EF:00:') }
+    it { is_expected.not_to allow_value('CA:FE:BE:EF::11') }
+    it { is_expected.not_to allow_value('OO:PS:NO:TH:EX:11') }
+  end
+end

--- a/types/macaddress.pp
+++ b/types/macaddress.pp
@@ -1,0 +1,2 @@
+# Matches MAC addresses
+type Simplib::Macaddress = Pattern['^[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}$']

--- a/types/macaddress.pp
+++ b/types/macaddress.pp
@@ -1,2 +1,2 @@
 # Matches MAC addresses
-type Simplib::Macaddress = Pattern['^[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}:[0-9,a-f,A-F]{1,2}$']
+type Simplib::Macaddress = Pattern['^[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}$']


### PR DESCRIPTION
* Create Simplib::Macaddress custom type
* Add deprecation notice to validate_macaddress() that references
  Simplib::Macaddress as its replacement
* Write unit test

SIMP-3910 #close