### PR TITLE
(SIMP-4214) simplib: Create ipa fact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ jobs:
         - bundle exec rake check:test_file
         - bundle exec rake pkg:check_version
         - bundle exec rake metadata_lint
-        - bundle exec rake compare_latest_tag
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
 
     - stage: spec
       rvm: 2.1.9

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 * Wed Jan 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 3.9.0-0
 - Add an 'ipa' fact that provides the IPA domain and server to which
-  a host is connected, when the host is joined to the IPA domain
-  AND is able to communicate with the IPA server.
+  a host is connected, when the host is joined to the IPA domain.
 
 * Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.0-0
 - Added a 'login_defs' structured fact that returns a hash of all values in

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.0-0
+* Wed Jan 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 3.9.0-0
+- Add an 'ipa' fact that provides the IPA domain and server to which
+  a host is connected, when the host is joined to the IPA domain
+  AND is able to communicate with the IPA server.
+
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.0-0
 - Added a 'login_defs' structured fact that returns a hash of all values in
   '/etc/login.defs' with a default 'uid_min' and 'gid_min'
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 4.0', '< 6.0'])
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,13 @@ require 'simp/rake/pupmod/helpers'
 require 'puppet-strings/tasks'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
+
+# Standard 'acceptance' Rake task does not work, because it does not
+# use the suite-specific nodeset YAML files. 
+desc 'Run acceptance tests'
+Rake::Task[:acceptance].clear
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  Rake::Task['beaker:suites'].invoke
+end
+
+

