### PR TITLE
(SIMP-4264) simplib: Refine ipa fact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10.1')
 end

--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10.1')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end

--- a/lib/facter/ipa.rb
+++ b/lib/facter/ipa.rb
@@ -1,23 +1,16 @@
 # _Description_
 #
 # Return a hash of IPA information:
-# * status:
-#   - 'joined' when the host is able to pull both the domain and IPA
-#      server information from an IPA server
-#   - 'unknown' when the host is not able to pull both the domain
-#     and server information from an IPA server.  This status can
-#     occur when connectivity to the IPA server is down or the
-#     host has been unprovisioned at the IPA server and thus is
-#     no longer joined to the configured IPA domain.
-# * domain: The IPA domain or nil, if the host is unable to pull the
-#   domain information from the IPA server
-# * server: The IPA server to which this host is connected or nil,
-#   if the host is unable to pull the server information from the
-#   IPA server
-# * default_domain:  The configured IPA domain from the domain setting
-#     in /etc/ipa/default.conf.
-# * default_server:  The nominal, configured IPA server extracted from
-#     the xmlrpc_uri setting in /etc/ipa/default.conf.
+# * connectd: Boolean value based on whether or not an IPA server could be reached
+#
+# * domain: The IPA domain for which this host is configured
+#
+# * server: The IPA server for which this host is configured
+#
+# * realm: The Kerberos realm for the host
+#
+# * tls_ca_cert: The location of the IPA server's TLS CA Certificate if the
+#     system is an IPA server
 #
 Facter.add(:ipa) do
   confine :kernel => 'Linux'
@@ -29,65 +22,64 @@ Facter.add(:ipa) do
   confine { ipa }
 
   # This file is only present if the host has, at some time,
-  # been joined to an IPA domain.  Its presence, however, is
-  # insufficient to tell us if the host is currently joined.
-  # A host can be unprovisioned by the IPA server and still
-  # retain this file.
+  # been joined to an IPA domain.
   confine { File.exist?('/etc/ipa/default.conf') }
 
   setcode do
-    ipa_fact = {}
-    defaults = IO.readlines('/etc/ipa/default.conf')
-    defaults.each do |line|
-      domain_match = line.match(/^domain\s*=\s*(\S*)/)
-      if domain_match
-        ipa_fact['default_domain'] = domain_match[1]
-      end
+    needed_keys = [
+      'domain',
+      'server',
+      'realm',
+      'basedn',
+      'tls_ca_cert'
+    ]
 
-      server_match = line.match(/^xmlrpc_uri\s*=\s*http[s]?:\/\/(\S*)\/ipa\/xml/)
-      if server_match
-        ipa_fact['default_server'] = server_match[1]
-      end
-      break if ipa_fact['default_domain'] and ipa_fact['default_server']
+    file_defaults = File.read('/etc/ipa/default.conf').lines.
+      map(&:strip).
+      map{ |x|
+        x.split(/\s*=\s*(.*)/)
+      }.delete_if{|x|
+        x.size < 2
+      }.flatten
+
+    defaults = Hash[*file_defaults]
+
+    defaults.delete_if { |k,v| !needed_keys.include?(k) }
+
+    # We won't know if we are connected to a server until later
+    defaults['connected'] = false
+
+    # Grab the necessary information from 'ipa env'
+    ipa_response = Facter::Core::Execution.exec("#{ipa} env #{needed_keys.join(' ')}")
+
+    unless $?.success?
+      # Obtain host Kerberos token so we can use IPA API
+      kinit_msg = Facter::Core::Execution.exec("#{kinit} -k 2>&1")
+      ipa_response = Facter::Core::Execution.exec("#{ipa} env #{needed_keys.join(' ')}")
     end
 
-    # Obtain host Kerberos token so we can use IPA API
-    kinit_msg = Facter::Core::Execution.exec("#{kinit} -k 2>&1")
-    if kinit_msg.nil? or !kinit_msg.strip.empty?
-      # Only messages emitted are error messages
-      ipa_fact.merge!({ 'status' => 'unknown', 'domain' => nil, 'server' => nil })
+    if ipa_response.strip.empty?
+      ipa_response = {}
     else
