### PR TITLE
(SIMP-4067) simplib: Disable simplib deprecation warnings by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Nov 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.8.0-0
+- Disable simplib deprecation warnings by default
+
 * Mon Nov 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 3.8.0-0
 - Convert a subset of Puppet 3 functions to Puppet 4 and emit a
   simplib deprecation warning when the Puppet 3 versions are called:

--- a/lib/puppet/functions/simplib/deprecation.rb
+++ b/lib/puppet/functions/simplib/deprecation.rb
@@ -1,8 +1,8 @@
 # Function to print deprecation warnings, logging a warning once
 # for a given key.
 #
-# Messages can be suppressed if the SIMPLIB_LOG_DEPRECATIONS
-# environment is set to 'false'
+# Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
+# environment variable is set to 'true'
 #
 Puppet::Functions.create_function(:'simplib::deprecation') do
 
@@ -23,7 +23,7 @@ Puppet::Functions.create_function(:'simplib::deprecation') do
       message = "#{message} at #{file}:#{line}"
     end
 
-    unless ENV['SIMPLIB_LOG_DEPRECATIONS'] == 'false'
+    if ENV['SIMPLIB_LOG_DEPRECATIONS'] == 'true'
       Puppet.deprecation_warning(message, key)
     end
   end

--- a/lib/puppet/functions/simplib/join_mount_opts.rb
+++ b/lib/puppet/functions/simplib/join_mount_opts.rb
@@ -7,7 +7,7 @@ Puppet::Functions.create_function(:'simplib::join_mount_opts') do
   #   `system_opts` when there are conflicts
   # @return [String] Merged options string in which `new_opts`
   #   mount options take precedence; options are comma delimited
-  # 
+  #
   dispatch :join_mount_opts do
     required_param 'Array[String]', :system_mount_opts
     required_param 'Array[String]', :new_mount_opts

--- a/lib/puppet/functions/simplib/validate_array_member.rb
+++ b/lib/puppet/functions/simplib/validate_array_member.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:'simplib::validate_array_member') do
   #   supported modifier.
   # @return [Nil]
   # @raise RuntimeError if validation fails
-  #   
+  #
   # @example Validating single input
   #
   #   validate_array_member('foo',['foo','bar'])     # succeeds

--- a/lib/puppet/functions/simplib/validate_between.rb
+++ b/lib/puppet/functions/simplib/validate_between.rb
@@ -26,9 +26,9 @@ Puppet::Functions.create_function(:'simplib::validate_between') do
   def validate_between(value, min_value, max_value)
     numeric_value = value.to_f
     unless numeric_value >= min_value and numeric_value <= max_value
-      # The original method was used in SIMP modules as if it raised an 
+      # The original method was used in SIMP modules as if it raised an
       # exception, so this implementation will work as expected.
-      err_msg = "simplib::validate_between: '#{value}' is not between" + 
+      err_msg = "simplib::validate_between: '#{value}' is not between" +
         " '#{min_value}' and '#{max_value}'"
       fail(err_msg)
     end

--- a/lib/puppet/parser/functions/simplib_deprecation.rb
+++ b/lib/puppet/parser/functions/simplib_deprecation.rb
@@ -3,8 +3,8 @@ module Puppet::Parser::Functions
     Function to print deprecation warnings for 3.X functions.
     The first argument is the uniqueness key, which allows deduping of messages.
     The second argument is the message to be printed.
-    Messages can be suppressed if the SIMPLIB_LOG_DEPRECATIONS environment
-    variable is set to 'false'.
+    Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS environment
+    variable is set to 'true'.
     @return [Nil]
 
     @example
@@ -18,7 +18,7 @@ module Puppet::Parser::Functions
     key = arguments[0]
     message = arguments[1]
 
-    unless ENV['SIMPLIB_LOG_DEPRECATIONS'] == "false"
+    if ENV['SIMPLIB_LOG_DEPRECATIONS'] == "true"
       Puppet.deprecation_warning(message, key)
     end
   end

--- a/spec/acceptance/suites/default/inspect_spec.rb
+++ b/spec/acceptance/suites/default/inspect_spec.rb
@@ -27,6 +27,10 @@ def normalize(puppet_log)
 end
 
 describe 'inspect function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "logs variables with deprecated inspect" do