--- a/lib/facter/ipa.rb
+++ b/lib/facter/ipa.rb
@@ -1,0 +1,71 @@
+# _Description_
+#
+# Return a hash of IPA information:
+# * status:
+#   - 'joined' when the host is able to pull both the domain and IPA
+#      server information from an IPA server
+#   - 'unknown' when the host is not able to pull both the domain
+#     and server information from an IPA server
+# * domain: The IPA domain or nil, if the host is unable to pull the
+#   domain information from the IPA server
+# * server: The IPA server to which this host is connected or nil,
+#   if the host is unable to pull the server information from the
+#   IPA server
+#
+Facter.add(:ipa) do
+  confine :kernel => 'Linux'
+
+  kinit = Facter::Core::Execution.which('kinit')
+  confine { kinit }
+
+  ipa = Facter::Core::Execution.which('ipa')
+  confine { ipa }
+
+  # This file is only present if the host has, at some time,
+  # been joined to an IPA domain.  Its presence, however, is
+  # insufficient to tell us if the host is currently joined.
+  # A host can be unprovisioned by the IPA server and still
+  # retain this file.
+  confine { File.exist?('/etc/ipa/default.conf') }
+
+  setcode do
+    # Obtain host Kerberos token so we can use IPA API
+    kinit_msg = Facter::Core::Execution.exec("#{kinit} -k 2>&1")
+    if kinit_msg.nil? or !kinit_msg.strip.empty?
+      # Only messages emitted are error messages
+      ipa_fact = { 'status' => 'unknown', 'domain' => nil, 'server' => nil }
+    else
+      # Use IPA API to determine this host's IPA server
+      #
+      # TODO: Just use 'ipa env server', once support for el6 is dropped.
+      #       Unfortunately, this is not available on el6.
+      host = Facter::Core::Execution.exec("#{ipa} env host")
+      host = host.strip.split('host:')[1] unless host.nil?
+      unless host.nil? or host.strip.empty?
+        # 'ipa host-show' will prompt if no host is passed in...
+        host_info = Facter::Core::Execution.exec("#{ipa} host-show #{host.strip}").to_s
+        managed_line = host_info.split("\n").delete_if {
+          |line| !line.include?('Managed by:')
+        }
+        server = managed_line.empty? ? nil : managed_line[0].strip.split('Managed by:')[1]
+        server = nil if (server and server.strip.empty?)
+      end
+
+      # Use IPA API to retrieve domain from the client environment
+      domain = Facter::Core::Execution.exec("#{ipa} env domain")
+      domain = domain.strip.split('domain:')[1] unless domain.nil?
+      domain = nil if (domain and domain.strip.empty?)
+
+      if domain.nil? or server.nil?
+        status = 'unknown'
+      else
+        status = 'joined'
+      end
+      domain.strip! unless domain.nil?
+      server.strip! unless server.nil?
+      ipa_fact = { 'status' => status, 'domain' => domain, 'server' => server }
+    end
+
+    ipa_fact
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.10.0",
+  "version": "3.9.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper_acceptance'
+
+test_name 'ipa fact'
+
+describe 'ipa fact' do
+  let (:manifest) {
+    <<-EOS
+      $ipa_value = $facts['ipa']
+      simplib::inspect('ipa_value', 'oneline_json')
+    EOS
+  }
+
+  servers = hosts_with_role(hosts, 'server')
+  servers.each do |server|
+    context 'when IPA is not installed' do
+      it 'ipa fact should be nil' do
+        results = apply_manifest_on(server, manifest)
+        expect(results.output).to match(/Notice: Type => NilClass Content => null/)
+        results = on(server, 'puppet facts')
+        expect(results.output).to_not match(/"ipa": {/)
+      end
+    end
+
+    context 'when IPA is installed, but host has not yet joined IPA domain' do
+      it 'ipa fact should be nil because /etc/ipa/default.conf does not exist' do
+        install_package(server, 'ipa-server')
+
+        results = apply_manifest_on(server, manifest)
+        expect(results.output).to match(/Notice: Type => NilClass Content => null/)
+        results = on(server, 'puppet facts')
+        expect(results.output).to_not match(/"ipa": {/)
+      end
+    end
+
+    context 'when IPA is installed and host has joined IPA domain' do
+      it 'ipa fact should contain domain and IPA server' do
+        # ipa-server-install installs both the IPA server and client.
+        # The fact uses the client env.
+        fqdn = on(server,'facter fqdn').output.strip
+        cmd = [
+          'ipa-server-install',
+          # IPA realm and domain do not have to match hostname
+          "--domain #{server.name.downcase}.example.com",
+          "--realm #{server.name.upcase}.EXAMPLE.COM",
+          "--hostname #{fqdn}",
+          '--ds-password d1r3ct0ry=P@ssw0r!',
+          '--admin-password @dm1n=P@ssw0r!',
+          '--unattended'
+        ]
+        puts "\e[1;34m>>>>> The next step takes a very long time ... Please be patient! \e[0m"
+        on(server, cmd.join(' '))
+        on(server, 'ipactl status')
+
+        results = apply_manifest_on(server, manifest)
+        expect(results.output).to match(/Notice: Type => Hash Content => {"status":"joined","domain":"#{server.name.downcase}.example.com","server":"#{fqdn}"}/)
+        results = on(server, 'puppet facts')
+        expect(results.output).to match(/"ipa": {/)
+      end
+
+      it 'ipa fact should have unknown status when connection to IPA server is down' do
+        # stop IPA server
+        on(server, 'ipactl stop')
+
+        results = apply_manifest_on(server, manifest)
+        expect(results.output).to match(/Notice: Type => Hash Content => {"status":"unknown","domain":"","server":""}/)
+        results = on(server, 'puppet facts')
+        expect(results.output).to match(/"ipa": {/)
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -35,6 +35,11 @@ describe 'ipa fact' do
     context 'when IPA is installed and host has joined IPA domain' do
       let(:ipa_domain) { "#{server.name.downcase}.example.com" }
       it 'ipa fact should contain domain and IPA server' do
+        # IPA requires entropy, so use haveged service
+        on(server, 'puppet resource package epel-release ensure=present')
+        on(server, 'puppet resource package haveged ensure=present')
+        on(server, 'puppet resource service haveged ensure=running enable=true')
+
         # ipa-server-install installs both the IPA server and client.
         # The fact uses the client env.
         fqdn = on(server,'facter fqdn').output.strip

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -33,6 +33,7 @@ describe 'ipa fact' do
     end
 
     context 'when IPA is installed and host has joined IPA domain' do
+      let(:ipa_domain) { "#{server.name.downcase}.example.com" }
       it 'ipa fact should contain domain and IPA server' do
         # ipa-server-install installs both the IPA server and client.
         # The fact uses the client env.
@@ -52,7 +53,7 @@ describe 'ipa fact' do
         on(server, 'ipactl status')
 
         results = apply_manifest_on(server, manifest)
-        expect(results.output).to match(/Notice: Type => Hash Content => {"status":"joined","domain":"#{server.name.downcase}.example.com","server":"#{fqdn}"}/)
+        expect(results.output).to match(/Notice: Type => Hash Content => {"default_domain":"#{ipa_domain}","default_server":"#{fqdn}","status":"joined","domain":"#{ipa_domain}","server":"#{fqdn}"}/)
         results = on(server, 'puppet facts')
         expect(results.output).to match(/"ipa": {/)
       end
@@ -61,8 +62,9 @@ describe 'ipa fact' do
         # stop IPA server
         on(server, 'ipactl stop')
 
+        fqdn = on(server,'facter fqdn').output.strip
         results = apply_manifest_on(server, manifest)
-        expect(results.output).to match(/Notice: Type => Hash Content => {"status":"unknown","domain":"","server":""}/)
+        expect(results.output).to match(/Notice: Type => Hash Content => {"default_domain":"#{ipa_domain}","default_server":"#{fqdn}","status":"unknown","domain":"","server":""}/)
         results = on(server, 'puppet facts')
         expect(results.output).to match(/"ipa": {/)
       end

--- a/spec/acceptance/suites/ipa_fact/metadata.yml
+++ b/spec/acceptance/suites/ipa_fact/metadata.yml
@@ -1,0 +1,2 @@
+---
+'default_run' : true

--- a/spec/acceptance/suites/ipa_fact/nodesets/default.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/default.yml
@@ -1,0 +1,22 @@
+HOSTS:
+  el7:
+    roles:
+      - server
+    masterless: true
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+  el6:
+    roles:
+      - server
+    masterless: true
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type:      aio
+  # IPA needs more resources than those used in a typical module acceptance test
+  vagrant_memsize: 2048
+  vagrant_cpus: 2
+  ## vb_gui: true

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -42,7 +42,6 @@ EOM
     it 'should return hash with joined status, IPA domain and IPA server' do
       Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
       Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-#File.expects(:exist?).with('/home/enemsick/.rvm/gems/ruby-2.1.9/gems/byebug-9.0.6/bin/byebug').returns(true)
       File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
       IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
       Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+
+describe "custom fact ipa" do
+  let (:host_info) { <<EOM
+  Host name: client.example.com
+  Principal name: host/client.example.com@EXAMPLE.COM
+  Principal alias: host/client.example.com@EXAMPLE.COM
+  SSH public key fingerprint: SHA256:m8TatOcxcXkhtd80EQjJUJG2zYUctl1EkoroadusTeU (ssh-rsa),
+                              SHA256:XI7tRHoZuQJ7nc63t0hlVaQ0sP/RJcvMmMAt83jwVzE (ecdsa-sha2-nistp256),
+                              SHA256:PmgNsbCMj40etrpL+f5lLnDGLWpwkvb/s7RmYTKQKfE (ssh-ed25519)
+  Password: False
+  Keytab: True
+  Managed by: ipaserver.example.com
+EOM
+  }
+
+  before(:each) do
+    Facter.clear
+
+    # mock out Facter method called when evaluating confine for :kernel
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+  end
+
+  context 'host is joined to IPA domain and can communicate with IPA server' do
+    it 'should return hash with joined status, IPA domain and IPA server' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com\n")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'joined',
+        'domain' => 'example.com',
+        'server' => 'ipaserver.example.com'
+      })
+    end
+  end
+
+  context 'kinit executable is not available' do
+    it 'should return nil' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns(nil)
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+
+      expect(Facter.fact('ipa').value).to be nil
+    end
+  end
+
+  context 'ipa executable is not available' do
+    it 'should return nil' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns(nil)
+
+      expect(Facter.fact('ipa').value).to be nil
+    end
+  end
+
+  context '/etc/ipa/default.conf is not available' do
+    it 'should return nil' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(false)
+
+      expect(Facter.fact('ipa').value).to be nil
+    end
+  end
+
+  context 'kinit fails' do
+    it "should return hash of unknown status and nil IPA domain and server if 'kinit' returns nil" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns(nil)
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => nil,
+        'server' => nil
+      })
+    end
+
+    it "should return hash with unknown status and nil IPA domain and server if 'kinit' fails" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      err_msg = "kinit: Cannot contact any KDC for realm 'EXAMPLE.COM' while getting initial credentials"
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns(err_msg)
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => nil,
+        'server' => nil
+      })
+    end
+  end
+
+  context 'ipa server is not available from the IPA client environment' do
+    it "should return hash with unknown status and nil server if exec of 'ipa env host' returns nil" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns(nil)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => 'example.com',
+        'server' => nil
+      })
+    end
+
+    it "should return hash with unknown status and nil server if exec of 'ipa env host' is empty" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => 'example.com',
+        'server' => nil
+      })
+    end
+
+    it "should return hash with unknown status and nil server if 'ipa host-show' fails" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(nil)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => 'example.com',
+        'server' => nil
+      })
+    end
+
+    it "should return hash with unknown status and nil server if 'ipa host-show' does not have 'Managed by:' line" do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => 'example.com',
+        'server' => nil
+      })
+    end
+  end
+
+  context 'when ipa domain is not available from the IPA client environment' do
+    it 'should return hash with unknown status and nil domain if domain is nil' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns(nil)
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => nil,
+        'server' => 'ipaserver.example.com'
+      })
+    end
+
+    it 'should return hash with unknown status and nil domain if domain is empty' do
+      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("\n")
+
+      expect(Facter.fact('ipa').value).to eq({
+        'status' => 'unknown',
+        'domain' => nil,
+        'server' => 'ipaserver.example.com'
+      })
+    end
+  end
+end


### PR DESCRIPTION
Created ipa fact that provides the IPA domain and server to which
a host is connected, when the host is joined to the IPA domain
AND is able to communicate with the IPA server.

As written, this fact cannot to distinguish between the following cases:

* No connectivity to the IPA server when joined to an IPA domain.
* The host is no longer joined to an IPA domain.

Addressing this deficiency is not trivial and will need to be done
in a follow-on ticket.

NOTE: At first blush, it seems like the fact could have been written
to pull information locally from the IPA configuration file,
/etc/ipa/default.conf.  However, the information in this file is not
definitive. Specifically, if the client has been removed from the IPA
domain using the IPA server GUI instead of running the IPA client
uninstall, this file will still exist but be inapplicable.

SIMP-4214 #close
SIMP-4215 #close
SIMP-4162 #comment code, unit, and acceptance test