-      # Use IPA API to determine this host's IPA server
-      #
-      # TODO: Just use 'ipa env server', once support for el6 is dropped.
-      #       Unfortunately, this is not available on el6.
-      host = Facter::Core::Execution.exec("#{ipa} env host")
-      host = host.strip.split('host:')[1] unless host.nil?
-      unless host.nil? or host.strip.empty?
-        # 'ipa host-show' will prompt if no host is passed in...
-        host_info = Facter::Core::Execution.exec("#{ipa} host-show #{host.strip}").to_s
-        managed_line = host_info.split("\n").delete_if {
-          |line| !line.include?('Managed by:')
-        }
-        server = managed_line.empty? ? nil : managed_line[0].strip.split('Managed by:')[1]
-        server = nil if (server and server.strip.empty?)
-      end
+      Facter::Core::Execution.exec("#{ipa} env --server host")
 
-      # Use IPA API to retrieve domain from the client environment
-      domain = Facter::Core::Execution.exec("#{ipa} env domain")
-      domain = domain.strip.split('domain:')[1] unless domain.nil?
-      domain = nil if (domain and domain.strip.empty?)
+      defaults['connected'] = $?.success?
 
-      if domain.nil? or server.nil?
-        status = 'unknown'
-      else
-        status = 'joined'
+      ipa_response = ipa_response.lines.grep(/\S:\s*.+/).map(&:strip).
+        map{ |x|
+          x.split(/:\s+(.*)/)
+        }.flatten
+
+      ipa_response = Hash[*ipa_response]
+
+      ipa_response.keys.each do |key|
+        # Some patch up work for EL6
+        if key =~ /^<(.+)>$/
+          ipa_response[$1] = ipa_response.delete(key)
+        end
       end
-      domain.strip! unless domain.nil?
-      server.strip! unless server.nil?
-      ipa_fact.merge!({ 'status' => status, 'domain' => domain, 'server' => server })
     end
 
-    ipa_fact
+    defaults.merge(ipa_response)
   end
 end

--- a/lib/facter/ipa.rb
+++ b/lib/facter/ipa.rb
@@ -1,6 +1,6 @@
 # _Description_
 #
-# Return a hash of IPA information:
+# Return a hash of IPA information, when the host has joined an IPA domain:
 # * connected: Boolean value based on whether or not an IPA server
 #     could be reached
 #
@@ -14,6 +14,8 @@
 #
 # * tls_ca_cert: The location of the IPA server's TLS CA Certificate if
 #     the system is an IPA server
+#
+# Returns nil otherwise
 #
 Facter.add(:ipa) do
   confine :kernel => 'Linux'

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -12,6 +12,11 @@ describe 'ipa fact' do
 
   servers = hosts_with_role(hosts, 'server')
   servers.each do |server|
+    # Skip EL6 if FIPS is enabled
+    # IPA server on EL6 doens't support EL6, only EL7.4+
+    # See https://www.freeipa.org/page/Releases/4.5.0#FIPS_140-2_Support
+    next if (ENV['BEAKER_fips'] && server.platform == 'el-6-x86_64')
+
     context 'when IPA is not installed' do
       it 'ipa fact should be nil' do
         results = apply_manifest_on(server, manifest)

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -2,17 +2,6 @@ require 'spec_helper_acceptance'
 
 test_name 'ipa fact'
 
-# Logic to handle all of the cases where we *know* IPA works in FIPS mode
-def works_with_fips?(os, version)
-  if ['RedHat', 'CentOS'].include?(os)
-    if Gem::Version.new(version) >= Gem::Version.new('7.4')
-      return true
-    end
-  end
-
-  return false
-end
-
 describe 'ipa fact' do
   let (:manifest) {
     <<-EOS
@@ -21,22 +10,37 @@ describe 'ipa fact' do
     EOS
   }
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
-    # Skip any OS other than those that we know work with FIPS enabled
-    # See https://www.freeipa.org/page/Releases/4.5.0#FIPS_140-2_Support
-    fips_requested = (ENV['BEAKER_fips'] == 'yes' ? true : false)
+  admin_password = '@dm1n=P@ssw0r!'
+  ipa_domain = 'test.case'
+  ipa_realm = ipa_domain.upcase
 
