### PR TITLE
(SIMP-4155) Enable data type tests in Puppet 4.10

### DIFF
--- a/spec/unit/data_types/emailaddress_spec.rb
+++ b/spec/unit/data_types/emailaddress_spec.rb
@@ -1,42 +1,40 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  describe 'Simplib::EmailAddress', type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          Simplib::EmailAddress $param
-        ){ }
+describe 'Simplib::EmailAddress', type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        Simplib::EmailAddress $param
+      ){ }
 
-        class { '#{class_name}':
-          param => '#{param}'
-        }
-      )}
+      class { '#{class_name}':
+        param => '#{param}'
+      }
+    )}
 
-      context 'with valid addresses' do
-        [
-          'foo@bar.baz',
-          'foo@bar',
-          'foo@bar-baz.com',
-          'foobar@bar-baz.com',
-          'foo+bar@bar-baz.com',
-          'foo.bar@bar-baz.com'
-        ].each do |param|
-          let(:param){ param }
+    context 'with valid addresses' do
+      [
+        'foo@bar.baz',
+        'foo@bar',
+        'foo@bar-baz.com',
+        'foobar@bar-baz.com',
+        'foo+bar@bar-baz.com',
+        'foo.bar@bar-baz.com'
+      ].each do |param|
+        let(:param){ param }
 
-          it "should accept #{param}" do
-            is_expected.to compile
-          end
+        it "should accept #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid addresses' do
-        [ 'foo' ].each do |param|
-          let(:param){ param }
+    context 'with invalid addresses' do
+      [ 'foo' ].each do |param|
+        let(:param){ param }
 
-          it "should accept #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should accept #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/host/port_spec.rb
+++ b/spec/unit/data_types/host/port_spec.rb
@@ -1,60 +1,58 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Host::Port'
+test_data_type = 'Simplib::Host::Port'
 
-  singular_item = 'host with port'
-  plural_item = 'hosts with port'
+singular_item = 'host with port'
+plural_item = 'hosts with port'
 
