### PR TITLE
(SIMP-3892) Add login_defs custom fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.0-0
+- Added a 'login_defs' structured fact that returns a hash of all values in
+  '/etc/login.defs' with a default 'uid_min' and 'gid_min'
+
 * Fri Dec 08 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.9.0-0
 - Add data types Simplib::Domain and Simplib::Domainlist
 - Re-enabled unit-style data type spec tests for Puppet 4.10

--- a/lib/facter/login_defs.rb
+++ b/lib/facter/login_defs.rb
@@ -6,18 +6,8 @@ Facter.add('login_defs') do
   end
 
   setcode do
-    def read_login_defs
-      File.read('/etc/login.defs')
-    end
 
-    if ['RedHat','CentOS'].include?(Facter.value(:operatingsystem)) &&
-       Facter.value(:operatingsystemmajrelease) < '7'
-        id_min = 500
-    else
-      id_min = 1000
-    end
-
-    attribute_hash = read_login_defs.lines.
+    attribute_hash = File.read('/etc/login.defs').lines.
       delete_if{|x| x =~ /^\s*(#|$)/}.
       map{|x| x = x.split(/\s+/); x[0].downcase!; x}.
       to_h
@@ -35,12 +25,6 @@ Facter.add('login_defs') do
         attribute_hash[k] = false
       elsif v =~ /^\d+$/
         attribute_hash[k] = v.to_i
-      end
-    end
-
-    ['uid_min', 'gid_min'].each do |id_attr|
-      unless attribute_hash[id_attr]
-        attribute_hash[id_attr] = id_min
       end
     end
 

--- a/lib/facter/login_defs.rb
+++ b/lib/facter/login_defs.rb
@@ -1,0 +1,49 @@
+# Returns the contents of /etc/login.defs as a hash with downcased keys
+#
+Facter.add('login_defs') do
+  confine do
+    File.exist?('/etc/login.defs') && File.readable?('/etc/login.defs')
+  end
+
+  setcode do
+    def read_login_defs
+      File.read('/etc/login.defs')
+    end
+
+    if ['RedHat','CentOS'].include?(Facter.value(:operatingsystem)) &&
+       Facter.value(:operatingsystemmajrelease) < '7'
+        id_min = 500
+    else
+      id_min = 1000
+    end
+
+    attribute_hash = read_login_defs.lines.
+      delete_if{|x| x =~ /^\s*(#|$)/}.
+      map{|x| x = x.split(/\s+/); x[0].downcase!; x}.
+      to_h
+
+    attribute_hash.each do |k, v|
+      # We have a few special cases to take care of
+
+      # Leave the umask as a string
+      next if k == 'umask'
+
+      # Change yes/no to true/false
+      if v == 'yes'
+        attribute_hash[k] = true
+      elsif v == 'no'
+        attribute_hash[k] = false
+      elsif v =~ /^\d+$/
+        attribute_hash[k] = v.to_i
+      end
+    end
+
+    ['uid_min', 'gid_min'].each do |id_attr|
+      unless attribute_hash[id_attr]
+        attribute_hash[id_attr] = id_min
+      end
+    end
+
+    attribute_hash
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/facter/login_defs_spec.rb
+++ b/spec/unit/facter/login_defs_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe "custom fact login_defs" do
+
+  before(:each) do
+    Facter.clear
+
+    Facter.stubs(:value).with(:operatingsystem).returns('Linux')
+  end
+
+  context 'with a well formed /etc/login.defs' do
+    let(:login_defs_content) { <<-EOM
+MAIL_DIR        /var/spool/mail
+PASS_MAX_DAYS   99999
+PASS_MIN_DAYS   0
+PASS_MIN_LEN    5
+PASS_WARN_AGE   7
+UID_MIN         1000
+UID_MAX         60000
+SYS_UID_MIN     201
+SYS_UID_MAX     999
+GID_MIN         1000
+GID_MAX         60000
+SYS_GID_MIN     201
+SYS_GID_MAX     999
+CREATE_HOME     yes
+UMASK           077
+USERGROUPS_ENAB yes
+ENCRYPT_METHOD  SHA512
+MD5_CRYPT_ENAB  no
+      EOM
+    }
+
+    it 'should return hash of values from /etc/login.defs with appropriate conversions' do
+      File.expects(:exist?).with('/etc/login.defs').returns(true)
+      File.expects(:readable?).with('/etc/login.defs').returns(true)
+      File.expects(:read).with('/etc/login.defs').returns(login_defs_content)
+
+      File.stubs(:exist?).with(Not(equals('/etc/login.defs')))
+      File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
+      File.stubs(:read).with(Not(equals('/etc/login.defs')))
+
+      expect(Facter.fact('login_defs').value).to eq({
+        "mail_dir"        =>"/var/spool/mail",
+        "pass_max_days"   =>99999,
+        "pass_min_days"   =>0,
+        "pass_min_len"    =>5,
+        "pass_warn_age"   =>7,
+        "uid_min"         =>1000,
+        "uid_max"         =>60000,
+        "sys_uid_min"     =>201,
+        "sys_uid_max"     =>999,
+        "gid_min"         =>1000,
+        "gid_max"         =>60000,
+        "sys_gid_min"     =>201,
+        "sys_gid_max"     =>999,
+        "create_home"     =>true,
+        "umask"           =>"077",
+        "usergroups_enab" =>true,
+        "encrypt_method"  =>"SHA512",
+        "md5_crypt_enab"  =>false
+      })
+    end
+  end
+
+  context 'with an empty login.defs' do
+    it 'should return hash of the uid_min and gid_min defaults' do
+      File.expects(:exist?).with('/etc/login.defs').returns(true)
+      File.expects(:readable?).with('/etc/login.defs').returns(true)
+      File.expects(:read).with('/etc/login.defs').returns('')
+
+      File.stubs(:exist?).with(Not(equals('/etc/login.defs')))
+      File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
+      File.stubs(:read).with(Not(equals('/etc/login.defs')))
+
+      expect(Facter.fact('login_defs').value).to eq({
+        'uid_min' => 1000,
+        'gid_min' => 1000
+      })
+    end
+  end
+end

--- a/spec/unit/facter/login_defs_spec.rb
+++ b/spec/unit/facter/login_defs_spec.rb
@@ -10,22 +10,35 @@ describe "custom fact login_defs" do
 
   context 'with a well formed /etc/login.defs' do
     let(:login_defs_content) { <<-EOM
+# I can haz comments!
 MAIL_DIR        /var/spool/mail
+
 PASS_MAX_DAYS   99999
 PASS_MIN_DAYS   0
+
 PASS_MIN_LEN    5
+
 PASS_WARN_AGE   7
+
 UID_MIN         1000
 UID_MAX         60000
+
 SYS_UID_MIN     201
 SYS_UID_MAX     999
+
 GID_MIN         1000
 GID_MAX         60000
+
 SYS_GID_MIN     201
 SYS_GID_MAX     999
+
 CREATE_HOME     yes
+
 UMASK           077
 USERGROUPS_ENAB yes
+    
+# Even inline comments!
+    # And indented comments
 ENCRYPT_METHOD  SHA512
 MD5_CRYPT_ENAB  no
       EOM
@@ -36,6 +49,11 @@ MD5_CRYPT_ENAB  no
       File.expects(:readable?).with('/etc/login.defs').returns(true)
       File.expects(:read).with('/etc/login.defs').returns(login_defs_content)
 
+      # This resets the stubbing code in Mocha to ensure that the code does not
+      # try to catch any other calls to the stubbed methods above.
+      #
+      # This is not documented well and is almost always what you want in
+      # Puppet testing
       File.stubs(:exist?).with(Not(equals('/etc/login.defs')))
       File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
       File.stubs(:read).with(Not(equals('/etc/login.defs')))
@@ -73,10 +91,7 @@ MD5_CRYPT_ENAB  no
       File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
       File.stubs(:read).with(Not(equals('/etc/login.defs')))
 
-      expect(Facter.fact('login_defs').value).to eq({
-        'uid_min' => 1000,
-        'gid_min' => 1000
-      })
+      expect(Facter.fact('login_defs').value).to eq({ })
     end
   end
 end


### PR DESCRIPTION
Returns a structured fact for the entire contents of /etc/login.defs
and defaults to returning 'uid_min' and 'gid_min' if they are not
present in the file

SIMP-3892 #comment add login_defs structured fact for use by other modules