-    if fips_requested
-      next unless works_with_fips?(fact_on(server, 'operatingsystem'), fact_on(server, 'operatingsystemrelease'))
+  hosts.each do |host|
+    it 'should be running haveged for entropy' do
+      # IPA requires entropy, so use haveged service
+      on(host, 'puppet resource package epel-release ensure=present')
+      on(host, 'puppet resource package haveged ensure=present')
+      on(host, 'puppet resource service haveged ensure=running enable=true')
+
+      # Install the IPA client on all hosts
+      on(host, 'puppet resource package ipa-client ensure=present')
+
+      # Admintools for EL6
+      on(host, 'puppet resource package ipa-admintools ensure=present', :accept_all_exit_codes => true)
+
+      # Ensure that the hostname is set to the FQDN
+      on(host, "hostname #{fact_on(host, 'fqdn')}")
     end
+  end
 
+  hosts_with_role(hosts, 'server').each do |server|
     context 'when IPA is not installed' do
       it 'ipa fact should be nil' do
         results = apply_manifest_on(server, manifest)
         expect(results.output).to match(/Notice: Type => NilClass Content => null/)
-        results = on(server, 'puppet facts')
-        expect(results.output).to_not match(/"ipa": {/)
+
+        results = JSON.load(on(server, 'puppet facts').output)
+
+        expect(results['values']['ipa']).to be_nil
       end
     end
 
@@ -46,51 +50,110 @@ describe 'ipa fact' do
 
         results = apply_manifest_on(server, manifest)
         expect(results.output).to match(/Notice: Type => NilClass Content => null/)
-        results = on(server, 'puppet facts')
-        expect(results.output).to_not match(/"ipa": {/)
+
+        results = JSON.load(on(server, 'puppet facts').output)
+
+        expect(results['values']['ipa']).to be_nil
       end
     end
 
     context 'when IPA is installed and host has joined IPA domain' do
       let(:ipa_domain) { "#{server.name.downcase}.example.com" }
       it 'ipa fact should contain domain and IPA server' do
-        # IPA requires entropy, so use haveged service
-        on(server, 'puppet resource package epel-release ensure=present')
-        on(server, 'puppet resource package haveged ensure=present')
-        on(server, 'puppet resource service haveged ensure=running enable=true')
-
         # ipa-server-install installs both the IPA server and client.
         # The fact uses the client env.
-        fqdn = on(server,'facter fqdn').output.strip
+        fqdn = fact_on(server, 'fqdn')
+
         cmd = [
           'ipa-server-install',
           # IPA realm and domain do not have to match hostname
-          "--domain #{server.name.downcase}.example.com",
-          "--realm #{server.name.upcase}.EXAMPLE.COM",
+          "--domain #{ipa_domain}",
+          "--realm #{ipa_realm}",
           "--hostname #{fqdn}",
-          '--ds-password d1r3ct0ry=P@ssw0r!',
-          '--admin-password @dm1n=P@ssw0r!',
+          '--ds-password "d1r3ct0ry=P@ssw0r!"',
+          "--admin-password '#{admin_password}'",
           '--unattended'
         ]
         puts "\e[1;34m>>>>> The next step takes a very long time ... Please be patient! \e[0m"
         on(server, cmd.join(' '))
         on(server, 'ipactl status')
 
-        results = apply_manifest_on(server, manifest)
-        expect(results.output).to match(/Notice: Type => Hash Content => {"default_domain":"#{ipa_domain}","default_server":"#{fqdn}","status":"joined","domain":"#{ipa_domain}","server":"#{fqdn}"}/)
-        results = on(server, 'puppet facts')
-        expect(results.output).to match(/"ipa": {/)
+        # We only care about this data
+        expect(apply_manifest_on(server, manifest).output).to match(/Hash Content => {"/)
+
+        results = JSON.load(on(server, 'puppet facts').output)
+
+        expect(results['values']['ipa']).to_not be_nil
+        expect(results['values']['ipa']['connected']).to eq true
+        expect(results['values']['ipa']['server']).to eq fqdn
+        expect(results['values']['ipa']['domain']).to eq ipa_domain
+        expect(results['values']['ipa']['realm']).to eq ipa_realm
       end
 
       it 'ipa fact should have unknown status when connection to IPA server is down' do
         # stop IPA server
         on(server, 'ipactl stop')
 
-        fqdn = on(server,'facter fqdn').output.strip
-        results = apply_manifest_on(server, manifest)
-        expect(results.output).to match(/Notice: Type => Hash Content => {"default_domain":"#{ipa_domain}","default_server":"#{fqdn}","status":"unknown","domain":"","server":""}/)
-        results = on(server, 'puppet facts')
-        expect(results.output).to match(/"ipa": {/)
+        results = JSON.load(on(server, 'puppet facts').output)
+
+        expect(results['values']['ipa']).to_not be_nil
+        expect(results['values']['ipa']['connected']).to eq false
+      end
+
+      it 'should restart the IPA server for further tests' do
+        on(server, 'ipactl start')
+      end
+    end
+  end
+
+  hosts_with_role(hosts, 'client').each do |client|
+    context 'as an IPA client' do
+
+      context 'prior to registration' do
+        it 'should not have an IPA fact' do
+          results = JSON.load(on(client, 'puppet facts').output)
+
+          expect(results['values']['ipa']).to be_nil
+        end
+      end
+
+      context 'after registration' do
+        let(:ipa_server) {
+          fact_on(hosts_with_role(hosts, 'server').first, 'fqdn')
+        }
+
+        it 'should register with the IPA server' do
+          ipa_command = [
+            # Unattended installation
+            'ipa-client-install -U',
+            # IPA directory domain
+            "--domain=#{ipa_domain}",
+            # IPA server to use
+            "--server=#{ipa_server}",
+            # Only point at this server and don't use SRV
+            '--fixed-primary',
+            # IPA krb5 realm
+            "--realm=#{ipa_realm}",
+            # Krb5 principal name to use
+            '--principal=admin',
+            # Admin password
+            "--password='#{admin_password}'",
+            # Don't update using authconfig
+            '--noac'
+          ].join(' ')
+
+          on(client, ipa_command)
+        end
+
+        it 'should have the IPA fact populated' do
+          results = JSON.load(on(client, 'puppet facts').output)
+
+          expect(results['values']['ipa']).to_not be_nil
+          expect(results['values']['ipa']['connected']).to eq true
+          expect(results['values']['ipa']['server']).to eq ipa_server
+          expect(results['values']['ipa']['domain']).to eq ipa_domain
+          expect(results['values']['ipa']['realm']).to eq ipa_realm
+        end
       end
     end
   end

--- a/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
+++ b/spec/acceptance/suites/ipa_fact/ipa_fact_spec.rb
@@ -154,6 +154,24 @@ describe 'ipa fact' do
           expect(results['values']['ipa']['domain']).to eq ipa_domain
           expect(results['values']['ipa']['realm']).to eq ipa_realm
         end
+
+        it 'ipa fact should have unknown status when connection to IPA server is down' do
+          # stop IPA server
+          hosts_with_role(hosts, 'server').each do |server|
+            on(server, 'ipactl stop')
+          end
+
+          results = JSON.load(on(client, 'puppet facts').output)
+
+          expect(results['values']['ipa']).to_not be_nil
+          expect(results['values']['ipa']['connected']).to eq false
+        end
+
+        it 'should restart the IPA server for further tests' do
+          hosts_with_role(hosts, 'server').each do |server|
+            on(server, 'ipactl start')
+          end
+        end
       end
     end
   end

--- a/spec/acceptance/suites/ipa_fact/nodesets/default.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/default.yml
@@ -9,6 +9,7 @@ HOSTS:
     # IPA needs more resources than those used in a typical module acceptance test
     vagrant_memsize: 2048
     vagrant_cpus: 2
+
   el7-client:
     roles:
       - client
@@ -16,9 +17,11 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: vagrant
-  el6:
+
+  el6-client:
     roles:
       - client
+      - no_fips
     masterless: true
     platform:   el-6-x86_64
     box:        centos/6

--- a/spec/acceptance/suites/ipa_fact/nodesets/default.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/default.yml
@@ -6,6 +6,16 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: vagrant
+    # IPA needs more resources than those used in a typical module acceptance test
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+  el7-client:
+    roles:
+      - client
+    masterless: true
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
   el6:
     roles:
       - client
@@ -16,7 +26,5 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  # IPA needs more resources than those used in a typical module acceptance test
-  vagrant_memsize: 2048
-  vagrant_cpus: 2
-  ## vb_gui: true
+  vagrant_memsize: 256
+  vagrant_cpus: 1

--- a/spec/acceptance/suites/ipa_fact/nodesets/default.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/default.yml
@@ -8,7 +8,7 @@ HOSTS:
     hypervisor: vagrant
   el6:
     roles:
-      - server
+      - client
     masterless: true
     platform:   el-6-x86_64
     box:        centos/6

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -3,32 +3,28 @@ require 'spec_helper'
 describe "custom fact ipa" do
   let (:default_conf) {
     [
-      "host = client.example.com\n",
-      "basedn = dc=example,dc=com\n",
-      "realm = EXAMPLE.COM\n",
+      'host = client.example.com',
+      'basedn = dc=example,dc=com',
+      'realm = EXAMPLE.COM',
       # In next 2 config lines, artificially prepend domain and IPA
       # server with 'default.' so we can validate parsing.
-      "domain = default.example.com\n",
-      "xmlrpc_uri = https://default.ipaserver.example.com/ipa/xml\n",
-      "ldap_uri = ldapi://%2fvar%2frun%2fslapd-EXAMPLE-COM.socket\n",
-      "enable_ra = True\n",
-      "ra_plugin = dogtag\n",
-      "dogtag_version = 10\n",
-      "mode = production\n"
-    ]
+      'domain = default.example.com',
+      'xmlrpc_uri = https://default.ipaserver.example.com/ipa/xml',
+      'ldap_uri = ldapi://%2fvar%2frun%2fslapd-EXAMPLE-COM.socket',
+      'enable_ra = True',
+      'ra_plugin = dogtag',
+      'dogtag_version = 10',
+      'mode = production'
+    ].join("\n")
   }
 
-  let (:host_info) { <<EOM
-  Host name: client.example.com
-  Principal name: host/client.example.com@EXAMPLE.COM
-  Principal alias: host/client.example.com@EXAMPLE.COM
-  SSH public key fingerprint: SHA256:m8TatOcxcXkhtd80EQjJUJG2zYUctl1EkoroadusTeU (ssh-rsa),
-                              SHA256:XI7tRHoZuQJ7nc63t0hlVaQ0sP/RJcvMmMAt83jwVzE (ecdsa-sha2-nistp256),
-                              SHA256:PmgNsbCMj40etrpL+f5lLnDGLWpwkvb/s7RmYTKQKfE (ssh-ed25519)
-  Password: False
-  Keytab: True
-  Managed by: ipaserver.example.com
-EOM
+  let (:ipa_env) {
+    [
+      '  domain: example.com',
+      '  server: ipaserver.example.com',
+      '  realm:  EXAMPLE.COM',
+      '  basedn: dc=example,dc=com'
+    ].join("\n")
   }
 
   before(:each) do
@@ -38,27 +34,51 @@ EOM
     Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
   end
 
-  context 'host is joined to IPA domain and can communicate with IPA server' do
-    it 'should return hash with joined status, IPA domain and IPA server' do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com\n")
+  context 'host is joined to IPA domain' do
+    context 'IPA server is available' do
+      it 'should return hash with joined status, IPA domain and IPA server' do
+        Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+        Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+        File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+        File.expects(:read).with('/etc/ipa/default.conf').returns(default_conf)
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env --server host').returns("  host: ipaserver.example.com\n")
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain server realm basedn tls_ca_cert').returns(ipa_env)
 
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'joined',
-        'domain' => 'example.com',
-        'server' => 'ipaserver.example.com'
-      })
+        expect(Facter.fact('ipa').value).to eq({
+          'connected' => true,
+          'domain'    => 'example.com',
+          'server'    => 'ipaserver.example.com',
+          'realm'     => 'EXAMPLE.COM',
+          'basedn'    => 'dc=example,dc=com'
+        })
+      end
     end
-  end
 
+=begin
+    context 'IPA server is not available' do
+      it 'should return hash with joined status, IPA domain and IPA server' do
+        Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
+        Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
+        File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
+        IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env --server host').returns('')
+        Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain server realm basedn tls_ca_cert').returns(ipa_env)
+
+        expect(Facter.fact('ipa').value).to eq({
+          'connected' => false,
+          'domain'    => 'example.com',
+          'server'    => 'ipaserver.example.com',
+          'realm'     => 'EXAMPLE.COM',
+          'basedn'    => 'dc=example,dc=com'
+        })
+      end
+    end
+=end
+  end
+=begin
   context 'kinit executable is not available' do
     it 'should return nil' do
       Facter::Core::Execution.expects(:which).with('kinit').returns(nil)
@@ -85,156 +105,42 @@ EOM
 
       expect(Facter.fact('ipa').value).to be nil
     end
-  end
 
-  context 'kinit fails' do
-    it "should return hash of unknown status and nil IPA domain and server if 'kinit' returns nil" do
+    context 'the IPA server is available' do
       Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
       Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns(nil)
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => nil,
-        'server' => nil
-      })
-    end
-
-    it "should return hash with unknown status and nil IPA domain and server if 'kinit' fails" do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      err_msg = "kinit: Cannot contact any KDC for realm 'EXAMPLE.COM' while getting initial credentials"
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns(err_msg)
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => nil,
-        'server' => nil
-      })
-    end
-  end
-
-  context 'ipa server is not available from the IPA client environment' do
-    it "should return hash with unknown status and nil server if exec of 'ipa env host' returns nil" do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns(nil)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => 'example.com',
-        'server' => nil
-      })
-    end
-
-    it "should return hash with unknown status and nil server if exec of 'ipa env host' is empty" do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => 'example.com',
-        'server' => nil
-      })
-    end
-
-    it "should return hash with unknown status and nil server if 'ipa host-show' fails" do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(false)
       Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
       Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(nil)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env --server host').returns("  host: ipaserver.example.com\n")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain server realm basedn tls_ca_cert').returns(ipa_env)
 
       expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => 'example.com',
