### PR TITLE
(SIMP-4266) Update domain_to_dn function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Jan 19 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.0-0
+- Updated the simplib::ldap::domain_to_dn function to allow users to choose
+  whether they want to upcase or downcase the LDAP attributes to work around
+  different system bugs
+
 * Mon Jan 15 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 3.9.0-0
 - Add a 'prelink' fact that indicates whether prelink has been enabled
 

--- a/functions/ldap/domain_to_dn.pp
+++ b/functions/ldap/domain_to_dn.pp
@@ -1,11 +1,25 @@
-# Provides a reasonable LDAP Base DN as generated from the ``domain`` fact
+# Provides a LDAP Base DN as generated from the ``domain`` fact
 #
 # @param domain
 #   The domain to convert
 #
+# @param downcase_attributes
+#   Whether or not to downcase the LDAP attributes
+#
+#     * Different tools have bugs where can can, or cannot, handle upcased (or
+#       downcased) LDAP attribute elements
+#
 # @return [String]
 function simplib::ldap::domain_to_dn (
-  String $domain = $facts['domain']
+  String $domain               = $facts['domain'],
+  Boolean $downcase_attributes = false
 ) {
-  join(split($domain,'\.').map |$x| { "DC=${x}" }, ',')
+  if $downcase_attributes {
+    $_dc = 'dc'
+  }
+  else {
+    $_dc = 'DC'
+  }
+
+  join(split($domain,'\.').map |$x| { "${_dc}=${x}" }, ',')
 }

--- a/spec/functions/ldap/domain_to_dn_spec.rb
+++ b/spec/functions/ldap/domain_to_dn_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'simplib::ldap::domain_to_dn' do
+  context 'with a regular domain' do
+    let(:facts) {{ :domain => 'test.domain' }}
+
+    it do
+      expect( subject.execute() ).to eq 'DC=test,DC=domain'
+    end
+  end
+
+  context 'with a short domain' do
+    let(:facts) {{ :domain => 'domain' }}
+
+    it do
+      expect( subject.execute() ).to eq 'DC=domain'
+    end
+  end
+
+  context 'when passed a domain' do
+    it do
+      expect( subject.execute('test.domain') ).to eq 'DC=test,DC=domain'
+    end
+  end
+
+  context 'when told to downcase the attributes' do
+    it do
+      expect( subject.execute('test.domain', true) ).to eq 'dc=test,dc=domain'
+    end
+  end
+end


### PR DESCRIPTION
* Added an option to simplib::ldap::domain_to_dn to allow users to
  choose whether or not they want to upcase the LDAP attribute strings.
  This allows users to work around bugs in various client applications
  as necessary

SIMP-4266 #comment Fixed issue discovered in setting up Dogtag