@@ -45,7 +49,7 @@ describe 'inspect function' do
       }
 
       it 'should be able to log variables with a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expected = %r|Warning: inspect is deprecated, please use simplib::inspect
 \s+\(at /etc/puppetlabs/code/environments/production/modules/simplib/lib/puppet/parser/functions/simplib_deprecation\.rb:\d+:in `block in <module:Functions>'\)
@@ -80,7 +84,7 @@ Warning: Inspect: Type => 'String' Content => '""'|
       }
 
       it 'should be log variables without any deprecation warnings' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         output = results.output
 

--- a/spec/acceptance/suites/default/ipaddresses_spec.rb
+++ b/spec/acceptance/suites/default/ipaddresses_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'ipaddresses function'
 
 describe 'ipaddresses function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when ipaddresses called with/without arguments" do
@@ -17,7 +21,7 @@ describe 'ipaddresses function' do
       }
 
       it 'should return IP addresses and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         all_ips_regex = %r{\["10.*","10.*","127.0.0.1"\]}
         expect(results.output).to match(all_ips_regex)
@@ -45,7 +49,7 @@ describe 'ipaddresses function' do
       }
 
       it 'should return IP addresses without logging a deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         # exact IP parsing already done in unit test
         all_ips_regex = %r{\["10.*","10.*","127.0.0.1"\]}

--- a/spec/acceptance/suites/default/nets2ddq_spec.rb
+++ b/spec/acceptance/suites/default/nets2ddq_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'nets2ddq function'
 
 describe 'nets2ddq function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context 'when nets2ddq' do
@@ -16,7 +20,7 @@ describe 'nets2ddq function' do
       }
 
       it 'should return a converted array and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expected_regex = %r{\["10.0.1.0\/255.255.255.0","10.0.2.0\/255.255.255.0","10.0.3.25","myhost"\]}
         expect(results.output).to match(expected_regex)
@@ -40,7 +44,7 @@ describe 'nets2ddq function' do
       }
 
       it 'should return a converted array without logging a deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expected_regex = %r{\["10.0.1.0\/255.255.255.0","10.0.2.0\/255.255.255.0","10.0.3.25","myhost"\]}
         expect(results.output).to match(expected_regex)

--- a/spec/acceptance/suites/default/parse_hosts_spec.rb
+++ b/spec/acceptance/suites/default/parse_hosts_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'parse_hosts function'
 
 describe 'parse_hosts function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when parse_hosts called" do
@@ -15,7 +19,7 @@ describe 'parse_hosts function' do
       }
 
       it 'should tranform the host list and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expected_content = %q({"1.2.3.4":{"ports":\["443"\],"protocols":{"https":\["443"\]}}})
         expect(results.output).to match(
@@ -40,7 +44,7 @@ describe 'parse_hosts function' do
       }
 
       it 'should transform the host list without logging a deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expected_content = %q({"my.example.net":{"ports":\["700","900"\],"protocols":{}}})
         expect(results.output).to match(

--- a/spec/acceptance/suites/default/passgen_spec.rb
+++ b/spec/acceptance/suites/default/passgen_spec.rb
@@ -8,6 +8,7 @@ else
 end
 
 describe 'passgen function' do
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     hash_algorithms.each do |hash|

--- a/spec/acceptance/suites/default/strip_ports_spec.rb
+++ b/spec/acceptance/suites/default/strip_ports_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'strip_ports function'
 
 describe 'strip_ports function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when strip_ports called" do
@@ -15,7 +19,7 @@ describe 'strip_ports function' do
       }
 
       it 'should tranform the host list and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expect(results.output).to match(
           %r(Notice: Type => Array Content => \["1.2.3.4"\])
@@ -39,7 +43,7 @@ describe 'strip_ports function' do
       }
 
       it 'should transform the host list without logging a deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expect(results.output).to match(
           %r(Notice: Type => Array Content => \["my.example.net"\])

--- a/spec/acceptance/suites/default/to_integer_spec.rb
+++ b/spec/acceptance/suites/default/to_integer_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'to_integer function'
 
 describe 'to_integer function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when to_integer called" do
@@ -17,7 +21,7 @@ describe 'to_integer function' do
       }
 
       it 'should return an integer and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expect(results.output).to match(/Notice: Type => Fixnum Content => 10/)
         expect(results.output).to match(/Notice: Type => Fixnum Content => 2345/)

--- a/spec/acceptance/suites/default/to_string_spec.rb
+++ b/spec/acceptance/suites/default/to_string_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper_acceptance'
 test_name 'to_string function'
 
 describe 'to_string function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when to_string called" do
@@ -17,7 +21,7 @@ describe 'to_string function' do
       }
 
       it 'should return a string and log a single deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expect(results.output).to match(/Notice: Type => String Content => "10"/)
         expect(results.output).to match(/Notice: Type => NilClass Content => null/)
@@ -42,7 +46,7 @@ describe 'to_string function' do
       }
 
       it 'should return a string without logging a deprecation warning' do
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         expect(results.output).to match(/Notice: Type => String Content => "-1"/)
         expect(results.output).to match(/Notice: Type => NilClass Content => null/)

--- a/spec/acceptance/suites/default/validate_array_member_spec.rb
+++ b/spec/acceptance/suites/default/validate_array_member_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_array_member function'
 
 describe 'validate_array_member function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context 'when validate_array_member called' do
@@ -12,7 +23,7 @@ describe 'validate_array_member function' do
         $var1 = 'foo'
         validate_array_member($var1, ['foo', 'FOO'])
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
@@ -26,7 +37,7 @@ describe 'validate_array_member function' do
         $var1 = 'foo'
         validate_array_member($var1, ['bar', 'BAR'])
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
@@ -42,7 +53,7 @@ describe 'validate_array_member function' do
         $var1 = 'foo'
         simplib::validate_array_member($var1, ['foo', 'FOO'])
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')
@@ -56,7 +67,7 @@ describe 'validate_array_member function' do
         $var1 = 'foo'
         simplib::validate_array_member($var1, ['bar', 'BAR'])
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_array_member is deprecated, please use simplib::validate_array_member')

--- a/spec/acceptance/suites/default/validate_between_spec.rb
+++ b/spec/acceptance/suites/default/validate_between_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_between function'
 
 describe 'validate_between function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context 'when validate_between called' do
@@ -12,7 +23,7 @@ describe 'validate_between function' do
         $var1 = 7
         validate_between($var1, 0, 60)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_between is deprecated, please use simplib::validate_between')
@@ -26,7 +37,7 @@ describe 'validate_between function' do
         $var1 = 70
         validate_between($var1, 0, 60)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [0])
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_between is deprecated, please use simplib::validate_between')
@@ -42,7 +53,7 @@ describe 'validate_between function' do
         $var1 = 7
         simplib::validate_between($var1, 0, 60)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_between is deprecated, please use simplib::validate_between')
@@ -57,7 +68,7 @@ describe 'validate_between function' do
         $var1 = 70
         simplib::validate_between($var1, 0, 60)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_between is deprecated, please use simplib::validate_between')

--- a/spec/acceptance/suites/default/validate_bool_simp_spec.rb
+++ b/spec/acceptance/suites/default/validate_bool_simp_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_bool function'
 
 describe 'validate_bool_simp function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context 'when validate_bool_simp called' do
@@ -12,7 +23,7 @@ describe 'validate_bool_simp function' do
         $var1 = "true"
         validate_bool_simp($var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
@@ -26,7 +37,7 @@ describe 'validate_bool_simp function' do
         $var1 = "true"
         validate_bool_simp($var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
@@ -42,7 +53,7 @@ describe 'validate_bool_simp function' do
         $var1 = "true"
         simplib::validate_bool($var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')
@@ -56,7 +67,7 @@ describe 'validate_bool_simp function' do
         $var1 = "True"
         simplib::validate_bool($var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_bool_simp is deprecated, please use simplib::validate_bool')

--- a/spec/acceptance/suites/default/validate_deep_hash_spec.rb
+++ b/spec/acceptance/suites/default/validate_deep_hash_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_deep_hash function'
 
 describe 'validate_deep_hash function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context 'when validate_deep_hash called' do
@@ -12,7 +23,7 @@ describe 'validate_deep_hash function' do
         $var1 = { 'server' => 'foo.bar.com' }
         validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
@@ -26,7 +37,7 @@ describe 'validate_deep_hash function' do
         $var1 = { 'server' => 'foo.baz.com' }
         validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
@@ -42,7 +53,7 @@ describe 'validate_deep_hash function' do
         $var1 = { 'server' => 'foo.bar.com' }
         simplib::validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')
@@ -56,7 +67,7 @@ describe 'validate_deep_hash function' do
         $var1 = { 'server' => 'foo.baz.com' }
         simplib::validate_deep_hash({ 'server' => 'bar.com$' }, $var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_deep_hash is deprecated, please use simplib::validate_deep_hash')

--- a/spec/acceptance/suites/default/validate_net_list_spec.rb
+++ b/spec/acceptance/suites/default/validate_net_list_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_net_list function'
 
 describe 'validate_net_list function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when validate_net_list called" do
@@ -12,7 +23,7 @@ describe 'validate_net_list function' do
         $var1 = ['10.10.10.0/24','1.2.3.4','1.3.4.5:400']
         validate_net_list($var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_net_list is deprecated, please use simplib::validate_net_list')
@@ -26,7 +37,7 @@ describe 'validate_net_list function' do
         $var1 = '10.10.10.0/24,1.2.3.4'
         validate_net_list($var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_net_list is deprecated, please use simplib::validate_net_list')
@@ -42,7 +53,7 @@ describe 'validate_net_list function' do
         $var1 = ['20.20.20.0/24','4.3.2.1','6.4.3.1:800']
         simplib::validate_net_list($var1)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_net_list is deprecated, please use simplib::validate_net_list')
@@ -56,7 +67,7 @@ describe 'validate_net_list function' do
         $var1 = 'bad stuff'
         simplib::validate_net_list($var1)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_net_list is deprecated, please use simplib::validate_net_list')

--- a/spec/acceptance/suites/default/validate_port_spec.rb
+++ b/spec/acceptance/suites/default/validate_port_spec.rb
@@ -3,7 +3,18 @@ require 'spec_helper_acceptance'
 test_name 'validate_port function'
 
 describe 'validate_port function' do
-  servers = hosts_with_role(hosts, 'server')
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
+ servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when validate_port called" do
 
@@ -11,7 +22,7 @@ describe 'validate_port function' do
         manifest = <<-EOS
         $var1 = validate_port(10)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_port is deprecated, please use simplib::validate_port')
@@ -24,7 +35,7 @@ describe 'validate_port function' do
         manifest = <<-EOS
         $var1 = validate_port(0)
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_port is deprecated, please use simplib::validate_port')
@@ -39,7 +50,7 @@ describe 'validate_port function' do
         manifest = <<-EOS
         $var1 = simplib::validate_port(20)
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_port is deprecated, please use simplib::validate_port')
@@ -52,7 +63,7 @@ describe 'validate_port function' do
         manifest = <<-EOS
         $var1 = simplib::validate_port('65535')
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_port is deprecated, please use simplib::validate_port')

--- a/spec/acceptance/suites/default/validate_uri_list_spec.rb
+++ b/spec/acceptance/suites/default/validate_uri_list_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper_acceptance'
 test_name 'validate_uri_list function'
 
 describe 'validate_uri_list function' do
+  let(:opts) do
+    {:environment=> {'SIMPLIB_LOG_DEPRECATIONS' => 'true'}}
+  end
+
+  let(:opts_with_exit_1) do
+    {
+      :environment           => {'SIMPLIB_LOG_DEPRECATIONS' => 'true'},
+      :acceptable_exit_codes => [1]
+    }
+  end
+
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
     context "when validate_uri_list called" do
@@ -11,7 +22,7 @@ describe 'validate_uri_list function' do
         manifest = <<-EOS
         $var1 = validate_uri_list('https://1.2.3.4:56', ['http','https'])
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_uri_list is deprecated, please use simplib::validate_uri_list')
@@ -24,7 +35,7 @@ describe 'validate_uri_list function' do
         manifest = <<-EOS
         $var1 = validate_uri_list('ldap://1.2.3.4:56', ['http','https'])
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_uri_list is deprecated, please use simplib::validate_uri_list')
@@ -39,7 +50,7 @@ describe 'validate_uri_list function' do
         manifest = <<-EOS
         $var1 = simplib::validate_uri_list('https://1.2.3.4:56', ['http','https'])
         EOS
-        results = apply_manifest_on(server, manifest)
+        results = apply_manifest_on(server, manifest, opts)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_uri_list is deprecated, please use simplib::validate_uri_list')
@@ -52,7 +63,7 @@ describe 'validate_uri_list function' do
         manifest = <<-EOS
         $var1 = simplib::validate_uri_list('ldap://1.2.3.4:56', ['http','https'])
         EOS
-        results = apply_manifest_on(server, manifest, :acceptable_exit_codes => [1])
+        results = apply_manifest_on(server, manifest, opts_with_exit_1)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('validate_uri_list is deprecated, please use simplib::validate_uri_list')

--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -1,22 +1,24 @@
 require 'spec_helper'
 
 describe 'simplib::deprecation' do
-  context 'with no SIMPLIB_LOG_DEPRECATIONS environment variable' do
+  context 'with SIMPLIB_LOG_DEPRECATIONS environment variable = "true" ' do
     it 'should display a single warning' do
+      ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
       Puppet.expects(:warning).with(includes('test_func is deprecated'))
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
 
     it 'should display a single warning, despite multiple calls' do
+      ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
       Puppet.expects(:warning).with(includes('test_func is deprecated')).once
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
   end
 
-  context 'with SIMPLIB_LOG_DEPRECATIONS environment variable = "false"' do
+  context 'with no SIMPLIB_LOG_DEPRECATIONS environment variable set' do
     it 'should not display a warning' do
-      ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'false'
+      ENV['SIMPLIB_LOG_DEPRECATIONS'] = nil
       Puppet.expects(:warning).with(includes('test_func is deprecated')).never
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end


### PR DESCRIPTION
Disable simplib deprecation warnings, temporarily.
Will re-enable when we are ready to address the deprecations
in SIMP modules.

Removed trailing whitespace.

SIMP-4067 #close