-  valid_data = [
-    'localhost:80',
-    'localhost.localdomain:443',
-    'my-domain.com:22',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+valid_data = [
+  'localhost:80',
+  'localhost.localdomain:443',
+  'my-domain.com:22',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  invalid_data = [
-    'a',
-    'my_domain.com',
-    '0.0.0',
-    '1.2.3.4/24',
-    '1.2.3.4/255.255.224.0'
-  ]
+invalid_data = [
+  'a',
+  'my_domain.com',
+  '0.0.0',
+  '1.2.3.4/24',
+  '1.2.3.4/255.255.224.0'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/host_spec.rb
+++ b/spec/unit/data_types/host_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Host'
+test_data_type = 'Simplib::Host'
 
-  singular_item = 'host'
-  plural_item = 'hosts'
+singular_item = 'host'
+plural_item = 'hosts'
 
-  valid_data = [
-    'localhost',
-    'localhost.localdomain',
-    'my-domain.com',
-    'aa.bb',
-    '0.0.0.0',
-    '1.2.3.4',
-    '::1',
-    '[::1]'
-  ]
+valid_data = [
+  'localhost',
+  'localhost.localdomain',
+  'my-domain.com',
+  'aa.bb',
+  '0.0.0.0',
+  '1.2.3.4',
+  '::1',
+  '[::1]'
+]
 
-  invalid_data = [
-    'a',
-    'my_domain.com',
-    '0.0.0',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
-    '1.2.3.4/24',
-    '1.2.3.4/255.255.224.0',
-    '1.2.3.4:443'
-  ]
+invalid_data = [
+  'a',
+  'my_domain.com',
+  '0.0.0',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
+  '1.2.3.4/24',
+  '1.2.3.4/255.255.224.0',
+  '1.2.3.4:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/hostname/port_spec.rb
+++ b/spec/unit/data_types/hostname/port_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Hostname::Port'
+test_data_type = 'Simplib::Hostname::Port'
 
-  singular_item = 'hostname with port'
-  plural_item = 'hostnames with port'
+singular_item = 'hostname with port'
+plural_item = 'hostnames with port'
 
-  valid_data = [
-    'localhost:443',
-    'localhost.localdomain:80',
-    'my-domain.com:22',
-    'aa.bb:65535',
-  ]
+valid_data = [
+  'localhost:443',
+  'localhost.localdomain:80',
+  'my-domain.com:22',
+  'aa.bb:65535',
+]
 
-  invalid_data = [
-    'a',
-    'my_domain.com',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '1.2.3.4/24',
-    '1.2.3.4/255.255.224.0',
-    '1.2.3.4:443',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
-    '::1',
-    '[::1]'
-  ]
+invalid_data = [
+  'a',
+  'my_domain.com',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '1.2.3.4/24',
+  '1.2.3.4/255.255.224.0',
+  '1.2.3.4:443',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
+  '::1',
+  '[::1]'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/hostname_spec.rb
+++ b/spec/unit/data_types/hostname_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Hostname'
+test_data_type = 'Simplib::Hostname'
 
-  singular_item = 'hostname'
-  plural_item = 'hostnames'
+singular_item = 'hostname'
+plural_item = 'hostnames'
 
-  valid_data = [
-    'localhost',
-    'localhost.localdomain',
-    'my-domain.com',
-    'aa.bb'
-  ]
+valid_data = [
+  'localhost',
+  'localhost.localdomain',
+  'my-domain.com',
+  'aa.bb'
+]
 
-  invalid_data = [
-    'a',
-    'my_domain.com',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '1.2.3.4/24',
-    '1.2.3.4/255.255.224.0',
-    '1.2.3.4:443',
-    '::1',
-    '[::1]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'a',
+  'my_domain.com',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '1.2.3.4/24',
+  '1.2.3.4/255.255.224.0',
+  '1.2.3.4:443',
+  '::1',
+  '[::1]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v4/cidr_spec.rb
+++ b/spec/unit/data_types/ip/v4/cidr_spec.rb
@@ -1,67 +1,65 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V4::CIDR'
+test_data_type = 'Simplib::IP::V4::CIDR'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '127.0.0.1/32',
-    '0.0.0.0/0',
-    '1.2.3.4/24'
-  ]
+valid_data = [
+  '127.0.0.1/32',
+  '0.0.0.0/0',
+  '1.2.3.4/24'
+]
 
-  invalid_data = [
-    'localhost',
-    '127.0.0.1/33',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '127.0.0.1/33',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v4/ddq_spec.rb
+++ b/spec/unit/data_types/ip/v4/ddq_spec.rb
@@ -1,68 +1,66 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V4::DDQ'
+test_data_type = 'Simplib::IP::V4::DDQ'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '127.0.0.1/255.255.255.0',
-    '1.2.3.4/255.255.255.128',
-    '1.2.3.4/255.128.0.0',
-    '0.0.0.0/0.0.0.0'
-  ]
+valid_data = [
+  '127.0.0.1/255.255.255.0',
+  '1.2.3.4/255.255.255.128',
+  '1.2.3.4/255.128.0.0',
+  '0.0.0.0/0.0.0.0'
+]
 
-  invalid_data = [
-    'localhost',
-    '127.0.0.1/33',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1/255.255.128.128',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '127.0.0.1/33',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1/255.255.128.128',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v4/port_spec.rb
+++ b/spec/unit/data_types/ip/v4/port_spec.rb
@@ -1,68 +1,66 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V4::Port'
+test_data_type = 'Simplib::IP::V4::Port'
 
-  singular_item = 'port'
-  plural_item = 'ports'
+singular_item = 'port'
+plural_item = 'ports'
 
-  valid_data = [
-    '127.0.0.1:65535',
-    '127.0.0.1:443',
-    '1.2.3.4:0'
-  ]
+valid_data = [
+  '127.0.0.1:65535',
+  '127.0.0.1:443',
+  '1.2.3.4:0'
+]
 
-  invalid_data = [
-    'localhost',
-    'localhost:443',
-    '127.0.0.1/33',
-    '127.0.0.1:443/33',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  'localhost:443',
+  '127.0.0.1/33',
+  '127.0.0.1:443/33',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v4_spec.rb
+++ b/spec/unit/data_types/ip/v4_spec.rb
@@ -1,62 +1,60 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V4'
+test_data_type = 'Simplib::IP::V4'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '254.0.0.1',
-    '255.255.255.255'
-  ]
+valid_data = [
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '254.0.0.1',
+  '255.255.255.255'
+]
 
-  invalid_data = [
-    'localhost',
-    '0.0.0',
-    '1.2.3.256',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '0.0.0',
+  '1.2.3.256',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v6/base_spec.rb
+++ b/spec/unit/data_types/ip/v6/base_spec.rb
@@ -1,64 +1,62 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V6::Base'
+test_data_type = 'Simplib::IP::V6::Base'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '::1',
-    '2001:db8:85a3:8d3:1319:8a2e:370:7348'
-  ]
+valid_data = [
+  '::1',
+  '2001:db8:85a3:8d3:1319:8a2e:370:7348'
+]
 
-  invalid_data = [
-    'localhost',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v6/bracketed_spec.rb
+++ b/spec/unit/data_types/ip/v6/bracketed_spec.rb
@@ -1,64 +1,62 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V6::Bracketed'
+test_data_type = 'Simplib::IP::V6::Bracketed'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '[::1]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
-  ]
+valid_data = [
+  '[::1]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
+]
 
-  invalid_data = [
-    'localhost',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v6/cidr_spec.rb
+++ b/spec/unit/data_types/ip/v6/cidr_spec.rb
@@ -1,65 +1,63 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V6::CIDR'
+test_data_type = 'Simplib::IP::V6::CIDR'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '::1/1',
-    '2001:db8:85a3:8d3:1319:8a2e:370:7348/128'
-  ]
+valid_data = [
+  '::1/1',
+  '2001:db8:85a3:8d3:1319:8a2e:370:7348/128'
+]
 
-  invalid_data = [
-    'localhost',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v6/port_spec.rb
+++ b/spec/unit/data_types/ip/v6/port_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V6::Port'
+test_data_type = 'Simplib::IP::V6::Port'
 
-  singular_item = 'port'
-  plural_item = 'ports'
+singular_item = 'port'
+plural_item = 'ports'
 
-  valid_data = [
-    '[::1]:443',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:0',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:65535'
-  ]
+valid_data = [
+  '[::1]:443',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:0',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:65535'
+]
 
-  invalid_data = [
-    'localhost',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '::1',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:65536'
-  ]
+invalid_data = [
+  'localhost',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '::1',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:65536'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip/v6_spec.rb
+++ b/spec/unit/data_types/ip/v6_spec.rb
@@ -1,65 +1,63 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP::V6'
+test_data_type = 'Simplib::IP::V6'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '::1',
-    '[::1]',
-    '2001:db8:85a3:8d3:1319:8a2e:370:7348',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
-  ]
+valid_data = [
+  '::1',
+  '[::1]',
+  '2001:db8:85a3:8d3:1319:8a2e:370:7348',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
+]
 
-  invalid_data = [
-    'localhost',
-    '1.2.3.256',
-    '256.0.0.1',
-    '0.0.0',
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '255.255.255.255',
-    '127.0.0.1:443',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '1.2.3.256',
+  '256.0.0.1',
+  '0.0.0',
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '255.255.255.255',
+  '127.0.0.1:443',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/ip_spec.rb
+++ b/spec/unit/data_types/ip_spec.rb
@@ -1,64 +1,62 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::IP'
+test_data_type = 'Simplib::IP'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    '0.0.0.0',
-    '1.2.3.4',
-    '127.0.0.1',
-    '254.0.0.1',
-    '255.255.255.255',
-    '::1',
-    '[::1]',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
-  ]
+valid_data = [
+  '0.0.0.0',
+  '1.2.3.4',
+  '127.0.0.1',
+  '254.0.0.1',
+  '255.255.255.255',
+  '::1',
+  '[::1]',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]'
+]
 
-  invalid_data = [
-    'localhost',
-    '0.0.0',
-    '1.2.3.256',
-    '127.0.0.1:443',
-    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-  ]
+invalid_data = [
+  'localhost',
+  '0.0.0',
+  '1.2.3.256',
+  '127.0.0.1:443',
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
           end
         end
       end

--- a/spec/unit/data_types/netlist/host_spec.rb
+++ b/spec/unit/data_types/netlist/host_spec.rb
@@ -1,71 +1,69 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist::Host'
+test_data_type = 'Simplib::Netlist::Host'
 
-  singular_item = 'host'
-  plural_item = 'hosts'
+singular_item = 'host'
+plural_item = 'hosts'
 
-  valid_data = [
-    [
-      'localhost',
-      'aa.bb',
-      'my-host.com'
-    ]
-  ]
-
-  invalid_data = [
+valid_data = [
+  [
     'localhost',
-    [
-      '0.0.0',
-      '1.2.3.256'
-    ],
-    [
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '1.2.3.4:443',
-      '::1',
-      '[::1]',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
+    'aa.bb',
+    'my-host.com'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+invalid_data = [
+  'localhost',
+  [
+    '0.0.0',
+    '1.2.3.256'
+  ],
+  [
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '1.2.3.4:443',
+    '::1',
+    '[::1]',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+  ]
+]
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/netlist/ip/v4_spec.rb
+++ b/spec/unit/data_types/netlist/ip/v4_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist::IP::V4'
+test_data_type = 'Simplib::Netlist::IP::V4'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    [
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '1.2.3.4:443'
-    ]
+valid_data = [
+  [
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '1.2.3.4:443'
   ]
+]
 
-  invalid_data = [
-    'localhost',
-    [
-      '0.0.0',
-      '1.2.3.256',
-      '::1',
-      '[::1]',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
+invalid_data = [
+  'localhost',
+  [
+    '0.0.0',
+    '1.2.3.256',
+    '::1',
+    '[::1]',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/netlist/ip/v6_spec.rb
+++ b/spec/unit/data_types/netlist/ip/v6_spec.rb
@@ -1,71 +1,69 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist::IP::V6'
+test_data_type = 'Simplib::Netlist::IP::V6'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    [
-      '[::1]',
-      '2001:db8:85a3:8d3:1319:8a2e:370:7348/128',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
+valid_data = [
+  [
+    '[::1]',
+    '2001:db8:85a3:8d3:1319:8a2e:370:7348/128',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
   ]
+]
 
-  invalid_data = [
-    'localhost',
-    [
-      '0.0.0',
-      '1.2.3.256',
-      '::1',
-      '[::1]',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ],
-    [
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '1.2.3.4:443'
-    ]
+invalid_data = [
+  'localhost',
+  [
+    '0.0.0',
+    '1.2.3.256',
+    '::1',
+    '[::1]',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
+  ],
+  [
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '1.2.3.4:443'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/netlist/ip_spec.rb
+++ b/spec/unit/data_types/netlist/ip_spec.rb
@@ -1,66 +1,64 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist::IP'
+test_data_type = 'Simplib::Netlist::IP'
 
-  singular_item = 'address'
-  plural_item = 'addresses'
+singular_item = 'address'
+plural_item = 'addresses'
 
-  valid_data = [
-    [
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '1.2.3.4:443',
-      '::1',
-      '[::1]',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
+valid_data = [
+  [
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '1.2.3.4:443',
+    '::1',
+    '[::1]',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
   ]
+]
 
-  invalid_data = [
-    'localhost',
-    [
-      '0.0.0',
-      '1.2.3.256'
-    ]
+invalid_data = [
+  'localhost',
+  [
+    '0.0.0',
+    '1.2.3.256'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/netlist/port_spec.rb
+++ b/spec/unit/data_types/netlist/port_spec.rb
@@ -1,71 +1,69 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist::Port'
+test_data_type = 'Simplib::Netlist::Port'
 
-  singular_item = 'port'
-  plural_item = 'ports'
+singular_item = 'port'
+plural_item = 'ports'
 
-  valid_data = [
-    [
-      'localhost:443',
-      'aa.bb:80',
-      'my-host.com:22',
-      '1.2.3.4:443',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
+valid_data = [
+  [
+    'localhost:443',
+    'aa.bb:80',
+    'my-host.com:22',
+    '1.2.3.4:443',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
   ]
+]
 
-  invalid_data = [
-    'localhost',
-    [
-      '0.0.0',
-      '1.2.3.256'
-    ],
-    [
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '::1',
-      '[::1]'
-    ]
+invalid_data = [
+  'localhost',
+  [
+    '0.0.0',
+    '1.2.3.256'
+  ],
+  [
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '::1',
+    '[::1]'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/netlist_spec.rb
+++ b/spec/unit/data_types/netlist_spec.rb
@@ -1,70 +1,68 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Netlist'
+test_data_type = 'Simplib::Netlist'
 
-  singular_item = 'net list'
-  plural_item = 'net lists'
+singular_item = 'net list'
+plural_item = 'net lists'
 
-  valid_data = [
-    [
-      'localhost',
-      'localhost.localdomain',
-      'aa.bb',
-      '0.0.0.0',
-      '1.2.3.4',
-      '1.2.3.4/24',
-      '1.2.3.4/255.255.224.0',
-      '1.2.3.4:443',
-      '::1',
-      '[::1]',
-      '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
-    ]
-  ]
-
-  invalid_data = [
+valid_data = [
+  [
     'localhost',
-    [
-      'a',
-      '0.0.0',
-      '1.2.3.256'
-    ]
+    'localhost.localdomain',
+    'aa.bb',
+    '0.0.0.0',
+    '1.2.3.4',
+    '1.2.3.4/24',
+    '1.2.3.4/255.255.224.0',
+    '1.2.3.4:443',
+    '::1',
+    '[::1]',
+    '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443'
   ]
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+invalid_data = [
+  'localhost',
+  [
+    'a',
+    '0.0.0',
+    '1.2.3.256'
+  ]
+]
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/port/dynamic_spec.rb
+++ b/spec/unit/data_types/port/dynamic_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Port::Dynamic'
+test_data_type = 'Simplib::Port::Dynamic'
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context 'with valid ports' do
-        [49152,56789,65535].each do |param|
-          let(:param){ param }
+    context 'with valid ports' do
+      [49152,56789,65535].each do |param|
+        let(:param){ param }
 
-          it "should work with port #{param}" do
-            is_expected.to compile
-          end
+        it "should work with port #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid ports' do
-        [0,49151,65536,'22',true].each do |param|
-          let(:param){ param }
+    context 'with invalid ports' do
+      [0,49151,65536,'22',true].each do |param|
+        let(:param){ param }
 
-          it "should fail on port #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should fail on port #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/port/random_spec.rb
+++ b/spec/unit/data_types/port/random_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Port::Random'
+test_data_type = 'Simplib::Port::Random'
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context 'with valid ports' do
-        [0].each do |param|
-          let(:param){ param }
+    context 'with valid ports' do
+      [0].each do |param|
+        let(:param){ param }
 
-          it "should work with port #{param}" do
-            is_expected.to compile
-          end
+        it "should work with port #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid ports' do
-        [1,1025,'22',true].each do |param|
-          let(:param){ param }
+    context 'with invalid ports' do
+      [1,1025,'22',true].each do |param|
+        let(:param){ param }
 
-          it "should fail on port #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should fail on port #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/port/system_spec.rb
+++ b/spec/unit/data_types/port/system_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Port::System'
+test_data_type = 'Simplib::Port::System'
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context 'with valid ports' do
-        [1,80,1024].each do |param|
-          let(:param){ param }
+    context 'with valid ports' do
+      [1,80,1024].each do |param|
+        let(:param){ param }
 
-          it "should work with port #{param}" do
-            is_expected.to compile
-          end
+        it "should work with port #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid ports' do
-        [0,1025,'22',true].each do |param|
-          let(:param){ param }
+    context 'with invalid ports' do
+      [0,1025,'22',true].each do |param|
+        let(:param){ param }
 
-          it "should fail on port #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should fail on port #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/port/user_spec.rb
+++ b/spec/unit/data_types/port/user_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Port::User'
+test_data_type = 'Simplib::Port::User'
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context 'with valid ports' do
-        [1025,2345,49151].each do |param|
-          let(:param){ param }
+    context 'with valid ports' do
+      [1025,2345,49151].each do |param|
+        let(:param){ param }
 
-          it "should work with port #{param}" do
-            is_expected.to compile
-          end
+        it "should work with port #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid ports' do
-        [0,1024,'22',49152,65535,true].each do |param|
-          let(:param){ param }
+    context 'with invalid ports' do
+      [0,1024,'22',49152,65535,true].each do |param|
+        let(:param){ param }
 
-          it "should fail on port #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should fail on port #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/port_spec.rb
+++ b/spec/unit/data_types/port_spec.rb
@@ -1,35 +1,33 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  describe 'Simplib::Port', type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          Simplib::Port $port
-        ){ }
+describe 'Simplib::Port', type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        Simplib::Port $port
+      ){ }
 
-        class { '#{class_name}':
-          port => #{port}
-        }
-      )}
+      class { '#{class_name}':
+        port => #{port}
+      }
+    )}
 
-      context 'with valid ports' do
-        [0,80,1024,65535].each do |port|
-          let(:port){ port }
+    context 'with valid ports' do
+      [0,80,1024,65535].each do |port|
+        let(:port){ port }
 
-          it "should work with port #{port}" do
-            is_expected.to compile
-          end
+        it "should work with port #{port}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid ports' do
-        [-1,65536,12345678910,'22',true].each do |port|
-          let(:port){ port }
+    context 'with invalid ports' do
+      [-1,65536,12345678910,'22',true].each do |port|
+        let(:port){ port }
 
-          it "should fail on port #{port}" do
-            is_expected.to compile.and_raise_error(/parameter 'port' expects/)
-          end
+        it "should fail on port #{port}" do
+          is_expected.to compile.and_raise_error(/parameter 'port' expects/)
         end
       end
     end

--- a/spec/unit/data_types/syslog/cfacility_spec.rb
+++ b/spec/unit/data_types/syslog/cfacility_spec.rb
@@ -1,55 +1,53 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::CFacility'
+test_data_type = 'Simplib::Syslog::CFacility'
 
-  singular_item = 'facility'
-  plural_item = 'facilities'
+singular_item = 'facility'
+plural_item = 'facilities'
 
-  valid_data = [
-    'LOG_KERN',
-    'LOG_LOCAL6'
-  ]
+valid_data = [
+  'LOG_KERN',
+  'LOG_LOCAL6'
+]
 
-  invalid_data = [
-    'KERN',
-    'LOCAL6'
-  ]
+invalid_data = [
+  'KERN',
+  'LOCAL6'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/cpriority_spec.rb
+++ b/spec/unit/data_types/syslog/cpriority_spec.rb
@@ -1,55 +1,53 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::CPriority'
+test_data_type = 'Simplib::Syslog::CPriority'
 
-  singular_item = 'priority'
-  plural_item = 'priorities'
+singular_item = 'priority'
+plural_item = 'priorities'
 
-  valid_data = [
-    'LOG_KERN.LOG_WARNING',
-    'LOG_LOCAL6.LOG_NOTICE'
-  ]
+valid_data = [
+  'LOG_KERN.LOG_WARNING',
+  'LOG_LOCAL6.LOG_NOTICE'
+]
 
-  invalid_data = [
-    'KERN.WARNING',
-    'LOCAL6.NOTICE'
-  ]
+invalid_data = [
+  'KERN.WARNING',
+  'LOCAL6.NOTICE'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/cseverity_spec.rb
+++ b/spec/unit/data_types/syslog/cseverity_spec.rb
@@ -1,55 +1,53 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::CSeverity'
+test_data_type = 'Simplib::Syslog::CSeverity'
 
-  singular_item = 'severity'
-  plural_item = 'severities'
+singular_item = 'severity'
+plural_item = 'severities'
 
-  valid_data = [
-    'LOG_WARNING',
-    'LOG_NOTICE'
-  ]
+valid_data = [
+  'LOG_WARNING',
+  'LOG_NOTICE'
+]
 
-  invalid_data = [
-    'WARNING',
-    'NOTICE'
-  ]
+invalid_data = [
+  'WARNING',
+  'NOTICE'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/facility_spec.rb
+++ b/spec/unit/data_types/syslog/facility_spec.rb
@@ -1,59 +1,57 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::Facility'
+test_data_type = 'Simplib::Syslog::Facility'
 
-  singular_item = 'facility'
-  plural_item = 'facilities'
+singular_item = 'facility'
+plural_item = 'facilities'
 
-  valid_data = [
-    'KERN',
-    'LOCAL6',
-    'LOG_KERN',
-    'LOG_LOCAL6',
-    'kern',
-    'local6'
-  ]
+valid_data = [
+  'KERN',
+  'LOCAL6',
+  'LOG_KERN',
+  'LOG_LOCAL6',
+  'kern',
+  'local6'
+]
 
-  invalid_data = [
-    'BOB',
-    'NOTICE'
-  ]
+invalid_data = [
+  'BOB',
+  'NOTICE'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/lowerfacility_spec.rb
+++ b/spec/unit/data_types/syslog/lowerfacility_spec.rb
@@ -1,56 +1,54 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::LowerFacility'
+test_data_type = 'Simplib::Syslog::LowerFacility'
 
-  singular_item = 'facility'
-  plural_item = 'facilities'
+singular_item = 'facility'
+plural_item = 'facilities'
 
-  valid_data = [
-    'kern',
-    'local6'
-  ]
+valid_data = [
+  'kern',
+  'local6'
+]
 
-  invalid_data = [
-    'KERN',
-    'LOG_KERN',
-    'stuff'
-  ]
+invalid_data = [
+  'KERN',
+  'LOG_KERN',
+  'stuff'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/lowerpriority_spec.rb
+++ b/spec/unit/data_types/syslog/lowerpriority_spec.rb
@@ -1,55 +1,53 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::LowerPriority'
+test_data_type = 'Simplib::Syslog::LowerPriority'
 
-  singular_item = 'priority'
-  plural_item = 'priorities'
+singular_item = 'priority'
+plural_item = 'priorities'
 
-  valid_data = [
-    'kern.warning',
-    'local6.notice'
-  ]
+valid_data = [
+  'kern.warning',
+  'local6.notice'
+]
 
-  invalid_data = [
-    'KERN.WARNING',
-    'LOCAL6.NOTICE'
-  ]
+invalid_data = [
+  'KERN.WARNING',
+  'LOCAL6.NOTICE'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/lowerseverity_spec.rb
+++ b/spec/unit/data_types/syslog/lowerseverity_spec.rb
@@ -1,57 +1,55 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::LowerSeverity'
+test_data_type = 'Simplib::Syslog::LowerSeverity'
 
-  singular_item = 'severity'
-  plural_item = 'severities'
+singular_item = 'severity'
+plural_item = 'severities'
 
-  valid_data = [
-    'warning',
-    'notice'
-  ]
+valid_data = [
+  'warning',
+  'notice'
+]
 
-  invalid_data = [
-    'LOG_NOTICE',
-    'LOG_WARNING',
-    'NOTICE',
-    'WARN'
-  ]
+invalid_data = [
+  'LOG_NOTICE',
+  'LOG_WARNING',
+  'NOTICE',
+  'WARN'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/priority_spec.rb
+++ b/spec/unit/data_types/syslog/priority_spec.rb
@@ -1,57 +1,55 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::Priority'
+test_data_type = 'Simplib::Syslog::Priority'
 
-  singular_item = 'priority'
-  plural_item = 'priorities'
+singular_item = 'priority'
+plural_item = 'priorities'
 
-  valid_data = [
-    'KERN.WARNING',
-    'LOCAL6.NOTICE',
-    'kern.warning',
-    'local6.notice'
-  ]
+valid_data = [
+  'KERN.WARNING',
+  'LOCAL6.NOTICE',
+  'kern.warning',
+  'local6.notice'
+]
 
-  invalid_data = [
-    'KERN.warning',
-    'local6.NOTICE',
-  ]
+invalid_data = [
+  'KERN.warning',
+  'local6.NOTICE',
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/severity_spec.rb
+++ b/spec/unit/data_types/syslog/severity_spec.rb
@@ -1,59 +1,57 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::Severity'
+test_data_type = 'Simplib::Syslog::Severity'
 
-  singular_item = 'severity'
-  plural_item = 'severities'
+singular_item = 'severity'
+plural_item = 'severities'
 
-  valid_data = [
-    'LOG_NOTICE',
-    'LOG_WARNING',
-    'NOTICE',
-    'WARNING',
-    'notice',
-    'warning'
-  ]
+valid_data = [
+  'LOG_NOTICE',
+  'LOG_WARNING',
+  'NOTICE',
+  'WARNING',
+  'notice',
+  'warning'
+]
 
-  invalid_data = [
-    'BOB',
-    'KERN'
-  ]
+invalid_data = [
+  'BOB',
+  'KERN'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/upperfacility_spec.rb
+++ b/spec/unit/data_types/syslog/upperfacility_spec.rb
@@ -1,56 +1,54 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::UpperFacility'
+test_data_type = 'Simplib::Syslog::UpperFacility'
 
-  singular_item = 'facility'
-  plural_item = 'facilities'
+singular_item = 'facility'
+plural_item = 'facilities'
 
-  valid_data = [
-    'KERN',
-    'LOCAL6'
-  ]
+valid_data = [
+  'KERN',
+  'LOCAL6'
+]
 
-  invalid_data = [
-    'kern',
-    'LOG_KERN',
-    'STUFF'
-  ]
+invalid_data = [
+  'kern',
+  'LOG_KERN',
+  'STUFF'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/upperpriority_spec.rb
+++ b/spec/unit/data_types/syslog/upperpriority_spec.rb
@@ -1,57 +1,55 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::UpperPriority'
+test_data_type = 'Simplib::Syslog::UpperPriority'
 
-  singular_item = 'priority'
-  plural_item = 'priorities'
+singular_item = 'priority'
+plural_item = 'priorities'
 
-  valid_data = [
-    'KERN.WARNING',
-    'LOCAL6.NOTICE'
-  ]
+valid_data = [
+  'KERN.WARNING',
+  'LOCAL6.NOTICE'
+]
 
-  invalid_data = [
-    'KERN.warning',
-    'kern.warn',
-    'local6.NOTICE',
-    'local6.notice'
-  ]
+invalid_data = [
+  'KERN.warning',
+  'kern.warn',
+  'local6.NOTICE',
+  'local6.notice'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/syslog/upperseverity_spec.rb
+++ b/spec/unit/data_types/syslog/upperseverity_spec.rb
@@ -1,57 +1,55 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  test_data_type = 'Simplib::Syslog::UpperSeverity'
+test_data_type = 'Simplib::Syslog::UpperSeverity'
 
-  singular_item = 'severity'
-  plural_item = 'severities'
+singular_item = 'severity'
+plural_item = 'severities'
 
-  valid_data = [
-    'WARNING',
-    'NOTICE'
-  ]
+valid_data = [
+  'WARNING',
+  'NOTICE'
+]
 
-  invalid_data = [
-    'LOG_NOTICE',
-    'LOG_WARNING',
-    'notice',
-    'warn'
-  ]
+invalid_data = [
+  'LOG_NOTICE',
+  'LOG_WARNING',
+  'notice',
+  'warn'
+]
 
-  describe test_data_type, type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          #{test_data_type} $param
-        ){ }
+describe test_data_type, type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        #{test_data_type} $param
+      ){ }
 
-        class { '#{class_name}':
-          param => #{param}
-        }
-      )}
+      class { '#{class_name}':
+        param => #{param}
+      }
+    )}
 
-      context "with valid #{plural_item}" do
-        valid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){ data.is_a?(String) ? "'#{data}'" : data }
+    context "with valid #{plural_item}" do
+      valid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){ data.is_a?(String) ? "'#{data}'" : data }
 
-            it 'should compile' do
-              is_expected.to compile
-            end
+          it 'should compile' do
+            is_expected.to compile
           end
         end
       end
+    end
 
-      context "with invalid #{plural_item}" do
-        invalid_data.each do |data|
-          context "with #{singular_item} #{data}" do
-            let(:param){
-              data.is_a?(String) ? "'#{data}'" : data
-            }
+    context "with invalid #{plural_item}" do
+      invalid_data.each do |data|
+        context "with #{singular_item} #{data}" do
+          let(:param){
+            data.is_a?(String) ? "'#{data}'" : data
+          }
 
-            it 'should fail to compile' do
-              is_expected.to compile.and_raise_error(/parameter 'param'/)
-            end
+          it 'should fail to compile' do
+            is_expected.to compile.and_raise_error(/parameter 'param'/)
           end
         end
       end

--- a/spec/unit/data_types/umask_spec.rb
+++ b/spec/unit/data_types/umask_spec.rb
@@ -1,42 +1,40 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  describe 'Simplib::Umask', type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          Simplib::Umask $param
-        ){ }
+describe 'Simplib::Umask', type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        Simplib::Umask $param
+      ){ }
 
-        class { '#{class_name}':
-          param => '#{param}'
-        }
-      )}
+      class { '#{class_name}':
+        param => '#{param}'
+      }
+    )}
 
-      context 'with valid umask' do
-        [
-          '0000',
-          '0240',
-          '1111'
-        ].each do |param|
-          let(:param){ param }
+    context 'with valid umask' do
+      [
+        '0000',
+        '0240',
+        '1111'
+      ].each do |param|
+        let(:param){ param }
 
-          it "should accept #{param}" do
-            is_expected.to compile
-          end
+        it "should accept #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid umask' do
-        [
-          '12345',
-          'bob'
-        ].each do |param|
-          let(:param){ param }
+    context 'with invalid umask' do
+      [
+        '12345',
+        'bob'
+      ].each do |param|
+        let(:param){ param }
 
-          it "should reject #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should reject #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end

--- a/spec/unit/data_types/uri_spec.rb
+++ b/spec/unit/data_types/uri_spec.rb
@@ -1,44 +1,42 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
-  describe 'Simplib::URI', type: :class do
-    describe 'valid handling' do
-      let(:pre_condition) {%(
-        class #{class_name} (
-          Simplib::URI $param
-        ){ }
+describe 'Simplib::URI', type: :class do
+  describe 'valid handling' do
+    let(:pre_condition) {%(
+      class #{class_name} (
+        Simplib::URI $param
+      ){ }
 
-        class { '#{class_name}':
-          param => '#{param}'
-        }
-      )}
+      class { '#{class_name}':
+        param => '#{param}'
+      }
+    )}
 
-      context 'with valid URI' do
-        [
-          'foo://bar',
-          'f00://bar',
-          'foo+bar://baz',
-          'foo.bar-baz+aaa://bbb'
-        ].each do |param|
-          let(:param){ param }
+    context 'with valid URI' do
+      [
+        'foo://bar',
+        'f00://bar',
+        'foo+bar://baz',
+        'foo.bar-baz+aaa://bbb'
+      ].each do |param|
+        let(:param){ param }
 
-          it "should accept #{param}" do
-            is_expected.to compile
-          end
+        it "should accept #{param}" do
+          is_expected.to compile
         end
       end
+    end
 
-      context 'with invalid URI' do
-        [
-          'foo',
-          'foo@bar://baz',
-          '1foo://bar'
-        ].each do |param|
-          let(:param){ param }
+    context 'with invalid URI' do
+      [
+        'foo',
+        'foo@bar://baz',
+        '1foo://bar'
+      ].each do |param|
+        let(:param){ param }
 
-          it "should reject #{param}" do
-            is_expected.to compile.and_raise_error(/parameter 'param' expects/)
-          end
+        it "should reject #{param}" do
+          is_expected.to compile.and_raise_error(/parameter 'param' expects/)
         end
       end
     end


### PR DESCRIPTION
Before this patch, spec tests against Puppet 4.10 silently failed to
load all 341 data type examples, due to a bug in a version comparison
test that wraps each test in order to prevent the inclusion in Puppet
versions older than 4.5. 

Since the module now supports Puppet >= 4.7.0, this commit resolves
the issue by removing the outdated conditionals from every test.

SIMP-4155 #close