-        'server' => nil
+        'connected' => true,
+        'domain'    => 'example.com',
+        'server'    => 'ipaserver.example.com',
+        'realm'     => 'EXAMPLE.COM',
+        'basedn'    => 'dc=example,dc=com'
       })
     end
 
-    it "should return hash with unknown status and nil server if 'ipa host-show' does not have 'Managed by:' line" do
+    context 'the IPA server is not available' do
       Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
       Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
+      File.expects(:exist?).with('/etc/ipa/default.conf').returns(false)
       Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
       Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("  domain: example.com")
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env --server host').returns('')
+      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain server realm basedn tls_ca_cert').returns(ipa_env)
 
       expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => 'example.com',
-        'server' => nil
+        'connected' => false,
+        'domain'    => 'example.com',
+        'server'    => 'ipaserver.example.com',
+        'realm'     => 'EXAMPLE.COM',
+        'basedn'    => 'dc=example,dc=com'
       })
     end
   end
-
-  context 'when ipa domain is not available from the IPA client environment' do
-    it 'should return hash with unknown status and nil domain if domain is nil' do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns(nil)
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => nil,
-        'server' => 'ipaserver.example.com'
-      })
-    end
-
-    it 'should return hash with unknown status and nil domain if domain is empty' do
-      Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-      Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-      File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-      IO.expects(:readlines).with('/etc/ipa/default.conf').returns(default_conf)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/kinit -k 2>&1').returns('')
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env host').returns("  host: client.example.com\n")
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa host-show client.example.com').returns(host_info)
-      Facter::Core::Execution.expects(:exec).with('/usr/bin/ipa env domain').returns("\n")
-
-      expect(Facter.fact('ipa').value).to eq({
-        'default_domain' => 'default.example.com',
-        'default_server' => 'default.ipaserver.example.com',
-        'status' => 'unknown',
-        'domain' => nil,
-        'server' => 'ipaserver.example.com'
-      })
-    end
-  end
+=end
 end


### PR DESCRIPTION
The IPA server doesn't support FIPS mode on EL6, so that test should be
skipped in that scenario.

SIMP-4264 #comment work done
SIMP-4272 #close
SIMP-4327 #close Fix ipa fact