### PR TITLE
(SIMP-4015) Fix failure on tmp_mount fact on RHEL5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,3 @@
-* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.2-0
-- Fixes split failure when "findmnt" does not exist on Linux
 * Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
 - Fixes split failure when "findmnt" does not exist on Linux
 * Thu Oct 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Mon Nov 6 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
+- Fixes split failure when "findmnt" does not exist on Linux
 * Thu Oct 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Add Simplib::Macaddress data type
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Mon Nov 6 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
+* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.2-0
+- Fixes split failure when "findmnt" does not exist on Linux
+* Mon Nov 06 2017 Jason Balicki <sakodak@gmail.com> - 3.7.1-0
 - Fixes split failure when "findmnt" does not exist on Linux
 * Thu Oct 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.7.0-0
 - Add Simplib::Macaddress data type

--- a/lib/facter/tmp_mounts.rb
+++ b/lib/facter/tmp_mounts.rb
@@ -49,7 +49,7 @@ mount_list.keys.each do |mnt|
   findmnt_output = Facter::Util::Resolution.exec("findmnt #{mnt}")
   # on RHEL 5 the command "findmnt" doesn't exist, if it doesn't exist
   # then we just want to ignore this since there's nothing to do
-  if findmnt_output != nil
+  if findmnt_output
     mnt_source = findmnt_output.split("\n").last.split(/\s+/)[1]
 
     # We're a bind mount if this happens

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.7.2",
+  "version": "3.7.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
The "findmnt" command does not exist on RHEL5 (and is not
available, afaict) and this causes an error:

undefined method `split' for nil:NilClass

in tmp_mounts.rb.  The fix I chose to implement just
skips the code block if "findmnt" returns no output.

SIMP-4015 #close