### PR TITLE
(SIMP-4262) Update the simplib README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
     * [Beginning with simplib](#beginning-with-simplib)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-    * [Stages](#stages)
     * [Facts](#facts)
     * [Functions](#functions)
     * [Puppet Extensions](#puppet-extensions)
     * [Puppet 3 Functions](#puppet-3-functions)
     * [Types](#types)
     * [Data Types](#data-types)
+    * [Stages](#stages)
 6. [Development - Guide for contributing to the module](#development)
 
 ## This is a SIMP module
@@ -34,26 +34,27 @@ If you find any issues, they can be submitted to our
 
 *simp/simplib* provides a standard library of resources for SIMP modules. It adds the following
 resources to Puppet:
-  * Stages
+
   * Data Types
   * Custom Types and Providers
   * Facts
   * Functions
   * Puppet Extensions
-  * Puppet 3 Functions (deprecated functions that will be removed in the near future)
+  * Puppet 3 Functions
+  * Stages
 
 ## Setup
 
 ### What simplib affects
 
-simplib contains functions, facts, and small utility classes.
+simplib contains data types, custom types and providers, facts, functions, and a class
+that expands Puppet Stdlib stages.
 
 ### Setup Requirements
 
 Agents will need to enable `pluginsync`.
 
 ## Usage
-
 
 Please see [reference](#reference) for usage.
 
@@ -66,131 +67,131 @@ A list of things provided by simplib is below.
 Please reference the `doc/` directory in the top level of the repo or the code
 itself for more detailed documentation.
 
-### Stages
-
- simplib::stages are added to ensure that anyone using the stdlib stages are not
- tripped up by any simp modules that may enable, or disable, various system,
- components; particularly ones that require a reboot.
-
- Added Stages:
-
-   * ``simp_prep`` -> Comes before stdlib's ``setup``
-   * ``simp_finalize`` -> Comes after stdlib's ``deploy``
-
 ### Facts
 
   * **acpid_enabled**        -  Return true if ACPI is available on the system
   * **boot_dir_uuid**        -  Return the UUID of the partition holding the
-   boot directory
+                                boot directory
   * **cmdline**              -  Returns the contents of `/proc/cmdline` as a
-   hash
+                                hash
   * **cpuinfo**              -  Returns the contents of `/proc/cpuinfo` as a
-   hash
+                                hash
   * **defaultgateway**       -  Return the default gateway of the system
   * **defaultgatewayiface**  -  Return the default gw interface of the system
   * **fips_ciphers**         -  Returns a list of available OpenSSL ciphers
-  * **fips_enabled**         -  Determine whether or not FIPS is enabled on
-   this system
-  * **fullrun**              -  Determine whether or not to do an intensive run
+  * **fips_enabled**         -  Determine whether FIPS is enabled on this system
+  * **fullrun**              -  Determine whether to do an intensive run
   * **gdm_version**          -  Return the version of GDM that is installed
   * **grub_version**         -  Return the grub version installed on the system
   * **init_systems**         -  Return a list of all init systems present on
    the system
   * **ipa**                  -  Return a hash containing the IPA domain and
-   server to which a host is connected
+                                server to which a host is connected
   * **ipv6_enabled**         -  Return true if IPv6 is enabled and false if not
   * **login_defs**           -  Return the contents of `/etc/login.defs` as a
-   hash with downcased keys
+                                hash with downcased keys
   * **prelink**              -  Returns a hash containing prelink status
   * **reboot_required**      -  Returns a hash of 'name' => 'reason' entries
   * **root_dir_uuid**        -  Return the UUID of the partition holding the
-   `/` directory
+                                `/` directory
   * **runlevel**             -  Return the current system runlevel
   * **shmall**               -  Return the value of shmall from sysctl
   * **simplib_sysctl**       -  Return hash of sysctl values that are relevant
-   to SIMP
+                                to SIMP
   * **simp_puppet_settings** -  Returns a hash of all Puppet settings on a node
   * **tmp_mounts**           -  This fact provides information about `/tmp`,
-  `/var/tmp`, and `/dev/shm` should they be present on the system
+                                `/var/tmp`, and `/dev/shm` should they be present
+                                on the system
   * **uid_min**              -  Return the minimum uid allowed
 
 ### Functions
 
-
-- [assert\_metadata](#simplibassert_metadata)
-- [deprecation](#simplibdeprecation)
-- [filtered](#simplibfiltered)
-- [gen\_random\_password](#simplibgen_random_password)
-- [ip\_to\_cron](#simplibip_to_cron)
-- [ipaddresses](#simplibipaddresses)
-- [join\_mount\_opts](#simplibjoin_mount_opts)
-- [knockout](#simplibknockout)
-- [ldap::domain\_to\_dn](#simplibldapdomain_to_dn)
-- [lookup](#simpliblookup)
-- [nets2cidr](#simplibnets2cidr)
-- [nets2ddq](#simplibnets2ddq)
-- [parse\_hosts](#simplibparse_hosts)
-- [passgen](#simplibpassgen)
-- [rand\_cron](#simplibrand_cron)
-- [strip\_ports](#simplibstrip_ports)
-- [to\_integer](#simplibto_integer)
-- [to\_string](#simplibto_string)
-- [validate\_array\_member](#simplibvalidate_array_member)
-- [validate\_between](#simplibvalidate_between)
-- [validate\_bool](#simplibvalidate_bool)
-- [validate\_deep\_hash](#simplibvalidate_deep_hash)
-- [validate\_net\_list](#simplibvalidate_net_list)
-- [validate\_port](#simplibvalidate_port)
-- [validate\_re\_array](#simplibvalidate_re_array)
-- [validate\_sysctl\_value](#simplibvalidate_sysctl_value)
-- [validate\_uri\_list](#simplibvalidate_uri_list)
+- [simplib::assert\_metadata](#simplibassert_metadata)
+- [simplib::deprecation](#simplibdeprecation)
+- [simplib::filtered](#simplibfiltered)
+- [simplib::gen\_random\_password](#simplibgen_random_password)
+- [simplib::inspect](#simplibinspect)
+- [simplib::ip\_to\_cron](#simplibip_to_cron)
+- [simplib::ipaddresses](#simplibipaddresses)
+- [simplib::join\_mount\_opts](#simplibjoin_mount_opts)
+- [simplib::knockout](#simplibknockout)
+- [simplib::ldap::domain\_to\_dn](#simplibldapdomain_to_dn)
+- [simplib::lookup](#simpliblookup)
+- [simplib::nets2cidr](#simplibnets2cidr)
+- [simplib::nets2ddq](#simplibnets2ddq)
+- [simplib::parse\_hosts](#simplibparse_hosts)
+- [simplib::passgen](#simplibpassgen)
+- [simplib::rand\_cron](#simplibrand_cron)
+- [simplib::strip\_ports](#simplibstrip_ports)
+- [simplib::to\_integer](#simplibto_integer)
+- [simplib::to\_string](#simplibto_string)
+- [simplib::validate\_array\_member](#simplibvalidate_array_member)
+- [simplib::validate\_between](#simplibvalidate_between)
+- [simplib::validate\_bool](#simplibvalidate_bool)
+- [simplib::validate\_deep\_hash](#simplibvalidate_deep_hash)
+- [simplib::validate\_net\_list](#simplibvalidate_net_list)
+- [simplib::validate\_port](#simplibvalidate_port)
+- [simplib::validate\_re\_array](#simplibvalidate_re_array)
+- [simplib::validate\_sysctl\_value](#simplibvalidate_sysctl_value)
+- [simplib::validate\_uri\_list](#simplibvalidate_uri_list)
 
 
 #### simplib::assert\_metadata
 
 Fails a puppet catalog compile if the client system is not compatible
-with the module's `meta_data.json`
+with the module's `metadata.json`
 
-*Arguments:*
-* ``module_name``  module name
-* ``options``       (Optional) Behavior modifiers for the function)
+*Arguments*:
 
-Options takes the form:
-  enable => If set to `false` disable all validation
-  os
-    validate => Whether or not to validate the OS settings
-    options
-      release_match => Enum['none','full','major']
-        none  -> No match on minor release (default)
-        full  -> Full release must match
-        major -> Only the major release must match
+* ``module_name`` module name
+* ``options``     (Optional) Hash of behavior modifiers for the function
+
+``options`` can be set globally (for all classes that use this
+ function) via hieradata and has the following keys:
+
+* ``enable`` If set to `false` disable all validation
+* ``os``     Options for OS validation to be done.  Valid keys:
+
+    * ``validate`` Whether to validate the OS settings
+    * `` options`` OS validation options. Valid keys:
+
+        * ``release_match`` Type of OS release matching to be done.
+          Valid values:
+
+            * ``none``  No match on minor release (default)
+            * ``full``  Full release must match
+            * ``major`` Only the major release must match
+
+*Returns*: `nil`
 
 *Example*:
+
 ```puppet
     simplib::assert_metadata('mymodule')
 ```
-*Returns*: `nil`
 
 #### **simplib::deprecation**
 
 Function to print deprecation warnings, logging a warning once
 for a given key.
 
-Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
-environment variable is set to 'true'
+Messages can be enabled if the SIMPLIB\_LOG\_DEPRECATIONS
+environment variable is set to 'true'.
 
 *Arguments*:
-* ``key``      Uniqueness key, which is used to dedupe of messages)
-* ``message``  Message to be printed, file and line info
-           will be appended if available.)
 
-*Examples*:
+* ``key``      Uniqueness key, which is used to dedupe messages
+* ``message``  Message to be printed, file and line info will be
+               appended if available.
+
+*Returns*: `nil`
+
+*Example*:
 
 ```puppet
-  simplib::deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::dconf and will be removed in a future version')
+  simplib::deprecation('simplib::foo','simplib::foo is deprecated and will be removed in a future version')
   # Writes message to log if SIMPLIB_LOG_DEPRECATIONS is true.
 ```
-*Returns*: `nil`
 
 #### **simplib::filtered**
 
@@ -198,172 +199,287 @@ Hiera v5 backend that takes a list of allowed hiera key names, and only
 returns results from the underlying backend function that match those keys.
 
 This allows hiera data to be delegated to end users in a multi-tenant
-environment without allowing them the ability to override every hiera data
-point (and potentially break systems)
+environment, without allowing them the ability to override every hiera data
+point (and potentially break systems).
 
 #### **simplib::gen_random_password**
 
 Generates a random password string.
 
+Terminates catalog compilation if the password cannot be created within
+allotted time.
+
 *Arguments*:
-* ``length``           (Optional) Integer - length of the string to return
-* ``complexity``       (Optional) Integer -Specifies the types of characters to be used in the password)
-                     `0` => Use only Alphanumeric characters (safest)
-                     `1` => Use Alphanumeric characters and reasonably safe symbols
-                     `2` => Use any printable ASCII characters
-* ``complex_only``    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
-* ``timeout_seconds`` (Optional) Integer or Float - Maximum time allotted to generate
-                     the password; a value of 0 disables the timeout
+
+* ``length``          Length of the string to return
+* ``complexity``      (Optional) The types of characters to be used in
+                      the password;  valid values:
+
+    * ``0``  Use only Alphanumeric characters (safest)
+    * ``1``  Use Alphanumeric characters and reasonably safe symbols
+    * ``2``  Use any printable ASCII characters
+
+* ``complex_only``    (Optional) Use only the characters explicitly added
+                       by the complexity rules
+* ``timeout_seconds`` (Optional) Maximum time allotted to generate
+                      the password; a value of 0 disables the timeout
 
 *Returns*: `String` Generated password
 
-Raises a RuntimeError if password cannot be created within allotted time
+*Raises*: `RuntimeError` if password cannot be created within allotted
+          time
 
 #### **simplib::ipaddresses**
 
-Return an array of all IP addresses known to be associated with the client. If
-an argument is passed, and is not false, then only return non-local addresses.
+Return an array of all IP addresses known to be associated with the client,
+optionally excluding local addresses.
 
 *Arguments*:
+
 * ``only_remote`` (Optional) Whether to exclude local addresses
-     from the return value.
+                  from the return value (e.g., '127.0.0.1').
 
 *Returns*: `Array`
+
+#### **simplib::inspect**
+
+Prints the passed variable's Ruby type and value for debugging purposes.
+This uses a ``Notify`` resource to print the information during the
+client run.
+
+*Arguments*:
+
+* ``var_name``    The actual name of the variable, fully scoped, as a
+                  ``String``.
+* ``output_type`` (Optional) The format that you wish to use to display
+                  the output during the run.
+
+    * Valid values are ``json``, ``oneline_json`` and ``yaml``.
+    *  ``json`` and ``yaml`` result in multi-line message content.
+    *  ``oneline_json`` results in single-line message content.
+
+*Returns*: `nil`
+
+*Example*:
+
+```puppet
+  class my_test(
+    String $var1,
+    Hash   $var2
+  )
+  {
+    simplib::inspect('var1')
+    simplib::inspect('var2')
+    ...
+  }
+```
 
 #### **simplib::ip_to_cron**
 
 Transforms an IP address to one or more interval values for `cron`.
 This can be used to avoid starting a certain cron job at the same
-time on all servers.ovides a "random" value to cron based on the passed integer value.
+time on all servers.
 
 *Arguments*:
-* ``occurs``     (Optional) The occurrence within an interval, i.e.,
+
+* ``occurs``    (Optional) The occurrence within an interval, i.e.,
                 the number of values to be generated for the interval.
 * ``max_value`` (Optional) The maximum value for the interval.  The values
                 generated will be in the inclusive range [0, max_value].
-* ``algorithm``  (Optional) When 'ip_mod', the modulus of the IP number is used as the basis
-                for the returned values.  This algorithm works well to create
-                cron job intervals for multiple hosts, when the number of hosts
-                exceeds the `max_value` and the hosts have largely, linearly-
-                assigned IP addresses.
-                When 'sha256', a random number generated using the IP address
-                string is the basis for the returned values.  This algorithm
-                works well to create cron job intervals for multiple hosts,
-                when the number of hosts is less than the `max_value` or the
-                hosts do not have linearly-assigned IP addresses.
-* ``ip``         (Optional) The IP address to use as the basis for the generated values.
-                 When `nil`, the 'ipaddress' fact (IPv4) is used.
+* ``algorithm`` (Optional) Valid values are ``ip_mod`` and ``sha256``
+
+    * ``ip_mod``: The modulus of the IP number is used as the basis
+      for the returned values.  This algorithm works well to create
+      cron job intervals for multiple hosts, when the number of hosts
+      exceeds the `max_value` and the hosts have largely, linearly-
+      assigned IP addresses.
+
+    * ``sha256``: A random number generated using the IP address
+      string is the basis for the returned values.  This algorithm
+      works well to create cron job intervals for multiple hosts,
+      when the number of hosts is less than the ``max_value`` or the
+      hosts do not have linearly-assigned IP addresses.
+
+* ``ip``        (Optional) The IP address to use as the basis for the
+                generated values.  When ``nil``, the ``ipaddress`` fact
+                (IPv4) is used.
+
+*Returns*: `Array[Integer]` Array of integers suitable for use in the
+  ``minute`` or ``hour`` cron field.
 
 *Examples*:
-  Generate one value for the `minute` cron interval
+
+  Generate one value for the `minute` cron interval:
 
 ```ruby
     simplib::ip_to_cron()
 ```
-  Generate 2 values for the `hour` cron interval, using the
-  sha256' algorithm and a provided IP address
+  Generate 2 values for the `hour` cron interval, using the 'sha256'
+  algorithm and a provided IP address:
+
 ```ruby
      simplib::ip_to_cron(2,23,'sha256','10.0.23.45')
 ```
-*Returns*: `Array[Integer]` Array of integers suitable for use in the
-  ``minute`` or ``hour`` cron field.
-
 
 #### **simplib::join_mount_opts**
 
-Merge two sets of 'mount' options in a reasonable fashion. The second set will
+Merge two sets of ``mount`` options in a reasonable fashion. The second set will
 always override the first.
 
 *Arguments*:
+
 * ``system_mount_opts`` System mount options
 * ``new_mount_opts``    New mount options, which will override
-                        `system_opts` when there are conflicts
+                        ``system_mount_opts`` when there are conflicts
 
 *Returns*: `String`
 
 #### **simplib::knockout**
 
-Uses the knockout prefix of '--' to remove elements from an array.
+Uses the knockout prefix of ``--`` to remove elements from an array.
 
 *Arguments*:
+
 * ``array``  The array to work on
 
-*Examples*:
+*Returns*: `Array`
+
+*Example*:
+
 ```puppet
   array = [
     'ssh',
     'sudo',
     '--ssh',
   ]
-  result = simplib::knockout(array)
-# returns: result => [ 'sudo' ]
+  $result = simplib::knockout(array)
+  #
+  # returns $result = [ 'sudo' ]
 ```
-*Returns*: `Array`
-
 
 #### **simplib::ldap::domain_to_dn**
 
-Takes a DNS domain name and converts it to an LDAP domain name.
+Generates an LDAP Base DN from a domain.
 
-Arguments:
-* ``domain``               (Optional) The dns domain name, defaults to fact domain.
-* ``downcase_attributes`` (Optional) Whether or not to downcase the LDAP attributes, false
+*Arguments*:
+
+* ``domain``              (Optional) The DNS domain name, defaults to
+                          ``domain`` fact
+* ``downcase_attributes`` (Optional) Whether to downcase the LDAP
+                          attributes
 
 *Returns*: `String`
+
+*Examples*:
+
+  Generate a LDAP Base DN with uppercase attributes:
+
+```puppet
+  $ldap_dn = simplib::ldap::domain_to_dn('test.local')
+
+  # returns $ldap_dn = 'DC=test,DC=local'
+```
+
+  Generate a LDAP Base DN with lowercase attributes:
+
+```puppet
+  $ldap_dn = simplib::ldap::domain_to_dn('test.local', true)
+  #  returns $ldap_dn = 'dc=test,dc=local'
+```
 
 #### **simplib::lookup**
 
 A function for falling back to global scope variable lookups when the
 Puppet 4 ``lookup()`` function cannot find a value.
 
-While ``lookup()`` will stop at the back-end data sources, ``lookup()`` will
-check the global scope first to see if the variable has been defined.
+While ``lookup()`` will stop at the back-end data sources,
+``simplib::lookup()`` will check the global scope first to see if the
+variable has been defined.
 
 This means that you can pre-declare a class and/or use an ENC and look up the
 variable whether it is declared this way or via Hiera or some other back-end.
 
 *Arguments*:
-* ``param``     The parameter you wish to look up.
-* ``options``   (Optional)Hash of options for regular ``lookup()``
-            This **must** follow the syntax rules for the
-            Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
-            No other formats are supported!
+
+* ``param``   The parameter you wish to look up.
+* ``options`` (Optional) Hash of options for regular ``lookup()``
+              This **must** follow the syntax rules for the Puppet
+              ``lookup( [\<NAME\>], \<OPTIONS HASH\> )`` version of
+              ``lookup()``. No other formats are supported!
+
+*Returns*: `Any` The value that is found in the system for the passed
+                 parameter
+
 *Examples*:
+
 ```puppet
   # No defaults
   simplib::lookup('foo::bar::baz')
+
   # With a default
   simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana' })
+
   # With a typed default
   simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana', 'value_type' => String })
 ```
-
-*Returns*: `Any` The value that is found in the system for the passed
 
 #### **simplib::nets2cidr**
 
 Take an input list of networks and returns an equivalent `Array` in
 CIDR notation.
-Hostnames are passed through untouched.
+
+* Hostnames are passed through untouched.
+* Terminates catalog compilation if any input item is not a valid
+  network or hostname.
 
 *Arguments*:
-* ``networks_list``  List of 1 or more networks separated by spaces,
-                 commas, or semicolons
+
+* ``networks_list`` List of 1 or more networks in a single string
+                    (separated by whitespace, commas, or semicolons)
+                    or an array of strings.
 
 *Returns* `Array[String]` Array of networks in CIDR notation
+
+*Example*:
+
+```puppet
+  $foo = [ '1.2.0.0/255.255.0.0',
+           '2001:db8:85a3::8a2e:370:0/112',
+           '1.2.3.4',
+           'myhost.test.local' ]
+
+  $cidrs = nets2cidr($foo)
+  #
+  # returns $cidrs = [ '1.2.0.0/16',
+  #                    '2001:db8:85a3::8a2e:370:0/112',
+  #                    '1.2.3.4',
+  #                    'myhost.test.local'
+  #                  ]
+```
 
 #### **simplib::nets2ddq**
 
 Tranforms a list of networks into an equivalent array in
 dotted quad notation.
 
-CIDR networks are converted to dotted quad notation networks.
-IP addresses and hostnames are left untouched.
+* CIDR networks are converted to dotted quad notation networks.
+* IP addresses and hostnames are left untouched.
+* Terminates catalog compilation if any input item is not a valid
+  network or hostname.
 
 *Arguments*:
-* ``networks``  The networks to convert
 
-*Examples*:
+* ``networks`` List of 1 or more networks in a single string (separated
+               by whitespace, commas, or semicolons) or an array of
+               strings.
+
+*Returns*: `Array[String]` Converted input
+
+*Raises*:  RuntimeError if any input item is not a valid network
+           or hostname
+
+*Example*:
+
 ```puppet
   # Convert Array input
   $foo = [ '10.0.1.0/24',
@@ -375,34 +491,40 @@ IP addresses and hostnames are left untouched.
   # returns  $bar = [ '10.0.1.0/255.255.255.0',
   #                   '10.0.2.0/255.255.255.0',
   #                   '10.0.3.25',
+  #                   'myhost' ]
 ```
-
-*Returns*: `Array[String]` Converted input
-           raise RuntimeError if any input item is not a valid network
-           or hostname
 
 #### **simplib::parse_hosts**
 
 Convert an `Array` of items that may contain port numbers or protocols
 into a structured `Hash` of host information.
 
-Works with Hostnames as well as IPv4 and IPv6 addresses.
+* Works with Hostnames as well as IPv4 and IPv6 addresses.
+* IPv6 addresses will be returned normalized with square brackets
+  around them for clarity.
+* Terminates catalog compilation if
 
-**NOTE:** IPv6 addresses will be returned normalized with square brackets
-around them for clarity.
+    * A valid network or hostname cannot be extracted from all input
+      items.
+    * Any input item that contains a port specifies an invalid port.
 
 *Arguments*:
-* ``hosts``   Array of host entries, where each entry may contain
-        a protocol or both a protocol and port
 
-*Examples*:
+* ``hosts`` Array of host entries, where each entry may contain
+            a protocol or both a protocol and port
+
+*Returns*: `Hash` Structured Hash of the host information
+
+*Raises*: `RuntimeError` if any input item that contains a port
+           specifies an invalid port
+
+*Example*:
+
 ```puppet
   # Input with multiple host formats:
-  simplib::parse_hosts([
-    '1.2.3.4',
-    'http://1.2.3.4',
-    'https://1.2.3.4:443'
-  ])
+  simplib::parse_hosts([ '1.2.3.4',
+                         'http://1.2.3.4',
+                         'https://1.2.3.4:443' ])
   #   Returns:
   #   {
   #     '1.2.3.4' => {
@@ -414,52 +536,58 @@ around them for clarity.
   #     }
   #   }
 ```
-*Returns*: `Hash` Structured Hash of the host information
 
 #### **simplib::passgen**
 
-Generates a random password string for a passed identifier. Returns
-the password or a hash of the password depending on arguments.  It also
-stores the password on the puppetserver using
-Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
-destination directory.
+Generates/retrieves a random password string or its hash for a
+passed identifier.
 
-The minimum length password that this function will return is 6
-characters.
-
-If no, or an invalid, second argument is provided then it will return the
-    currently stored string.
+* Uses `Puppet.settings[:vardir]/simp/environments/$environment/simp_autofiles/gen_passwd/`
+  as the destination directory for password storage.
+* The minimum length password that this function will return is `8`
+  characters.
+* Terminates catalog compilation if the password storage directory
+  cannot be created/accessed by the Puppet user, the password cannot
+  be created in the allotted time, or files not owned by the Puppet
+  user are present in the password storage directory.
 
 *Arguments*:
-* ``identifier``      Unique `String` to identify the password usage.
-* ``modifier_hash``  (Optional) may contain any of the following options:
-                    - 'last' => false(*) or true
-                      * Return the last generated password
-                    - 'length' => Integer
-                      * Length of the new password
-                    - 'hash' => false(*), true, md5, sha256 (true), sha512
-                      * Return a hash of the password instead of the password itself.
-                    - 'complexity' => 0(*), 1, 2
-                      * 0 => Use only Alphanumeric characters in your password (safest) 1 =>
-                      * Add reasonably safe symbols 2 => Printable ASCII
 
-*Examples*:
-```puppet
-    #run pasgen for the firstime
-    password = simplib::passgen('myfavpasswd',{'length'=> 34})
-    #returns password = string of length 34 plain text.
+* ``identifier``     Unique `String` to identify the password usage.
+* ``modifier_hash``  (Optional) Hash which may contain any of the following
+                     options:
 
-    # Generate the password and return the hash
-    password = simplib::passgen('yourfavpasswd',{ hash => 'sha256' })
-    # returns sha256 hash of generated password and salt.
+    * ``last``       Whether to return the last generated password
+    * ``length``     Length of the new password
+    * ``hash``       Whether to return a hash  of the password, instead of
+                     the password itself. Valid values are:
 
-    # To retrieve the above password (assuming the above command
-    #  was run previously in the catalog or on an earlier catalog run:
-    password = simplib::passgen('yourfavpasswd')
-    # returns the 32 character password generated by the first call
-```
+        * ``false``
+        * ``true`` which is equivalent to ``sha256``
+        * ``md5``,
+        * ``sha256``
+        * ``sha512``
+
+    * ``complexity`` The types of characters to be used in the password;
+                     valid values:
+
+        * ``0``  Use only Alphanumeric characters (safest)
+        * ``1``  Use Alphanumeric characters and reasonably safe symbols
+        * ``2``  Use any printable ASCII characters
 
 *Returns*: `String` Password specified
+
+*Examples*:
+
+```puppet
+  # Run simplib::passgen for the first time for an identifier.  This
+  # generates a length 34 password, stores it, and returns it in plain text.
+  $password = simplib::passgen('myfavpasswd',{'length'=> 34})
+
+  # Request a password hash.  Since a password already exists for this
+  # identifier, retrieves the existing password and returns the hash of it.
+  $password_hash = simplib::passgen('myfavpasswd',{ hash => 'sha256' })
+```
 
 #### **simplib::rand_cron**
 
@@ -468,381 +596,546 @@ This can be used to avoid starting a certain cron job at the same
 time on all servers.
 
 *Arguments*:
-* ``modifier``    The input string to use as the basis for the generated values
-* ``algorithm``   Randomization algorithm to apply to transform the input string.
+
+* ``modifier``    The input string to use as the basis for the
+                  generated values
+* ``algorithm``   Randomization algorithm to apply to transform the
+                  input string; valid values are ``ip_mod`` and ``sha256``
+
+    * ``ip_mod``: The modulus of the IP number is used as the basis
+      for the returned values.  This algorithm works well to create
+      cron job intervals for multiple hosts, when the number of hosts
+      exceeds the `max_value` and the hosts have largely, linearly-
+      assigned IP addresses.
+
+    * ``sha256``: A random number generated using the IP address
+      string is the basis for the returned values.  This algorithm
+      works well to create cron job intervals for multiple hosts,
+      when the number of hosts is less than the ``max_value`` or the
+      hosts do not have linearly-assigned IP addresses.
+
 * ``occurs``      (Optional) The occurrence within an interval
-* ``max_value``  (Optional) The maximum value for the interval.
+* ``max_value``   (Optional) The maximum value for the interval
+
+*Returns*: `Array[Integer]` Array of integers suitable for use
+            in the ``minute`` or ``hour`` cron field
 
 *Examples*:
+
 ```puppet
-   # Generate one value for the `minute` cron interval using using sha256
-   simplib::rand_cron('myhost.test.local','sha256')
+  # Generate one value for the `minute` cron interval using using sha256
+  simplib::rand_cron('myhost.test.local','sha256')
 
   # Generate 2 values for the `hour` cron interval, using the
   # 'ip_mod' algorithm
   simplib::rand_cron('10.0.6.78', 'ip_mod', 2, 23)
 ```
 
-*Returns*: `Array[Integer]` Array of integers suitable for use
-            in the ``minute`` or ``hour`` cron field
-
 #### **simplib::strip_ports**
 
 Extract list of unique hostnames and/or IP addresses from an `Array`
 of hosts, each of which may may contain protocols and/or port numbers
 
+Terminates catalog compilation if
+
+* A valid network or hostname cannot be extracted from all input items.
+* Any input item that contains a port specifies an invalid port.
+
 *Arguments*:
-* hosts   Array of hosts which may contain protocols and port numbers
 
-*Examples*:
-```puppet
-$foo = ['https://mysite.net:8443',
-        'http://yoursite.net:8081',
-        'https://theirsite.com']
-
-$bar = strip_ports($foo)
-
-# results  $bar = ['https://mysite.net','http://yoursite.net','theirsite.com']
-```
+* ``hosts``  Array of hosts which may contain protocols and port numbers
 
 *Returns*: `Array` Non-port portion of hostnames
 
-#### **simplib::to_integer**
-Converts the argument into an Integer.
-Only works if the passed argument responds to the 'to\_i' Ruby method.
+*Raises*: `RuntimeError` if any input item that contains a port
+           specifies an invalid port
 
-*Returns*: `integer`
+*Example*:
+
+```puppet
+  $foo = ['https://mysite.net:8443',
+          'http://yoursite.net:8081',
+          'https://theirsite.com']
+
+  $bar = strip_ports($foo)
+
+  # results  $bar = ['mysite.net','yoursite.net','theirsite.com']
+```
+
+#### **simplib::to_integer**
+
+Converts the argument into an Integer.
+
+Terminates catalog compilation if the argument's class
+does not respond to the `to_i()` Ruby method.
+
+*Arguments*:
+
+* ``input`` Item to be converted
+
+*Returns*: `Integer`
+
+*Raises*: `RuntimeError` if any ``input`` does not implement a
+          ``to_i()`` method
 
 #### **simplib::to_string**
 
 Converts the argument into a String.
-Only works if the passed argument responds to the 'to\_s' Ruby method.
 
-*Returns*: `string`
+*Arguments*:
+
+* ``input`` Item to be converted
+
+*Returns*: `String`
 
 #### **simplib::validate_array_member**
 
-Validate that the first string (or array) passed is a member of the second
-array passed. An optional third argument of i can be passed, which ignores
-the case of the objects inside the array.
+Validate that an single input is a member of another `Array` or an
+`Array` input is a subset of another `Array`.
+
+* The comparison can optionally ignore the case of `String` elements.
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
-* ``input``    The element to find in the target array.
+
+* ``input``    The input to find in the target array.
 * ``target``   The array to search.
 * ``modifier`` (Optional) If 'i' ignores case.
 
+*Returns*: `nil`
+
+*Raises*:  RuntimeError if ``input`` is not found in ``target``
+
 *Examples*:
+
 ```ruby
-validate_array_member('foo',['foo','bar'])     # => true
-validate_array_member('foo',['FOO','BAR'])     # => false
+  # Passing:
+  simplib::validate_array_member('foo',['foo','bar'])
+  simplib::validate_array_member('foo',['FOO','BAR'],'i')
 
-#Optional 'i' as third object, ignoring case of FOO and BAR#
-
-simplib::validate_array_member('foo',['FOO','BAR'],'i') # => true
+  # Failing, causing compilation to abort:
+  simplib::validate_array_member(['foo','bar'],['FOO','BAR','BAZ'])
 ```
 
-*Returns*: `Boolean` Whether or not the argument is an element of the
-            array.
-
 #### **simplib::validate_between**
-Validate that the first value is between the second and third values
-numerically, inclusively. Fail catalog compile if not.
 
-Deprecated:  You should be able to use type declarions instead of this.
+Validate that the first value is between the second and third values
+numerically.
+
+* The range is inclusive.
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
+
 * ``value``       Value to validate
 * ``min_value``   Minimum value that is valid
 * ``max_value``   Maximum value that is valid
 
 *Returns*: `nil`
 
-#### **simplib::validate_bool**
-Validate that all passed values are either true or false. Abort catalog
-compilation if any value fails this check.
-
-Modified from the stdlib validate\_bool to handle the strings 'true' and
-'false'.
-
-*Arguments*:
-* ``values_to_validate``   The value to validate.
+*Raises*: `RuntimeError` if validation fails
 
 *Examples*:
-```ruby
-# The following will pass
-$iamtrue = true
 
-simplib::validate_bool(true)
-simplib::validate_bool("false")
-simplib::validate_bool("true")
-simplib::validate_bool(true, 'true', false, $iamtrue)
+```puppet
+  # Passing:
+  simplib::validate_between('-1', -3, 0)
+  simplib::validate_between(7, 0, 60)
+  simplib::validate_between(7.6, 7.1, 8.4)
 
-#The following values will fail, causing compilation to abort:
-
-$some_array = [ true ]
-
-simplib::validate_bool($some_array)
+  # Failing, causing compilation to abort:
+  simplib::validate_between('-1', 0, 3)
+  simplib::validate_between(0, 1, 60)
+  simplib::validate_between(7.6, 7.7, 8.4)
 ```
 
-*Returns*: `nil` Fails catalog compilation if it is not a Boolean'
+#### **simplib::validate_bool**
 
-#### **simplib::validate_deep_hash**
-Perform a deep validation on two passed `Hashes`.
-The first hash is the one to validate against, and the second is the one being
-validated.
+Validate that all passed values are either ``true``, 'true',
+``false`` or 'false'.
 
-All keys must be defined in the reference `Hash` that is being
-validated against.
-
-Unknown keys in the `Hash` being compared will cause a failure in
-validation
-
-All values in the final leaves of the 'reference 'Hash' must
-be a String, Boolean, or nil.
-
-All values in the final leaves of the `Hash` being compared must
-support a to\_s() method.
+Terminates catalog compilation if validation fails.
 
 *Arguments*:
-* ``reference``   Reference Hash
-* ``to_check``   Hash to validate.
+
+* ``values_to_validate``   The value to validate.
+
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
 
 *Examples*:
-```puppet
-  # Passing Examples
-   reference = {
-     'foo' => {
-       'bar' => {
-         #NOTE: Use quotes for regular expressions instead of '/'
-         'baz' => '^\d+$',
-         'abc' => '^\w+$',
-         'def' => nil
-       },
-       'baz' => {
-         'qrs' => false
-         'xyz' => '^true|false$'
-       }
-     }
-   }
 
-   to_check = {
-     'foo' => {
-       'bar' => {
-         'baz' => ['123', 45]
-         'abc' => [ 'these', 'are', 'words' ],
-         'def' => 'Anything will work here!'
-       },
-       'baz' => {
-         'qrs' => false
-         'xyz' => true
-       }
-     }
-   }
+```ruby
+  # Passing:
+  $iamtrue = true
+  simplib::validate_bool(true)
+  simplib::validate_bool("false")
+  simplib::validate_bool("true")
+  simplib::validate_bool(true, 'true', false, $iamtrue)
+
+  # Failing, causing compilation to abort:
+  simplib::validate_bool('True')
+  simplib::validate_bool('FALSE')
+```
+
+#### **simplib::validate_deep_hash**
+
+Perform a deep validation on two passed `Hashes`.
+
+* All keys must be defined in the reference `Hash` that is being
+  validated against.
+* Unknown keys in the `Hash` being compared will cause a failure in
+  validation
+* All values in the final leaves of the 'reference 'Hash' must
+  be a String, Boolean, or nil.
+* All values in the final leaves of the `Hash` being compared must
+  support a ``to_s()`` method.
+* Terminates catalog compilation if validation fails.
+
+*Arguments*:
+
+* ``reference`` Reference Hash to validate against.  Keys at all
+                levels of the hash define the structure of the hash
+                and the value at each final leaf in the hash tree
+                contains a regular expression string, a boolean or
+                nil for value validation:
+
+    * When the validation value is a regular expression string, the
+      string representation of the ``to_check`` value (from the
+      ``to_s()`` method) will be compared to the regular expression
+      contained in the reference string.
+
+    * When the validation value is a Boolean, the string representation
+      of the ``to_check`` value will be compared with the string
+      representation of the Boolean (as provided by the ``to_s()``
+      method).
+
+    * When the validation value is a ``nil`` or 'nil', no value
+      validation will be done for the key.
+
+    * When the ``to_check`` value contains an ``Array`` of values for
+      a key, the validation for that key will be applied to each element
+      in that array.
+
+* ``to_check``   Hash to validate against the reference
+
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
+
+*Examples*:
+
+```puppet
+  # Passing:
+  reference = {
+    'foo' => {
+      'bar' => {
+        #NOTE: Use quotes for regular expressions instead of '/'
+        'baz' => '^\d+$',
+        'abc' => '^\w+$',
+        'def' => nil
+      },
+      'baz' => {
+        'qrs' => false
+        'xyz' => '^true|false$'
+      }
+    }
+  }
+
+  to_check = {
+    'foo' => {
+      'bar' => {
+        'baz' => ['123', 45]
+        'abc' => [ 'these', 'are', 'words' ],
+        'def' => 'Anything will work here!'
+      },
+      'baz' => {
+        'qrs' => false
+        'xyz' => true
+      }
+    }
+  }
   simplib::validate_deep_hash(reference, to_check)
 
-  # Failing Examples
+  # Failing, causing compilation to abort:
   reference => { 'foo' => '^\d+$' }
   to_check  => { 'foo' => 'abc' }
 
   simplib::validate_deep_hash(reference, to_check)
 ```
-*Returns*: `nil` Fails catalog compilation they do not match.
 
 #### **simplib::validate_port**
-Validates whether or not the passed argument is a valid port (i.e.  between
-1 - 65535).  It will work on strings ot integers.
+
+Validates whether each passed argument contains valid port(s).
+
+* Each argument can be an individual string, individual integer,
+  or an array containing strings and/or integers.
+* Each port, numerically, must be in the range [1, 65535].
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
+
 * ``port_args``  A port or array of ports.
 
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
+
 *Examples*:
+
 ```puppet
-# Examples that pass
-$port = '10541'
-$ports = [5555, 7777, 1, 65535]
+  # Passing
+  $port = '10541'
+  $ports = [5555, 7777, 1, 65535]
 
-simplib::validate_port($port)
-simplib::validate_port($ports)
-simplib::validate_port($port, $ports)
+  simplib::validate_port($port)
+  simplib::validate_port($ports)
+  simplib::validate_port($port, $ports)
 
-# The following values will not pass:
-
-simplib::validate_port('0')
-simplib::validate_port(65536)
+  # Failing, causing compilation to abort:
+  simplib::validate_port('0')
+  simplib::validate_port(65536)
 ```
-
-*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 #### **simplib::validate_net_list**
+
 Validate that a passed list (`Array` or single `String`) of networks
 is filled with valid IP addresses, network addresses (CIDR notation),
-or hostnames. Hostnames are checked per RFC 1123. Ports appended with
-a colon `:` are allowed for hostnames and individual IP addresses.
+or hostnames.
+
+* Hostnames are checked per
+  [RFC 1123](https://tools.ietf.org/html/rfc1123).
+* Ports appended with a colon `:` are allowed for hostnames and
+  individual IP addresses.
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
-* ``net``         Single network to be validated.
-* ``str_match``  (Optional) A regex of `String` that should be ignored
-              from the list. Omit the beginning and ending `/` delimiter.
+* ``net_list``   1 or more network to be validated.
+* ``str_match``  (Optional) Stringified regular expression (regex
+                 without the `//` delimiters)
+
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
 
 *Examples*:
-```puppet
-#  Passing
 
-   $trusted_nets = '10.10.10.0/24'
-   simplib::validate_net_list($trusted_nets)
-
-   $trusted_nets = '1.2.3.5:400'
-   simplib::validate_net_list($trusted_nets)
-
-   $trusted_nets = 'ALL'
-   simplib::validate_net_list($trusted_nets,'^(%any|ALL)$')
-
-# Failing
-
-   $trusted_nets = '10.10.10.0/24,1.2.3.4'
-   simplib::validate_net_list($trusted_nets)
-
-   $trusted_nets = 'bad stuff'
-   simplib::validate_net_list($trusted_nets)
-```
-
-*Returns*: `nil` Catalog compilation will fail if it does not pass.
-
-#### **simplib::validate_re_array**
-Perform simple validation of a `String`, or `Array` of `Strings`,
-against one or more regular expressions.
-Derived from the Puppet Labs stdlib validate\_re.
-
-*Arguments*:
-* ``input``   String to be validated
-* ``regex``   Stringified regex expression (regex without the `//`
-   delimiters)
-* ``err_msg``  (Optional) error message to emit upon failure
-
-*Examples*:
 ```puppet
   #  Passing
-  simplib::validate_re_array('one', '^one$')
-  #
-  #  Failing
-  simplib::validate_re_array('one', '^two')
-  #
-  # Custom Error Message
-  simplib::validate_re_array($::puppetversion, '^2.7', 'The $puppetversion fact value does not match 2.7')
-  #
+  $trusted_nets = '10.10.10.0/24'
+  simplib::validate_net_list($trusted_nets)
+
+  $trusted_nets = '1.2.3.5:400'
+  simplib::validate_net_list($trusted_nets)
+
+  $trusted_nets = 'ALL'
+  simplib::validate_net_list($trusted_nets,'^(%any|ALL)$')
+
+  # Failing, causing compilation to abort:
+  $trusted_nets = '10.10.10.0/24,1.2.3.4'
+  simplib::validate_net_list($trusted_nets)
+
+  $trusted_nets = 'bad stuff'
+  simplib::validate_net_list($trusted_nets)
 ```
 
-*Returns*: `nil` Catalog compilation will fail if it does not pass.
+#### **simplib::validate_re_array**
 
-#### **simplib::validate_sysctl_value****
+Perform simple validation of a `String`, or `Array` of `Strings`,
+against one or more regular expressions.
 
-Validate that the passed value is correct for the passed sysctl key.
-
-If a key is not know, simply returns that the value is valid.
+* Derived from the Puppet Labs stdlib ``validate_re()``
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
-* ``key``    sysctl setting whose value is to be validated
+
+* ``input``   String to be validated
+* ``regex``   Stringified regular expression (regex without the `//`
+              delimiters)
+* ``err_msg`` (Optional) error message to emit upon failure
+
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
+
+*Examples*:
+
+```puppet
+  # Passing
+  simplib::validate_re_array('one', '^one$')
+
+  # Failing, causing compilation to abort:
+  simplib::validate_re_array('one', '^two')
+
+  # Failing with a custom error message
+  simplib::validate_re_array($::puppetversion, '^2.7',
+    'The $puppetversion fact value does not match 2.7')
+```
+
+#### **simplib::validate_sysctl_value**
+
+Validate that the passed value is correct for the passed ``sysctl`` key.
+
+* If a key is not known, simply returns that the value is valid.
+* Terminates catalog compilation if validation fails.
+
+*Arguments*:
+
+* ``key``    ``sysctl`` setting whose value is to be validated
 * ``value``  Value to be validated
 
-*Returns*: `nil` Catalog compilation will fail if it does not pass.
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
 
 #### **simplib::validate_uri_list**
+
 Validate that a passed list (`Array` or single `String`) of URIs is
 valid according to Ruby's URI parser.
-Caution:  No scheme (protocol type) validation is done the scheme_list
-parameter is not set.
+
+* **Caution**:  No scheme (protocol type) validation is done if the
+  ``scheme_list`` parameter is not set.
+* Terminates catalog compilation if validation fails.
 
 *Arguments*:
+
 * ``uri``          URI to be validated.
-* ``scheme_list`` (Optional) List of schemes (protocol types) allowed for the URI.
+* ``scheme_list`` (Optional) List of schemes (protocol types) allowed
+                  for the URI.
+
+*Returns*: `nil`
+
+*Raises*: `RuntimeError` if validation fails
 
 *Examples*:
+
 ```puppet
-# The following values will pass:
-$uris = [http://foo.bar.baz:1234','ldap://my.ldap.server']
-simplib::validate_uri_list($uris)
+  # Passing:
+  $uris = [http://foo.bar.baz:1234','ldap://my.ldap.server']
+  simplib::validate_uri_list($uris)
 
-$uris = ['ldap://my.ldap.server','ldaps://my.ldap.server']
-simplib::validate_uri_list($uris,['ldap','ldaps'])
+  $uris = ['ldap://my.ldap.server','ldaps://my.ldap.server']
+  simplib::validate_uri_list($uris,['ldap','ldaps'])
 ```
-
-*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 ### Puppet Extensions
-- [hostname_only?](#hostname_only)
-- [hostname?](#hostname)
-- [split_port](#split_port)
 
-#### **hostname_only?**
-Determine whether or not the passed value is a valid hostname.
-Returns false if is not comprised of ASCII letters (upper or lower case),
-digits, hypens (except at the beginning and end), and dots (except at
-beginning and end)
-NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+The following methods are Puppet extensions in the ``PuppetX::SIMP::Simplib``
+namespace:
 
-*Examples*:
-```ruby
-  # Returns True
-  PuppetX::SIMP::Simplib.hostname?('hostname.me.com')
+- [hostname?](#puppetxsimpsimplibhostname)
+- [hostname\_only?](#puppetxsimpsimplibhostname_only)
+- [human\_sort](#puppetxsimpsimplibhuman_sort)
+- [split\_port](#puppetxsimpsimplibsplit_port)
 
-  # Returns false
-  PuppetX::SIMP::Simplib.hostname?('-hostname.me.com')
+#### **PuppetX::SIMP::Simplib::hostname?**
 
-  # Returns false
-  PuppetX::SIMP::Simplib.hostname?('hostname.me.com:5454')
+Determine whether the passed value is a valid hostname, optionally
+postpended with ':\<number\>' or '/\<number\>'.
 
-```
+*NOTE*:  This returns true for an IPv4 address, as it conforms to
+         RFC 1123.
 
-*Returns*: `Boolean`
+*Arguments*:
 
-#### **hostname?**
-Determine whether or not the passed value is a valid hostname optionally
-postpended with ':<number>' or '/<number>'.
-Returns false if is not comprised of ASCII letters (upper or lower case),
-digits, hypens (except at the beginning and end), and dots (except at
-beginning and end), optional pluss ':<number>' or '/<number>'
-NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+* ``obj`` Input to be assessed
+
+*Returns*: `Boolean` ``false`` if ``obj`` is not comprised of ASCII
+           letters (upper or lower case), digits, hypens (except at the
+           beginning and end), and dots (except at beginning and end),
+           excluding an optional, trailing ':\<number\>' or '/\<number\>'
 
 *Examples*:
+
 ```ruby
-  # Returns True
-  PuppetX::SIMP::Simplib.hostname?('hostname.me.com')
-
-  # Returns false
-  PuppetX::SIMP::Simplib.hostname?('-hostname.me.com')
-
   # Returns true
+  PuppetX::SIMP::Simplib.hostname?('hostname.me.com')
   PuppetX::SIMP::Simplib.hostname?('hostname.me.com:5454')
+
+  # Returns false
+  PuppetX::SIMP::Simplib.hostname?('-hostname.me.com')
 ```
 
-*Returns*: `Boolean`
+#### **PuppetX::SIMP::Simplib::hostname_only?**
 
-#### **split_port**
-Return a host/port pair
+Determine whether the passed value is a valid hostname.
+
+*NOTE*:  This returns true for an IPv4 address, as it conforms to
+         RFC 1123.
+
+*Arguments*:
+
+* ``obj`` Input to be assessed
+
+*Returns*: `Boolean` ``false`` if ``obj`` is not comprised of ASCII
+           letters (upper or lower case), digits, hypens (except at the
+           beginning and end), and dots (except at beginning and end)
 
 *Examples*:
-```ruby
-  PuppetX::SIMP::Simplib.split_port['myhost.name:5656']
-  #returns ['myhost.name','5656']
 
-  PuppetX::SIMP::Simplib.split_port['192.165.3.9/24']
-  #returns [nil, nil]
+```ruby
+  # Returns true
+  PuppetX::SIMP::Simplib.hostname_only?('hostname.me.com')
+
+  # Returns false
+  PuppetX::SIMP::Simplib.hostname_only?('-hostname.me.com')
+  PuppetX::SIMP::Simplib.hostname_only?('hostname.me.com:5454')
+```
+
+#### **PuppetX::SIMP::Simplib::human_sort**
+
+Sort a list of values based on usual human sorting semantics.
+
+*Arguments*:
+
+* ``obj`` Enumerable object to be sorted
+
+*Returns*: Sorted object
+
+#### **PuppetX::SIMP::Simplib::split_port**
+
+Split input string into a [ host, port ] pair
+
+*Arguments*:
+
+* ``host_string`` String to be split into host and port
+
+*Returns*: `Array[ host, port ]` Host and port pair
+
+    * Returns ``[ nil, nil ]`` if ``host_string`` is ``nil`` or
+      an empty string
+    * Returns ``[ host_string, nil ]`` if ``host_string`` is
+      a CIDR address or contains no port
+    * Port returned is a string
+
+*Examples*:
+
+```ruby
+  PuppetX::SIMP::Simplib.split_port('myhost.name:5656')
+  # returns ['myhost.name','5656']
 
   PuppetX::SIMP::Simplib.split_port['192.165.3.9']
-  #returns ['192.165.3.9',nil]
+  # returns ['192.165.3.9',nil]
+
+  PuppetX::SIMP::Simplib.split_port['192.165.3.9/24']
+  # returns ['192.164.3.9/24',nil]
+
+  PuppetX::SIMP::Simplib.split_port('[2001:0db8:85a3:0000:0000:8a2e:0370]:'))
+  # returns ['[2001:0db8:85a3:0000:0000:8a2e:0370]',nil]
 ```
 
-*Returns*: `Array[ hostname, port]`
+### Puppet 3 Functions
 
-### Deprecated Puppet 3 Functions
+Many of these functions have been deprecated and will be removed in
+a future release.  **Do not use these functions in new code.**
+Instead, use the newer, environment-safe functions described in
+[Functions](#functions). Also, wherever possible, replace the existing
+use of these functions with strongly-type parameters, Puppet functions,
+or the newer ``simplib`` functions.
 
-These functions have all been deprecated.  This is here for information purposes only.
-Use functions from the `Functions` section in new code.
-Many of them have been replaced by standard puppet functions, data type functionality
-in puppet 4 and later versions.
-
-If there is a corresponding simplib function for versions of puppet later than
-version 3, it is noted in the comments.
+When ``simplib`` replacement exists for a function, it will be noted
+in the function's description.
 
 - [array\_include](#array_include)
 - [array\_size](#array_size)
@@ -888,8 +1181,6 @@ version 3, it is noted in the comments.
 
 #### **array\_include**
 
-This function has been deprecated
-
 Determine if the first passed array contains the contents of another array or
 string.
 
@@ -914,8 +1205,6 @@ Returns: `boolean`
 
 #### **array\_size**
 
-This function has been deprecated
-
 Returns the number of elements in an array. If a string is passed, simply
 returns '1'.
 
@@ -925,8 +1214,6 @@ the size of an array or the length of a string when called.
 Returns: `integer`
 
 #### **array\_union**
-
-This function has been deprecated
 
 Return the union of two arrays.
 
@@ -945,8 +1232,6 @@ Returns: `array`
 
 #### **bracketize**
 
-This function has been deprecated
-
 Add brackets to IP addresses and arrays of IP addresses based on the
 rules for bracketing IPv6 addresses. Ignore anything that doesn't
 look like an IPv6 address.
@@ -954,8 +1239,6 @@ look like an IPv6 address.
 Returns: `string` or `array`
 
 #### **deep\_merge**
-
-This function has been deprecated
 
 Perform a deep merge on two passed hashes.
 
@@ -967,8 +1250,8 @@ Returns: `hash`
 
 #### **filtered**
 
-This function has been deprecated
-It has been replaced by simplib::filtered
+*This function is deprecated and has been replaced by*
+[simplib::filtered](#simplibfiltered).
 
 ##### data\_hash variant
 
@@ -1009,8 +1292,6 @@ Returns: `hash`
 
 #### **generate\_reboot\_msg**
 
-This function has been deprecated
-
 Generate a reboot message from a passed hash.
 
 Requires a hash of the following form:
@@ -1035,8 +1316,6 @@ Returns: `hash`
 
 #### **get\_ports**
 
-This function has been deprecated
-
 Take an array of items that may contain port numbers and appropriately return
 the port portion. Works with hostnames, IPv4, and IPv6.
 
@@ -1052,15 +1331,11 @@ Returns: `array`
 
 #### **h2n**
 
-This function has been deprecated
-
 Return an IP address for the passed hostname.
 
 Returns: `string`
 
 #### **host\_is\_me**
-
-This function has been deprecated.
 
 Detect if a local system identifier Hostname/IP address is contained in the
 passed whitespace delimited list. Whitespace and comma delimiters and passed
@@ -1071,20 +1346,18 @@ Returns: `boolean`
 
 #### **inspect**
 
-This function has been deprecated.
-It has been replaced by simplib::inspect.
-Note: simplib::inspect is a puppet code function.
+*This function is deprecated and has been replaced by*
+[simplib::inspect](#simplibinspect).
 
-Prints out Puppet warning messages that display the passed variable.
+Prints out Puppet warning messages that displays the contents of the passed
+variable.
 
 This is mainly meant for debugging purposes.
 
-Returns: `string`
-
 #### **ipaddresses**
 
-This function has been deprecated
-It has been replaced by simplib::ipaddresses
+*This function is deprecated and has been replaced by*
+[simplib::ipaddresses](#simplibipaddresses).
 
 Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
@@ -1093,16 +1366,14 @@ Returns: `array`
 
 #### **ip\_is\_me**
 
-This function has been deprecated
-
 Detect if an IP address is contained in the passed whitespace delimited list.
 
 Returns: `boolean`
 
-#### **ip\_to_cron**
+#### **ip\_to\_cron**
 
-This function has been deprecated
-It has been replaced by simplib::ip\_to\_cron
+*This function is deprecated and has been replaced by*
+[simplib::ip\_to\_cron](#simplibip_to_cron).
 
 Provides a "random" value to cron based on the passed integer value.
 Used to avoid starting a certain cron job at the same time on all
@@ -1127,8 +1398,8 @@ Returns: `integer` or `array`
 
 #### **join_mount_opts**
 
-This function has been deprecated
-It has been replaced by simplib::join\_mount\_opts
+*This function is deprecated and has been replaced by*
+[simplib::join\_mount\_opts](#simplibjoin_mount_opts).
 
 Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
@@ -1136,8 +1407,6 @@ always override the first.
 Returns: `string`
 
 #### **localuser**
-
-This function has been deprecated
 
 Pull a pre-set password from a password list and return an array of user
 details associated with the passed hostname.
@@ -1150,25 +1419,22 @@ If the password is in plain text form, then it will be hashed and stored back
 into the source file for future use. The plain text version will be commented
 out in the file.
 
-Arguments:
-* filename (path to the file containing the local users)
-* hostname (host that you are trying to match against)
+*Arguments*:
+* ``filename`` Path to the file containing the local users
+* ``hostname`` Host that you are trying to match against
 
-Returns: `array`
+*Returns*: `array`
 
 #### **mapval**
 
-This function has been deprecated
-
 Pull a mapped value from a text file. Must provide a Ruby regex!.
 
-Returns: `string`
+*Returns*: `string`
 
 #### **nets2cidr**
 
-
-This function has been deprecated
-It has been replaced by simplib::nets2cidr
+*This function is deprecated and has been replaced by*
+[simplib::nets2cidr](#simplibnets2cidr).
 
 Convert an array of networks into CIDR notation
 
@@ -1176,8 +1442,8 @@ Returns: `array`
 
 #### **nets2ddq**
 
-This function has been deprecated
-It has been replaced by simplib::nets2ddq
+*This function is deprecated and has been replaced by*
+[simplib::nets2ddq](#simplibnets2ddq).
 
 Convert an array of networks into dotted quad notation
 
@@ -1185,8 +1451,8 @@ Returns: `array`
 
 #### **parse\_hosts**
 
-This function has been deprecated
-It has been replaced by simplib::parse\_hosts
+*This function is deprecated and has been replaced by*
+[simplib::parse\_hosts](#simplibparse_hosts).
 
 Take an array of items that may contain port numbers or protocols and return
 the host information, ports, and protocols. Works with hostnames, IPv4, and
@@ -1217,11 +1483,11 @@ Returns: `hash`
 
 #### **passgen**
 
-This function has been deprecated
-It has been replaced by simplib::passgen
+*This function is deprecated and has been replaced by*
+[simplib::passgen](#simplibpassgen).
 
 Generates a random password string for a passed identifier. Uses
-Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
+Puppet\[:environmentpath\]/\$environment/simp_autofiles/gen_passwd/ as the
 destination directory.
 
 ```
@@ -1249,8 +1515,8 @@ Returns: `string`
 
 #### **rand\_cron**
 
-This function has been deprecated
-It has been replaced by simplib::rand\_cron
+*This function is deprecated and has been replaced by*
+[simplib::rand\_cron](#simplibrand_cron).
 
 Provides a "random" value to cron based on the passed integer value.
 Used to avoid starting a certain cron job at the same time on all
@@ -1274,15 +1540,11 @@ Returns: `integer` or `array`
 
 #### **simp\_version**
 
-This function has been deprecated
-
 Return the version of SIMP that this server is running.
 
 Returns: `string`
 
 #### **slice\_array**
-
-This function has been deprecated
 
 Split an array into an array of arrays that contain groupings of 'max_length'
 size. This is similar to 'each_slice' in newer versions of Ruby.
@@ -1302,8 +1564,8 @@ Returns: `array of arrays`
 
 #### **strip\_ports**
 
-This function has been deprecated
-It has been replaced by simplib::strip\_ports
+*This function is deprecated and has been replaced by*
+[simplib::strip\_ports](#simplibstrip_ports).
 
 Take an array of items that may contain port numbers and appropriately return
 the non-port portion. Works with hostnames, IPv4, and IPv6.
@@ -1322,29 +1584,27 @@ Returns: `array`
 
 #### **to\_integer**
 
-This function has been deprecated
-It has been replaced by simplib::to\_integer
+*This function is deprecated and has been replaced by*
+[simplib::to\_integer](#simplibto_integer).
 
 Converts the argument into an Integer.
 
-Only works if the passed argument responds to the 'to\_i' Ruby method.
+Only works if the passed argument responds to the ``to_i()`` Ruby method.
 
 Returns: `integer`
 
 #### **to\_string**
 
-This function has been deprecated
-It has been replaced by simplib::to\_string
+*This function is deprecated and has been replaced by*
+[simplib::to\_string](#simplibto_string).
 
 Converts the argument into a String.
 
-Only works if the passed argument responds to the 'to\_s' Ruby method.
+Only works if the passed argument responds to the ``to_s()`` Ruby method.
 
 Returns: `string`
 
-#### **validate\_array\_of\_hashes**_
-
-This function has been deprecated
+#### **validate\_array\_of\_hashes**
 
 Validate that the passed argument is either an empty array or an array that
 only contains hashes.
@@ -1361,8 +1621,8 @@ Returns: `boolean`
 
 #### **validate\_array\_member**
 
-This function has been deprecated
-It has been replaced by simplib::validate\_array\_member
+*This function is deprecated and has been replaced by*
+[simplib::validate\_array\_member](#simplibvalidate_array_member)
 
 Validate that the first string (or array) passed is a member of the second
 array passed. An optional third argument of i can be passed, which ignores
@@ -1383,8 +1643,8 @@ Returns: `boolean`
 
 #### **validate\_between**
 
-This function has been deprecated
-It has been replaced by simplib::validate\_between
+*This function is deprecated and has been replaced by*
+[simplib::validate\_between](#simplibvalidate_between)
 
 Validate that the first value is between the second and third values
 numerically.
@@ -1395,8 +1655,8 @@ Returns: `boolean`
 
 #### **validate\_bool\_simp**
 
-This function has been deprecated
-It has been replaced by simplib::validate\_bool
+*This function is deprecated and has been replaced by*
+[simplib::validate\_bool](#simplibvalidate_bool)
 
 Validate that all passed values are either true or false. Abort catalog
 compilation if any value fails this check.
@@ -1427,8 +1687,8 @@ Returns: `boolean`
 
 #### **validate\_deep\_hash**
 
-This function has been deprecated
-It has been replaced by simplib::validate\_deep\_hash
+*This function is deprecated and has been replaced by*
+[simplib::validate\_deep\_hash](#simplibvalidate_deep_hash)
 
 Perform a deep validation on two passed hashes.
 
@@ -1476,23 +1736,20 @@ Returns: `boolean`
 
 #### **validate\_float**
 
-This function has been deprecated.
-
-Validates whether or not the passed argument is a float.
+Validates whether the passed argument is a float.
 
 Returns: `boolean`
 
 #### **validate\_integer**
 
-This function has been deprecated.
-
-Validates whether or not the passed argument is an integer.
+Validates whether the passed argument is an integer.
 
 Returns: `boolean`
 
 #### **validate\_macaddress**
 
-This function has been deprecated.
+*This function is deprecated and has been replaced by*
+``Simplib::Macaddress`` data type.
 
 Validate that all passed values are valid MAC addresses.
 
@@ -1510,10 +1767,10 @@ Returns: `boolean`
 
 #### **validate\_port**
 
-This function has been deprecated.
-It has been replaced by simplib::validate\_port
+*This function is deprecated and has been replaced by*
+[simplib::validate\_port](#simplibvalidate_port)
 
-Validates whether or not the passed argument is a valid port (i.e.  between
+Validates whether the passed argument is a valid port (i.e.  between
 1 - 65535).
 
 The following values will pass:
@@ -1538,12 +1795,12 @@ Returns: `boolean`
 
 #### **validate\_net\_list**
 
-This function has been deprecated.
-It has been replaced by simplib::validate\_net\_list
+*This function is deprecated and has been replaced by*
+[simplib::validate\_net\_list](#simplibvalidate_net_list)
 
 Validate that a passed list (Array or single String) of networks is filled
 with valid IP addresses or hostnames. Hostnames are checked per
-[RFC 1123](https://tools.ietf.org/html/rfc1123).Ports appended with a colon (:)
+[RFC 1123](https://tools.ietf.org/html/rfc1123). Ports appended with a colon (:)
 are allowed.
 
 There is a second, optional argument that is a regex of strings that should be
@@ -1576,8 +1833,8 @@ Returns: `boolean`
 
 #### **validate\_re\_array**
 
-This function has been deprecated.
-It has been replaced by simplib::validate\_re\_array
+*This function is deprecated and has been replaced by*
+[simplib::validate\_re\_array](#simplibvalidate_re_array)
 
 Perform simple validation of a string, or array of strings, against one or
 more regular expressions. The first argument of this function should be a
@@ -1614,8 +1871,8 @@ Returns: `boolean`
 
 #### **validate\_sysctl\_value**
 
-This function has been deprecated.
-It has been replaced by simplib::validate\_sysctl\_value
+*This function is deprecated and has been replaced by*
+[simplib::validate\_sysctl\_value](#simplibvalidate_sysctl_value)
 
 Validate that the passed value is correct for the passed sysctl key.
 
@@ -1627,7 +1884,8 @@ Returns: `boolean`
 
 #### **validate\_umask**
 
-This function has been deprecated.
+*This function is deprecated and has been replaced by*
+``Simplib::Umask`` data type.
 
 Validate that the passed value is a valid umask string.
 
@@ -1643,8 +1901,8 @@ Returns: `boolean`
 
 #### **validate\_uri\_list**
 
-This function is deprecated and is replaced by
-simplib::validate\_uri\_list
+*This function is deprecated and has been replaced by*
+[simplib::validate\_uri\_list](#simplibvalidate_uri_list)
 
 Usage: validate\_uri\_list(\[LIST\],\[\])
 
@@ -1676,47 +1934,50 @@ Returns: `boolean`
 #### **ftpusers**
 
 Adds all system users to the named file, preserving any other
-          entries currently in the file.
-
-*Examples*:
-```puppet
-    #This will add all users in /etc/passwd with uid < 500
-    # and nobody and jim to the file /etc/ftpusers'
-    #
-    ftpusers { '/etc/ftpusers':
-      min_id      => 500,
-      always_deny => ['nobody', 'jim'],
-      require     => File['/etc/ftpusers']
-    }
-
-```
-#### **init_ulimit**
-This type is for systems that do not support systemd.
-It will update the ``ulimit`` settings in init scripts.
-
-*Examples*:
-```puppet
-# Long Names
-
-    init_ulimit { 'rsyslog':
-      ensure     => 'present',
-      limit_type => 'both'
-      item       => 'max_open_files',
-      value      => 'unlimited'
-    }
-
-# Short Names
-
-    init_ulimit { 'rsyslog':
-      item       => 'n',
-      value      => 'unlimited'
-    }
-```
-
-####  **prepend_file_line**
-Type that can prepend whole a line to a file if it does not already contain it.
+entries currently in the file.
 
 *Example*:
+
+```puppet
+  # This will add all users in /etc/passwd with uid < 500
+  # and 'nobody' and 'jim' to the file '/etc/ftpusers'
+  #
+  ftpusers { '/etc/ftpusers':
+    min_id      => 500,
+    always_deny => ['nobody', 'jim'],
+    require     => File['/etc/ftpusers']
+  }
+```
+#### **init_ulimit**
+
+**This type is for systems that do not support ``systemd``.**
+
+Updates the ``ulimit`` settings in init scripts.
+
+*Examples*:
+```puppet
+  # limit long name
+  init_ulimit { 'rsyslog':
+    ensure     => 'present',
+    limit_type => 'both'
+    item       => 'max_open_files',
+    value      => 'unlimited'
+  }
+
+  # limit short name
+  init_ulimit { 'rsyslog':
+    item       => 'n',
+    value      => 'unlimited'
+  }
+```
+
+#### **prepend_file_line**
+
+Prepends a whole line to a file, if the file does not already contain
+the line.
+
+*Example*:
+
 ```puppet
   file_prepend_line { 'sudo_rule':
     path => '/etc/sudoers',
@@ -1725,177 +1986,199 @@ Type that can prepend whole a line to a file if it does not already contain it.
 ```
 
 #### **reboot_notify**
+
 Notifies users when a system reboot is required.
 
-This type creates a file at $target the contents of which
-provide a summary of the reasons why the system requires a
-reboot.
-
-NOTE: This type will *only* register entries on refresh. Any
-other use of the type will not report the necessary reboot.
-
-A reboot notification will be printed at each puppet run until
-the system is successfully rebooted
+* This type creates a file with contents that provide a summary
+  of the reasons why the system requires a reboot.
+* This type will *only* register entries on refresh. Any
+  other use of the type will not report the necessary reboot.
+* A reboot notification will be printed at each Puppet run until
+  the system is successfully rebooted
 
 *Examples*:
+
 ```puppet
-    reboot_notify { 'selinux':
-      reason    => 'A reboot is required to completely modify selinux state',
-      subscribe => Selinux_state['set_selinux_state']
-    }
+  reboot_notify { 'selinux':
+    reason    => 'A reboot is required to completely modify selinux state',
+    subscribe => Selinux_state['set_selinux_state']
+  }
 ```
 #### **runlevel**
-Changes the system runlevel by re-evaluating the inittab or systemd link.
 
-*Examples*: 
+Changes the system runlevel by re-evaluating the ``inittab`` or ``systemd`` link.
+
+*Examples*:
+
 ```puppet
   # Set the current level and the default level to mulit-user
-
   runlevel { '3': persist => true, }
 
   # Set the current level to graphical
-
   runlevel { 'graphical':
     persist => false
   }
 ```
+
 #### **script_umask**
-Alters the umask settings in the passed file if a umask line exists.
+
+Alters the umask settings in the passed file, if a umask line exists.
 
 *Examples*:
+
 ```puppet
   script_umask { '/usr/local/myscript.sh':
       umask => 077
   }
 ```
 
-####  **simp_file_line**
+#### **simp_file_line**
+
 Ensures that a given line is contained within a file.  The implementation
 matches the full line, including whitespace at the beginning and end.  If
 the line is not contained in the given file, Puppet will add the line to
 ensure the desired state.  Multiple resources may be declared to manage
 multiple lines in the same file.
 
-This is an enhancement to the stdlib file_line that allows for the
+This is an enhancement to the stdlib ``file_line`` that allows for the
 following additional options:
-   * prepend     => [binary] Prepend the line instead of appending it if not
-                    using 'match'
-   * deconflict  => [binary] Do not execute if there is a file resource that
+
+   * ``prepend``    Whether to prepend the line instead of appending it,
+                    if not using the ``match`` option.
+   * ``deconflict`` Whether to not execute if there is a file resource that
                     already manipulates the content of the target file.
 
 *Examples*:
+
 ```puppet
+  # This will add both lines to /etc/sudoers
+  simp_file_line { 'sudo_rule':
+    path => '/etc/sudoers',
+    line => '%sudo ALL=(ALL) ALL',
+  }
+  simp_file_line { 'sudo_rule_nopw':
+    path => '/etc/sudoers',
+    line => '%sudonopw ALL=(ALL) NOPASSWD: ALL',
+  }
 
-   # This will add both lines to /etc/sudoers
-   simp_file_line { 'sudo_rule':
-     path => '/etc/sudoers',
-     line => '%sudo ALL=(ALL) ALL',
-   }
-   simp_file_line { 'sudo_rule_nopw':
-     path => '/etc/sudoers',
-     line => '%sudonopw ALL=(ALL) NOPASSWD: ALL',
-   }
+  # This will not add the line
+  file { '/tmp/myfile':
+    content => 'junk content',
+  }
+  simp_file_line { 'junk':
+    path => '/tmp/myfile',
+    line => 'What a beautiful day'
+  }
 
-   # This will not add the line
-   file { '/tmp/myfile':
-     content => 'junk content',
-   }
-   simp_file_line { 'junk':
-     path => '/tmp/myfile',
-     line => 'What a beautiful day'
-   }
-
-   # This will  add the line
-   file { '/tmp/myfile':
-     content => 'junk content',
-     replace => false
-   }
-   simp_file_line { 'junk':
-     path => '/tmp/myfile',
-     line => 'What a beautiful day'
-   }
-
+  # This will  add the line
+  file { '/tmp/myfile':
+    content => 'junk content',
+    replace => false
+  }
+  simp_file_line { 'junk':
+    path => '/tmp/myfile',
+    line => 'What a beautiful day'
+  }
 ```
 
 ### Data Types
 
 The following Puppet 4 compatible Data Types have been added for convenience
-and validation across the SIMP codebase.
+and validation across the SIMP code base.
 
-* Simplib::EmailAddress
-    * Simple e-mail address validator
+* ``Simplib::Domain``
+    * Valid DNS domain names (RFC 3696, Section 2). Examples:
+        * ``example.com``
+
+* ``Simplib::Domainlist``
+    * List of valid domains (RFC 3696, Section 2)
+
+* ``Simplib::EmailAddress``
+    * Simple e-mail address validator. Examples:
         * ``foo@bar.com``
 
-* Simplib::Host
-    * A single Host or an IP Address
+* ``Simplib::Host``
+    * A single Host or an IP Address. Examples:
         * ``1.2.3.4``
         * ``my-host.com``
 
-* Simplib::Host::Port
-    * A single Host or an IP Address with a Port
+* ``Simplib::Host::Port``
+    * A single Host or an IP Address with a Port. Examples:
         * ``1.2.3.4:80``
         * ``my-host.com:443``
 
-* Simplib::Hostname
-    * A hostname, Unicode hostnames are not currently supported
+* ``Simplib::Hostname``
+    * A hostname, Unicode hostnames are not currently supported.
+      Examples:
         * ``my-host.com``
         * ``aa.bb``
 
-* Simplib::IP
-    * An IP Address
+* ``Simplib::Hostname::Port``
+    * A single Hostname with a Port. Examples:
+        * ``my-host.com:443``
+
+* ``Simplib::IP``
+    * An IP Address. Examples:
         * ``1.2.3.4``
         * ``2001:0db8:85a3:0000:0000:8a2e:0370:7334``
 
-* Simplib::IP::Port
-    * An IP Address (V4 or V6) with a Port
-
-* Simplib::IP::V4
-    * An IPv4 Address
-        * ``1.2.3.4``
-
-* Simplib::IP::CIDR
-    * An IPv4 or IPv6 Address with a CIDR Subnet
+* ``Simplib::IP::CIDR``
+    * An IPv4 or IPv6 Address with a CIDR Subnet. Examples:
         * ``1.2.3.4/24``
         * ``2001:0db8:85a3:0000:0000:8a2e:0370:7334/96``
 
-* Simplib::IP::V4::CIDR
-    * An IPv4 Address with a CIDR Subnet
+* ``Simplib::IP::Port``
+    * An IP Address (V4 or V6) with a Port. Examples:
+        * ``1.2.3.4:80``
+        * ``[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443``
+
+* ``Simplib::IP::V4``
+    * An IPv4 Address. Examples:
+        * ``1.2.3.4``
+
+* ``Simplib::IP::V4::CIDR``
+    * An IPv4 Address with a CIDR Subnet. Examples:
         * ``1.2.3.4/24``
 
-* Simplib::IP::V4::DDQ
-    * An IPv4 Address with a Dotted Quad Subnet
+* ``Simplib::IP::V4::DDQ``
+    * An IPv4 Address with a Dotted Quad Subnet. Examples:
         * ``1.2.3.4/255.255.0.0``
 
-* Simplib::IP::V4::Port
-    * An IPv4 Address with an attached Port
+* ``Simplib::IP::V4::Port``
+    * An IPv4 Address with an attached Port. Examples:
         * ``1.2.3.4:443``
 
-* Simplib::IP::V6
-    * An IPv6 Address
+* ``Simplib::IP::V6``
+    * An IPv6 Address. Examples:
         * ``::1``
         * ``2001:0db8:85a3:0000:0000:8a2e:0370:7334``
         * ``[::1]``
         * ``[2001:0db8:85a3:0000:0000:8a2e:0370:7334]``
 
-* Simplib::IP::V6::Base
-    * A regular IPv6 Address
+* ``Simplib::IP::V6::Base``
+    * A regular IPv6 Address. Examples:
         * ``::1``
         * ``2001:0db8:85a3:0000:0000:8a2e:0370:7334``
 
-* Simplib::IP::V6::Bracketed
-    * A bracketed IPv6 Address
+* ``Simplib::IP::V6::Bracketed``
+    * A bracketed IPv6 Address. Examples:
         * ``[::1]``
         * ``[2001:0db8:85a3:0000:0000:8a2e:0370:7334]``
 
-* Simplib::IP::V6::CIDR
-    * An IPv6 address with a CIDR subnet
+* ``Simplib::IP::V6::CIDR``
+    * An IPv6 address with a CIDR subnet. Examples:
         * ``2001:0db8:85a3:0000:0000:8a2e:0370:7334/96``
 
-* Simplib::IP::V6::Port
-    * An IPv6 address with an attached Port
+* ``Simplib::IP::V6::Port``
+    * An IPv6 address with an attached Port. Examples:
         * ``[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443``
 
-* Simplib::Netlist
+* ``Simplib::Macaddress``
+    * A MAC address. Examples:
+        * ``CA:FE:BE:EF:00:11``
+        * ``ca:fe:be:ef:00:11``
+
+* ``Simplib::Netlist``
     * An Array of network-relevant entries
         * Hostname
         * IPv4
@@ -1905,114 +2188,145 @@ and validation across the SIMP codebase.
         * IPv4 with Subnet
         * IPv4 with Port
 
-* Simplib::Netlist::Host
+* ``Simplib::Netlist::Host``
     * An Array of Hosts
         * Hostname
         * IPv4
         * IPv6
 
-* Simplib::Netlist::IP
+* ``Simplib::Netlist::IP``
     * An Array of IP Addresses
         * IPv4
         * IPv6
 
-* Simplib::Netlist::IP::V4
+* ``Simplib::Netlist::IP::V4``
     * An Array of IPv4 Addresses
 
-* Simplib::Netlist::IP::V6
+* ``Simplib::Netlist::IP::V6``
     * An Array of IPv6 Addresses
 
-* Simplib::Netlist::Port
+* ``Simplib::Netlist::Port``
     * An Array of Hosts with Ports
 
-* Simplib::Port
+* ``Simplib::PackageEnsure``
+    * Valid ``ensure`` values for a ``Package`` resource. Examples:
+        * ``absent``
+        * ``latest``
+
+* ``Simplib::Port``
     * A Port Number
 
-* Simplib::Port::Dynamic
-    * Either 49152 or 65535
+* ``Simplib::Port::Dynamic``
+    * Port in the unprivileged port range [49152, 65535]
 
-* Simplib::Port::Random
-    * Port 0
+* ``Simplib::Port::Random``
+    * Port ``0`` which has different behaviors but usually binds to
+      a random port
 
-* Simplib::Port::System
-    * 1-1024
+* ``Simplib::Port::System``
+    * Port in the system privileged port range [1, 1024]
 
-* Simplib::Port::User
-    * 1025-49151
-    * 49153-65534
+* ``Simplib::Port::User``
+    * Port available to users in the unprivileged port ranges [1025, 49151]
+      and [49153, 65534]
 
-* Simplib::Syslog::CFacility
-  * A syslog log facility, in the form expected by ``syslog(3)``
-    * LOG_KERN
-    * LOG_LOCAL6
+* ``Simplib::Puppet::Metadata::OS_support``
+    * The 'operating\_support' data structure in a Puppet module's
+      ``metadata.json``
 
-* Simplib::Syslog::CPriority
-  * A syslog log priority, in the form expected by ``syslog(3)``
-    * LOG_KERN.LOG_INFO
-    * LOG_LOCAL6.LOG_WARNING
+* ``Simplib::Serverdistribution``
+    * Valid options for a Puppet server distribution
+        * ``PC1``
+        * ``PE``
 
-* Simplib::Syslog::CSeverity
-  * A syslog log severity, in the form expected by ``syslog(3)``
-    * LOG_INFO
-    * LOG_WARNING
+* ``Simplib::Syslog::CFacility``
+    * A syslog log facility, in the form expected by ``syslog(3)``.
+      Examples:
+        * ``LOG_KERN``
+        * ``LOG_LOCAL6``
 
-* Simplib::Syslog::Facility
-  * A syslog log facility, in either all uppercase or all lowercase.
-    * kern
-    * local6
-    * LOCAL6
+* ``Simplib::Syslog::CPriority``
+    * A syslog log priority, in the form expected by ``syslog(3)``.
+      Examples:
+        * ``LOG_KERN.LOG_INFO``
+        * ``LOG_LOCAL6.LOG_WARNING``
 
-* Simplib::Syslog::LowerFacility
-  * A syslog log facility, in all lowercase.
-    * auth
-    * local4
+* ``Simplib::Syslog::CSeverity``
+    * A syslog log severity, in the form expected by ``syslog(3)``.
+      Examples:
+        * ``LOG_INFO``
+        * ``LOG_WARNING``
 
-* Simplib::Syslog::UpperFacility
-  * A syslog log facility, in all uppercase.
-    * MAIL
-    * LOCAL7
+* ``Simplib::Syslog::Facility``
+    * A syslog log facility, in either all uppercase or all lowercase..
+      Examples:
+        * ``kern``
+        * ``local6``
+        * ``LOCAL6``
 
-* Simplib::Syslog::Severity
-  * A syslog severity level, in either all uppercase or all lowercase.
-    * info
-    * WARNING
+* ``Simplib::Syslog::LowerFacility``
+    * A syslog log facility, in all lowercase. Examples:
+        * ``auth``
+        * ``local4``
 
-* Simplib::Syslog::LowerSeverity
-  * A syslog severity level, in all lowercase.
-    * info
-    * emerg
+* ``Simplib::Syslog::UpperFacility``
+    * A syslog log facility, in all uppercase. Examples:
+        * ``MAIL``
+        * ``LOCAL7``
 
-* Simplib::Syslog::UpperSeverity
-  * A syslog severity level, in all uppercase.
-    * DEBUG
-    * WARNING
+* ``Simplib::Syslog::Severity``
+    * A syslog severity level, in either all uppercase or all lowercase.
+      Examples:
+        * ``info``
+        * ``WARNING``
 
-* Simplib::Syslog::Priority
-  * A syslog priority destination, in format 'facility.severity' and in either
-    all uppercase or all lowercase. This type only accepts the keyword
-    facilities and severities.
-    * mail.info
-    * KERN.EMERG
+* ``Simplib::Syslog::LowerSeverity``
+    * A syslog severity level, in all lowercase. Examples:
+        * ``info``
+        * ``emerg``
 
-* Simplib::Syslog::LowerPriority
-  * A syslog priority destination, in format 'facility.severity' and in only
-    all lowercase. This type only accepts the keyword
-    facilities and severities.
-    * mail.info
-    * user.err
+* ``Simplib::Syslog::UpperSeverity``
+    * A syslog severity level, in all uppercase. Examples:
+        * ``DEBUG``
+        * ``WARNING``
 
-* Simplib::Syslog::UpperPriority
-  * A syslog priority destination, in format 'facility.severity' and in only
-    all uppercase. This type only accepts the keyword
-    facilities and severities.
-    * SYSLOG.WARNING
-    * AUTHPRIV.INFO
+* ``Simplib::Syslog::Priority``
+    * A syslog priority destination, in format 'facility.severity' and
+      in either all uppercase or all lowercase. This type only accepts
+      the keyword facilities and severities. Examples:
+        * ``mail.info``
+        * ``KERN.EMERG``
 
-* Simplib::Umask
+* ``Simplib::Syslog::LowerPriority``
+    * A syslog priority destination, in format 'facility.severity' and
+      in only all lowercase. This type only accepts the keyword
+      facilities and severities. Examples:
+        * ``mail.info``
+        * ``user.err``
+
+* ``Simplib::Syslog::UpperPriority``
+    * A syslog priority destination, in format 'facility.severity' and
+      in only all uppercase. This type only accepts the keyword
+      facilities and severities. Examples:
+        * ``SYSLOG.WARNING``
+        * ``AUTHPRIV.INFO``
+
+* ``Simplib::Umask``
     * A valid Umask
 
-* Simplib::URI
+* ``Simplib::URI``
     * A valid URI string (lightly sanity checked)
+
+### Stages
+
+ ``simplib::stages`` are added to ensure that anyone using the ``stdlib`` stages are not
+ tripped up by any SIMP modules that may enable, or disable, various system,
+ components; particularly ones that require a reboot.
+
+ Added Stages:
+
+   * ``simp_prep`` -> Comes before ``stdlib``'s ``setup`` stage
+   * ``simp_finalize`` -> Comes after ``stdlib``'s ``deploy`` stage
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ around them for clarity.
   #       }
   #     }
   #   }
-
+```
 *Returns*: `Hash` Structured Hash of the host information
 
 #### **simplib::passgen**
@@ -470,13 +470,13 @@ Transforms an input string to one or more interval values for `cron`.
 This can be used to avoid starting a certain cron job at the same
 time on all servers.
 
-Arguments:
+*Arguments*:
 * ``modifier``    The input string to use as the basis for the generated values
 * ``algorithm``   Randomization algorithm to apply to transform the input string.
 * ``occurs``      (Optional) The occurrence within an interval
 * ``max\_value``  (Optional) The maximum value for the interval.
 
-Example:
+*Examples*:
 ```puppet
    # Generate one value for the `minute` cron interval using using sha256
    simplib::rand_cron('myhost.test.local','sha256')
@@ -532,7 +532,6 @@ the case of the objects inside the array.
 * ``modifier`` (Optional) If 'i' ignores case.
 
 *Examples*:
-
 ```ruby
 validate_array_member('foo',['foo','bar'])     # => true
 validate_array_member('foo',['FOO','BAR'])     # => false
@@ -650,14 +649,12 @@ support a to\_s() method.
   to_check  => { 'foo' => 'abc' }
 
   simplib::validate_deep_hash(reference, to_check)
-
 ```
 *Returns*: `nil` Fails catalog compilation they do not match.
 
 #### **simplib::validate_port**
 Validates whether or not the passed argument is a valid port (i.e.  between
 1 - 65535).  It will work on strings ot integers.
-
 
 *Arguments*:
 * ``port\_args``  A port or array of ports.
@@ -671,13 +668,11 @@ $ports = [5555, 7777, 1, 65535]
 simplib::validate_port($port)
 simplib::validate_port($ports)
 simplib::validate_port($port, $ports)
-```
 
-The following values will not pass:
+# The following values will not pass:
 
-```puppet
-validate_port('0')
-validate_port(65536)
+simplib::validate_port('0')
+simplib::validate_port(65536)
 ```
 
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
@@ -696,7 +691,7 @@ a colon `:` are allowed for hostnames and individual IP addresses.
 ```puppet
 #  Passing
 
-  $trusted_nets = '10.10.10.0/24'
+   $trusted_nets = '10.10.10.0/24'
    simplib::validate_net_list($trusted_nets)
 
    $trusted_nets = '1.2.3.5:400'

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Fails a puppet catalog compile if the client system is not compatible
 with the module's `meta_data.json`
 
 *Arguments:*
-* module\_name  module name
-* options       (Optional) Behavior modifiers for the function)
+* ``module\_name``  module name
+* ``options``       (Optional) Behavior modifiers for the function)
 
 Options takes the form:
   enable => If set to `false` disable all validation
@@ -178,8 +178,8 @@ Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
 environment variable is set to 'true'
 
 *Arguments*:
-* key      Uniqueness key, which is used to dedupe of messages)
-* message  Message to be printed, file and line info
+* ``key``      Uniqueness key, which is used to dedupe of messages)
+* ``message``  Message to be printed, file and line info
            will be appended if available.)
 
 *Examples*:
@@ -203,13 +203,13 @@ point (and potentially break systems)
 Generates a random password string.
 
 *Arguments*:
-* length           (Optional) Integer - length of the string to return
-* complexity       (Optional) Integer -Specifies the types of characters to be used in the password)
+* ``length``           (Optional) Integer - length of the string to return
+* ``complexity``       (Optional) Integer -Specifies the types of characters to be used in the password)
                      `0` => Use only Alphanumeric characters (safest)
                      `1` => Use Alphanumeric characters and reasonably safe symbols
                      `2` => Use any printable ASCII characters
-* complex\_only    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
-* timeout\_seconds (Optional) Integer or Float - Maximum time allotted to generate
+* ``complex\_only``    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
+* ``timeout\_seconds`` (Optional) Integer or Float - Maximum time allotted to generate
                      the password; a value of 0 disables the timeout
 
 *Returns*: `String` Generated password
@@ -236,11 +236,11 @@ This can be used to avoid starting a certain cron job at the same
 time on all servers.ovides a "random" value to cron based on the passed integer value.
 
 *Arguments*:
-* occurs     (Optional) The occurrence within an interval, i.e.,
+* ``occurs``     (Optional) The occurrence within an interval, i.e.,
                 the number of values to be generated for the interval.
-* max\_value (Optional) The maximum value for the interval.  The values
+* ``max\_value`` (Optional) The maximum value for the interval.  The values
                 generated will be in the inclusive range [0, max_value].
-* algorithm  (Optional) When 'ip_mod', the modulus of the IP number is used as the basis
+* ``algorithm``  (Optional) When 'ip_mod', the modulus of the IP number is used as the basis
                 for the returned values.  This algorithm works well to create
                 cron job intervals for multiple hosts, when the number of hosts
                 exceeds the `max_value` and the hosts have largely, linearly-
@@ -250,7 +250,7 @@ time on all servers.ovides a "random" value to cron based on the passed integer 
                 works well to create cron job intervals for multiple hosts,
                 when the number of hosts is less than the `max_value` or the
                 hosts do not have linearly-assigned IP addresses.
-* ip         (Optional) The IP address to use as the basis for the generated values.
+* ``ip``         (Optional) The IP address to use as the basis for the generated values.
                  When `nil`, the 'ipaddress' fact (IPv4) is used.
 
 *Examples*:
@@ -274,8 +274,8 @@ Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
 *Arguments*:
-* system\_mount\_opts System mount options
-* new\_mount\_opts    New mount options, which will override
+* ``system\_mount\_opts`` System mount options
+* ``new\_mount\_opts``    New mount options, which will override
                         `system_opts` when there are conflicts
 
 *Returns*: `String`
@@ -285,7 +285,7 @@ always override the first.
 Uses the knockout prefix of '--' to remove elements from an array.
 
 *Arguments*:
-* array  The array to work on
+* ``array``  The array to work on
 
 *Examples*:
 ```puppet
@@ -305,8 +305,8 @@ Uses the knockout prefix of '--' to remove elements from an array.
 Takes a DNS domain name and converts it to an LDAP domain name.
 
 Arguments:
-* domain               (Optional) The dns domain name, defaults to fact domain.
-* downcase\_attributes (Optional) Whether or not to downcase the LDAP attributes, false
+* ``domain``               (Optional) The dns domain name, defaults to fact domain.
+* ``downcase\_attributes`` (Optional) Whether or not to downcase the LDAP attributes, false
 
 *Returns*: `String`
 
@@ -319,10 +319,10 @@ check the global scope first to see if the variable has been defined.
 
 This means that you can pre-declare a class and/or use an ENC and look up the
 variable whether it is declared this way or via Hiera or some other back-end.
-  # @param param The parameter that you wish to look up
+
 *Arguments*:
-* param     The parameter you wish to look up.
-* options   (Optional)Hash of options for regular ``lookup()``
+* ``param``     The parameter you wish to look up.
+* ``options``   (Optional)Hash of options for regular ``lookup()``
             This **must** follow the syntax rules for the
             Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
             No other formats are supported!
@@ -343,8 +343,8 @@ variable whether it is declared this way or via Hiera or some other back-end.
 A mock data function
 
 *Arguments*:
-* options
-* context
+* ``options``
+* ``context``
 
 *Returns*: `Any`
 
@@ -354,7 +354,7 @@ CIDR notation.
 Hostnames are passed through untouched.
 
 *Arguments*:
-* networks\_list  List of 1 or more networks separated by spaces,
+* ``networks\_list``  List of 1 or more networks separated by spaces,
                  commas, or semicolons
 
 *Returns* `Array[String]` Array of networks in CIDR notation
@@ -367,7 +367,7 @@ CIDR networks are converted to dotted quad notation networks.
 IP addresses and hostnames are left untouched.
 
 *Arguments*:
-* networks  The networks to convert
+* ``networks``  The networks to convert
 
 *Examples*:
 ```puppet
@@ -397,7 +397,7 @@ Works with Hostnames as well as IPv4 and IPv6 addresses.
 around them for clarity.
 
 *Arguments*:
-hosts   Array of host entries, where each entry may contain
+* ``hosts``   Array of host entries, where each entry may contain
         a protocol or both a protocol and port
 
 *Examples*:
@@ -431,8 +431,8 @@ The minimum length password that this function will return is 6
 characters.
 
 *Arguments*:
-* identifier      Unique `String` to identify the password usage.
-* modifier\_hash  (Optional) may contain any of the following options:
+* ``identifier``      Unique `String` to identify the password usage.
+* ``modifier\_hash``  (Optional) may contain any of the following options:
                     - 'last' => false(*) or true
                       * Return the last generated password
                     - 'length' => Integer
@@ -471,18 +471,18 @@ This can be used to avoid starting a certain cron job at the same
 time on all servers.
 
 Arguments:
-* modifier    The input string to use as the basis for the generated values
-* algorithm   Randomization algorithm to apply to transform the input string.
-* occurs      (Optional) The occurrence within an interval
-* max\_value  (Optional) The maximum value for the interval.
+* ``modifier``    The input string to use as the basis for the generated values
+* ``algorithm``   Randomization algorithm to apply to transform the input string.
+* ``occurs``      (Optional) The occurrence within an interval
+* ``max\_value``  (Optional) The maximum value for the interval.
 
 Example:
 ```puppet
    # Generate one value for the `minute` cron interval using using sha256
    simplib::rand_cron('myhost.test.local','sha256')
 
-  *Generate 2 values for the `hour` cron interval, using the
-  #   'ip_mod' algorithm
+  # Generate 2 values for the `hour` cron interval, using the
+  # 'ip_mod' algorithm
   simplib::rand_cron('10.0.6.78', 'ip_mod', 2, 23)
 ```
 
@@ -527,9 +527,9 @@ array passed. An optional third argument of i can be passed, which ignores
 the case of the objects inside the array.
 
 *Arguments*:
-* input    The element to find in the target array.
-* target   The array to search.
-* modifier (Optional) If 'i' ignores case.
+* ``input``    The element to find in the target array.
+* ``target``   The array to search.
+* ``modifier`` (Optional) If 'i' ignores case.
 
 *Examples*:
 
@@ -552,9 +552,9 @@ numerically, inclusively. Fail catalog compile if not.
 Deprecated:  You should be able to use type declarions instead of this.
 
 *Arguments*:
-* value       Value to validate
-* min\_value   Minimum value that is valid
-* max\_value   Maximum value that is valid
+* ``value``       Value to validate
+* ``min\_value``   Minimum value that is valid
+* ``max\_value``   Maximum value that is valid
 
 *Returns*: `nil`
 
@@ -568,7 +568,7 @@ Modified from the stdlib validate\_bool to handle the strings 'true' and
 The following values will pass:
 
 *Arguments*:
-* values\_to\_validate   The value to validate.
+* ``values\_to\_validate``   The value to validate.
 
 *Examples*:
 ```ruby
@@ -609,8 +609,8 @@ All values in the final leaves of the `Hash` being compared must
 support a to\_s() method.
 
 *Arguments*:
-* reference   Reference Hash
-* to\_check   Hash to validate.
+* ``reference``   Reference Hash
+* ``to\_check``   Hash to validate.
 
 *Examples*:
 ```puppet
@@ -660,7 +660,7 @@ Validates whether or not the passed argument is a valid port (i.e.  between
 
 
 *Arguments*:
-* port\_args  A port or array of ports.
+* ``port\_args``  A port or array of ports.
 
 *Examples*:
 ```puppet
@@ -689,8 +689,8 @@ or hostnames. Hostnames are checked per RFC 1123. Ports appended with
 a colon `:` are allowed for hostnames and individual IP addresses.
 
 *Arguments*:
-* net         Single network to be validated.
-* str\_match  (Optional) A regex of `String` that should be ignored
+* ``net``         Single network to be validated.
+* ``str\_match``  (Optional) A regex of `String` that should be ignored
               from the list. Omit the beginning and ending `/` delimiter.
 *Examples*:
 ```puppet
@@ -722,10 +722,10 @@ against one or more regular expressions.
 Derived from the Puppet Labs stdlib validate\_re.
 
 *Arguments*:
-* input   String to be validated
-* regex   Stringified regex expression (regex without the `//`
+* ``input``   String to be validated
+* ``regex``   Stringified regex expression (regex without the `//`
    delimiters)
-* err\_msg  (Optional) error message to emit upon failure
+* ``err\_msg``  (Optional) error message to emit upon failure
 
 *Examples*:
 ```puppet
@@ -749,8 +749,8 @@ Validate that the passed value is correct for the passed sysctl key.
 If a key is not know, simply returns that the value is valid.
 
 *Arguments*:
-* key    sysctl setting whose value is to be validated
-* value  Value to be validated
+* ``key``    sysctl setting whose value is to be validated
+* ``value``  Value to be validated
 
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
 
@@ -761,8 +761,8 @@ Caution:  No scheme (protocol type) validation is done the scheme_list
 parameter is not set.
 
 *Arguments*:
-* uri          URI to be validated.
-* scheme\_list (Optional) List of schemes (protocol types) allowed for the URI.
+* ``uri``          URI to be validated.
+* ``scheme\_list`` (Optional) List of schemes (protocol types) allowed for the URI.
 
 *Examples*:
 ```puppet

--- a/README.md
+++ b/README.md
@@ -1593,13 +1593,13 @@ Returns: `boolean`
 
 ### Types
 
-* **ftpusers**
-* **init_ulimit**
-* **prepend_file_line**
-* **reboot_notify**
-* **runlevel**
-* **script_umask**
-* **simp_file_line**
+* [**ftpusers**](#ftpusers)
+* [**init_ulimit**](#init_ulimit)
+* [**prepend_file_line**](#prepend_file_line)
+* [**reboot_notify**](#reboot_notify)
+* [**runlevel**](#runlevel)
+* [**script_umask**](#script_umask)
+* [**simp_file_line**](#simp_file_line)
 
 #### **ftpusers**
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ itself for more detailed documentation.
 ### Functions
 
 
-- [assert\_metadata](#sbassertmetadata)
+- [assert\_metadata](#assert_metadata)
 - [deprecation](#simplibdeprecation)
-- [filtered](#simplib::filtered)
+- [filtered](#simplib\:\:filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
 - [ip\_to\_cron](#simplib::ip_to_cron)
 - [ipaddresses](#simplib::ipaddresses)
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplibassert_metadata
+#### assert_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib assert\_metadata {#sbassertmetadata}
+#### simplib::assert\_metadata {#sbassertmetadata}
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`
@@ -165,7 +165,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### **simplib::deprecation**
+#### **simplib::deprecation** {#simplibdeprecation}
 
 Function to print deprecation warnings, logging a warning once
 for a given key.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib::assert\_metadata {#sbassertmetadata}
+#### simplibassert_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`
@@ -165,7 +165,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### **simplib::deprecation** {#simplibdeprecation}
+#### **simplibdeprecation** 
 
 Function to print deprecation warnings, logging a warning once
 for a given key.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ itself for more detailed documentation.
 ### Functions
 
 
-- [simplib::assert\_metadata](#simplib+assert_metadata)
-- [deprecation](#simplib\:\:deprecation)
+- [assert\_metadata](#sbassertmetadata)
+- [deprecation](#simplibdeprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
 - [ip\_to\_cron](#simplib::ip_to_cron)
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib assert_metadata
+#### simplib assert\_metadata {#sbassertmetadata}
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ itself for more detailed documentation.
 ### Functions
 
 
-- [assert\_metadata](#assert\_metadata)
+- [assert\_metadata](#simplibassert_metadata)
 - [deprecation](#simplibdeprecation)
-- [filtered](#simplib\:\:filtered)
-- [gen\_random\_password](#simplib::gen_random_password)
-- [ip\_to\_cron](#simplib::ip_to_cron)
-- [ipaddresses](#simplib::ipaddresses)
+- [filtered](#simplibfiltered)
+- [gen\_random\_password](#simplibgen_random_password)
+- [ip\_to\_cron](#simplibip_to_cron)
+- [ipaddresses](#simplibipaddresses)
 - [join\_mount\_opts](#simplib::join_mount_opts)
 - [knockout](#simplib::knockout)
 - [ldap::domain\_to\_dn](#simplib::ldap::domain_to_dn)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
     * [Facts](#facts)
     * [Functions](#functions)
+    * [Puppet Extensions](#puppet-extensions)
     * [Puppet 3 Functions](#puppet-3-functions)
     * [Types](#types)
     * [Data Types](#data-types)
@@ -37,6 +38,7 @@ resources to Puppet:
   * Custom Types and Providers
   * Facts
   * Functions
+  * Puppet Extensions
   * Puppet 3 Functions (deprecated functions that will be removed in the near future)
 
 ## Setup
@@ -197,8 +199,8 @@ This allows hiera data to be delegated to end users in a multi-tenant
 environment without allowing them the ability to override every hiera data
 point (and potentially break systems)
 
-
 #### **simplib::gen_random_password**
+
 Generates a random password string.
 
 *Arguments*:
@@ -224,9 +226,7 @@ an argument is passed, and is not false, then only return non-local addresses.
 * ``only_remote`` (Optional) Whether to exclude local addresses
      from the return value.
 
-
 *Returns*: `Array`
-
 
 #### **simplib::ip_to_cron**
 
@@ -310,6 +310,7 @@ Arguments:
 *Returns*: `String`
 
 #### **simplib::lookup**
+
 A function for falling back to global scope variable lookups when the
 Puppet 4 ``lookup()`` function cannot find a value.
 
@@ -337,8 +338,8 @@ variable whether it is declared this way or via Hiera or some other back-end.
 
 *Returns*: `Any` The value that is found in the system for the passed
 
-
 #### **simplib::nets2cidr**
+
 Take an input list of networks and returns an equivalent `Array` in
 CIDR notation.
 Hostnames are passed through untouched.
@@ -350,6 +351,7 @@ Hostnames are passed through untouched.
 *Returns* `Array[String]` Array of networks in CIDR notation
 
 #### **simplib::nets2ddq**
+
 Tranforms a list of networks into an equivalent array in
 dotted quad notation.
 
@@ -378,6 +380,7 @@ IP addresses and hostnames are left untouched.
            or hostname
 
 #### **simplib::parse_hosts**
+
 Convert an `Array` of items that may contain port numbers or protocols
 into a structured `Hash` of host information.
 
@@ -399,7 +402,6 @@ around them for clarity.
     'https://1.2.3.4:443'
   ])
   #   Returns:
-  #
   #   {
   #     '1.2.3.4' => {
   #       :ports     => ['443'],
@@ -413,6 +415,7 @@ around them for clarity.
 *Returns*: `Hash` Structured Hash of the host information
 
 #### **simplib::passgen**
+
 Generates a random password string for a passed identifier. Returns
 the password or a hash of the password depending on arguments.  It also
 stores the password on the puppetserver using
@@ -763,12 +766,78 @@ simplib::validate_uri_list($uris,['ldap','ldaps'])
 
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
 
-### Puppet 3 Functions
+### Puppet Extensions
+- [hostname_only?](#hostname_only?)
+- [hostname?](#hostname)
+-
+
+
+#### **hostname_only?**
+Determine whether or not the passed value is a valid hostname.
+Returns false if is not comprised of ASCII letters (upper or lower case),
+digits, hypens (except at the beginning and end), and dots (except at
+beginning and end)
+NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+
+*Examples*:
+```ruby
+  # Returns True
+  PuppetX::SIMP::Simplib.hostname?('hostname.me.com')
+
+  # Returns false
+  PuppetX::SIMP::Simplib.hostname?('-hostname.me.com')
+
+  # Returns false
+  PuppetX::SIMP::Simplib.hostname?('hostname.me.com:5454')
+
+```
+*Returns*: `Boolean`
+
+#### **hostname?**
+Determine whether or not the passed value is a valid hostname optionally
+postpended with ':<number>' or '/<number>'.
+Returns false if is not comprised of ASCII letters (upper or lower case),
+digits, hypens (except at the beginning and end), and dots (except at
+beginning and end), optional pluss ':<number>' or '/<number>'
+NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+*Examples*:
+```ruby
+  # Returns True
+  PuppetX::SIMP::Simplib.hostname?('hostname.me.com')
+
+  # Returns false
+  PuppetX::SIMP::Simplib.hostname?('-hostname.me.com')
+
+  # Returns true
+  PuppetX::SIMP::Simplib.hostname?('hostname.me.com:5454')
+```
+
+*Returns*: `Boolean`
+
+#### **split_port**
+Return a host/port pair
+
+*Examples*:
+```ruby
+  PuppetX::SIMP::Simplib.split_port['myhost.name:5656']
+  #returns ['myhost.name','5656']
+
+  PuppetX::SIMP::Simplib.split_port['192.165.3.9/24']
+  #returns [nil, nil]
+
+  PuppetX::SIMP::Simplib.split_port['192.165.3.9']
+  #returns ['192.165.3.9',nil]
+```
+
+*Returns*: `Array[ hostname, port]`
+
+### Deprecated Puppet 3 Functions
 
 These functions have all been deprecated.  This is here for information purposes only.
 Use functions from the `Functions` section in new code.
-Many of them have been replaced by standard puppet functions or functionality in
-later versionis of puppet.
+Many of them have been replaced by standard puppet functions, data type functionality
+in puppet 4 and later versions.
+
 If there is a corresponding simplib function for versions of puppet later than
 version 3, it is noted in the comments.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### assert_metadata
+#### simplib::assert_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`
@@ -165,7 +165,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### **simplibdeprecation** 
+#### **simplib::deprecation** 
 
 Function to print deprecation warnings, logging a warning once
 for a given key.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [assert\_metadata](#simplib::assert\_metadata)
+- [assert\_metadata](#simplib::assert_metadata)
 - [deprecation](#simplib::deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
@@ -142,7 +142,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib::assert\_metadata
+#### **simplib::assert_metadata**
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`
@@ -163,7 +163,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### simplib::deprecation
+#### **simplib::deprecation
 
 Function to print deprecation warnings, logging a warning once
 for a given key.
@@ -183,7 +183,7 @@ Returns: `hash`
 
 #### **simplib::filtered**
 
-#### **simplib::gen\_random\_password**
+#### **simplib::gen_random_password**
 
 
 #### **simplib::ipaddresses**
@@ -191,9 +191,9 @@ Returns: `hash`
 Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
 
-**Type**: `array`
+*Type*: `array`
 
-#### simplib::ip\_to\_cron
+#### **simplib::ip_to_cron**
 
 Provides a "random" value to cron based on the passed integer value.
 Used to avoid starting a certain cron job at the same time on all
@@ -216,24 +216,24 @@ simplib::ip_to_cron(2,24) - returns an array of two values between 0..23
 
 Returns: `integer` or `array`
 
-#### simplib::join\_mount\_opts
+#### **simplib::join_mount_opts**
 
 Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
-**Type**: `string`
+*Type*: `string`
 
-#### simplib::knockout
+#### **simplib::knockout**
 
 Uses the knockout prefix of '--' to remove elements from an array.
 
 Arguments:
 * array (The array to work on)
 
-**Type**: `array`
+*Type*: `array`
 
 
-#### simplib::ldap::domain\_to\_dn
+#### **simplib::ldap::domain_to_dn**
 
 Takes a DNS domain name and converts it to an LDAP domain name.
 
@@ -241,27 +241,27 @@ Arguments:
 * domain (The dns domain name)
 * downcase_attributes (Whether or not to downcase the LDAP attributes)
 
-**Type**: `string`
+*Type*: `string`
 
-#### simplib::lookup
-
-
-#### simplib::mock\_data
+#### **simplib::lookup**
 
 
-#### simplib::nets2cidr
+#### **simplib::mock_data**
+
+
+#### **simplib::nets2cidr**
 
 Convert an array of networks into CIDR notation
 
-**Type**: `array`
+*Type*: `array`
 
-#### simplib::nets2ddq
+#### **simplib::nets2ddq**
 
 Convert an array of networks into dotted quad notation
 
-**Type**: `array`
+*Type*: `array`
 
-#### simplib::parse\_hosts
+#### **simplib::parse_hosts**
 
 Take an array of items that may contain port numbers or protocols and return
 the host information, ports, and protocols. Works with hostnames, IPv4, and
@@ -287,9 +287,9 @@ simplib::parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
 
 -----------------
 
-**Type**: `hash`
+*Type*: `hash`
 
-#### simplib::passgen
+#### **simplib::passgen**
 
 Generates a random password string for a passed identifier. Uses
 Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
@@ -316,9 +316,9 @@ characters.
     currently stored string.
 ```
 
-**Type**: `string`
+*Type*: `string`
 
-#### simplib::rand\_cron
+#### **simplib::rand_cron**
 
 Transforms an input string to one or more interval values for `cron`.
 This can be used to avoid starting a certain cron job at the same
@@ -337,9 +337,9 @@ simplib::rand_cron(100,2)    - returns an array of two values between 0..59 base
 simplib::rand_cron(100,2,24) - returns an array of two values between 0..23 based on the value 100
 ```
 
-**Type**: Array[Integer]
+*Type*: Array[Integer]
 
-#### simplib::strip\_ports
+#### **simplib::strip_ports**
 
 Take an array of items that may contain port numbers and appropriately return
 the non-port portion. Works with hostnames, IPv4, and IPv6.
@@ -356,15 +356,15 @@ $bar contains: ['https://mysite.net','http://yoursite.net','theirsite.com']
 
 Returns: `array`
 
-#### simplib::to\_integer
+#### **simplib::to_integer**
 
 Converts the argument into an Integer.
 
-Only works if the passed argument responds to the 'to\_i' Ruby method.
+Only works if the passed argument responds to the 'to_i' Ruby method.
 
 Returns: `integer`
 
-#### simplib::to\_string
+#### **simplib::to_string**
 
 Converts the argument into a String.
 
@@ -373,7 +373,7 @@ Only works if the passed argument responds to the 'to\_s' Ruby method.
 Returns: `string`
 
 
-#### simplib::validate\_array\_member
+#### **simplib::validate_array_member**
 
 Validate that the first string (or array) passed is a member of the second
 array passed. An optional third argument of i can be passed, which ignores
@@ -392,7 +392,7 @@ validate_array_member('foo',['FOO','BAR'],'i') # => true
 
 Returns: `boolean`
 
-#### simplib::validate\_between
+#### **simplib::validate_between**
 
 Validate that the first value is between the second and third values
 numerically.
@@ -401,7 +401,7 @@ This is a pure Ruby comparison, not a human comparison.
 
 Returns: `boolean`
 
-#### simplib::validate\_bool
+#### **simplib::validate_bool**
 
 Validate that all passed values are either true or false. Abort catalog
 compilation if any value fails this check.
@@ -430,7 +430,7 @@ validate_bool($some_array)
 
 Returns: `boolean`
 
-#### simplib::validate\_deep\_hash
+#### **simplib::validate_deep_hash**
 
 Perform a deep validation on two passed hashes.
 
@@ -476,7 +476,7 @@ validated against. Unknown keys in the hash being compared will cause a
 
 Returns: `boolean`
 
-#### simplib::validate\_port
+#### **simplib::validate_port**
 
 Validates whether or not the passed argument is a valid port (i.e.  between
 1 - 65535).
@@ -501,7 +501,7 @@ validate_port('65536')
 
 Returns: `boolean`
 
-#### simplib::validate\_net\_list
+#### **simplib::validate_net_list**
 
 Validate that a passed list (Array or single String) of networks is filled
 with valid IP addresses or hostnames. Hostnames are checked per
@@ -536,7 +536,7 @@ validate_net_list($trusted_nets)
 
 Returns: `boolean`
 
-#### simplib::validate\_re\_array
+#### **simplib::validate_re_array**
 
 Perform simple validation of a string, or array of strings, against one or
 more regular expressions. The first argument of this function should be a
@@ -571,7 +571,7 @@ value does not match 2.7')
 
 Returns: `boolean`
 
-#### simplib::validate\_sysctl\_value
+#### **simplib::validate_sysctl_value****
 
 Validate that the passed value is correct for the passed sysctl key.
 
@@ -581,7 +581,7 @@ Example:
 
 Returns: `boolean`
 
-#### simplib::validate\_uri\_list
+#### **simplib::validate_uri_list**
 
 Usage: validate\_uri\_list(\[LIST\],\[\])
 
@@ -864,7 +864,7 @@ Detect if an IP address is contained in the passed whitespace delimited list.
 
 Returns: `boolean`
 
-#### **ip\_to\_cron**
+#### **ip\_to_cron**
 
 This function has been deprecated
 It has been replaced by simplib::ip\_to\_cron
@@ -890,7 +890,7 @@ ip_to_cron(2,24) - returns an array of two values between 0..23
 
 Returns: `integer` or `array`
 
-#### **join\_mount\_opts**
+#### **join_mount_opts**
 
 This function has been deprecated
 It has been replaced by simplib::join\_mount\_opts

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     * [Beginning with simplib](#beginning-with-simplib)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+    * [Stages](#stages)
     * [Facts](#facts)
     * [Functions](#functions)
     * [Puppet Extensions](#puppet-extensions)
@@ -67,7 +68,7 @@ itself for more detailed documentation.
 
 ### Stages
 
- simplib::stages are added to ensure that anyone using the stdlib stages was not
+ simplib::stages are added to ensure that anyone using the stdlib stages are not
  tripped up by any simp modules that may enable, or disable, various system,
  components; particularly ones that require a reboot.
 

--- a/README.md
+++ b/README.md
@@ -120,52 +120,56 @@ itself for more detailed documentation.
 - [gen\_random\_password](#simplibgen_random_password)
 - [ip\_to\_cron](#simplibip_to_cron)
 - [ipaddresses](#simplibipaddresses)
-- [join\_mount\_opts](#simplib::join_mount_opts)
-- [knockout](#simplib::knockout)
-- [ldap::domain\_to\_dn](#simplib::ldap::domain_to_dn)
-- [lookup](#simplib::lookup)
-- [mock\_data](#simplib::mock_data)
-- [nets2cidr](#simplib::nets2cidr)
-- [nets2ddq](#simplib::nets2ddq)
-- [parse\_hosts](#simplib::parse_hosts)
-- [passgen](#simplib::passgen)
-- [rand\_cron](#simplib::rand_cron)
-- [strip\_ports](#simplib::strip_ports)
-- [to\_integer](#simplib::to_integer)
-- [to\_string](#simplib::to_string)
-- [validate\_array\_member](#simplib::validate_array_member)
-- [validate\_between](#simplib::validate_between)
-- [validate\_bool](#simplib::validate_bool)
-- [validate\_deep\_hash](#simplib::validate_deep_hash)
-- [validate\_net\_list](#simplib::validate_net_list)
-- [validate\_port](#simplib::validate_port)
-- [validate\_re\_array](#simplib::validate_re_array)
-- [validate\_sysctl\_value](#simplib::validate_sysctl_value)
-- [validate\_uri\_list](#simplib::validate_uri_list)
+- [join\_mount\_opts](#simplibjoin_mount_opts)
+- [knockout](#simplibknockout)
+- [ldap::domain\_to\_dn](#simplibldapdomain_to_dn)
+- [lookup](#simpliblookup)
+- [mock\_data](#simplibmock_data)
+- [nets2cidr](#simplibnets2cidr)
+- [nets2ddq](#simplibnets2ddq)
+- [parse\_hosts](#simplibparse_hosts)
+- [passgen](#simplibpassgen)
+- [rand\_cron](#simplibrand_cron)
+- [strip\_ports](#simplibstrip_ports)
+- [to\_integer](#simplibto_integer)
+- [to\_string](#simplibto_string)
+- [validate\_array\_member](#simplibvalidate_array_member)
+- [validate\_between](#simplibvalidate_between)
+- [validate\_bool](#simplibvalidate_bool)
+- [validate\_deep\_hash](#simplibvalidate_deep_hash)
+- [validate\_net\_list](#simplibvalidate_net_list)
+- [validate\_port](#simplibvalidate_port)
+- [validate\_re\_array](#simplibvalidate_re_array)
+- [validate\_sysctl\_value](#simplibvalidate_sysctl_value)
+- [validate\_uri\_list](#simplibvalidate_uri_list)
 
 
 #### simplib::assert\_metadata
 
-Fails a compile if the client system is not compatible with the module's
-`meta_data.json`
+Fails a puppet catalog compile if the client system is not compatible
+with the module's `meta_data.json`
 
-Arguments:
-* module\_name
-* options (Behavior modifiers for the function)
+*Arguments:*
+* module\_name  module name
+* options       (Optional) Behavior modifiers for the function)
 
 Options takes the form:
-* enable => If set to `false` disable all validation
-* os
-  * validate => Whether or not to validate the OS settings
-  * options
-    * release\_match => Enum['none','full','major']
-      none  -> No match on minor release (default)
-      full  -> Full release must match
-      major -> Only the major release must match
+  enable => If set to `false` disable all validation
+  os
+    validate => Whether or not to validate the OS settings
+    options
+      release\_match => Enum['none','full','major']
+        none  -> No match on minor release (default)
+        full  -> Full release must match
+        major -> Only the major release must match
 
-*Type*: `nil`
+*Example*:
+```puppet
+    simplib::assert_metadata('mymodule')
+```
+*Returns*: `nil`
 
-#### **simplib::deprecation** 
+#### **simplib::deprecation**
 
 Function to print deprecation warnings, logging a warning once
 for a given key.
@@ -173,66 +177,127 @@ for a given key.
 Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
 environment variable is set to 'true'
 
-*Examples:*
+*Arguments*:
+* key      Uniqueness key, which is used to dedupe of messages)
+* message  Message to be printed, file and line info
+           will be appended if available.)
+
+*Examples*:
 
 ```puppet
-deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::dconf and will be removed in a future version')
-# Writes message to log if SIMPLIB_LOG_DEPRECATIONS is true.
-
-*Type*: `nil`
-
-Returns: `hash`
+  simplib::deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::dconf and will be removed in a future version')
+  # Writes message to log if SIMPLIB_LOG_DEPRECATIONS is true.
+```
+*Returns*: `nil`
 
 #### **simplib::filtered**
+Hiera v5 backend that takes a list of allowed hiera key names, and only
+returns results from the underlying backend function that match those keys.
+
+This allows hiera data to be delegated to end users in a multi-tenant
+environment without allowing them the ability to override every hiera data
+point (and potentially break systems)
+
 
 #### **simplib::gen_random_password**
+Generates a random password string.
 
+*Arguments*:
+* length           (Optional) Integer - length of the string to return
+* complexity       (Optional) Integer -Specifies the types of characters to be used in the password)
+                     `0` => Use only Alphanumeric characters (safest)
+                     `1` => Use Alphanumeric characters and reasonably safe symbols
+                     `2` => Use any printable ASCII characters
+* complex\_only    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
+* timeout\_seconds (Optional) Integer or Float - Maximum time allotted to generate
+                     the password; a value of 0 disables the timeout
+
+*Returns*: `String` Generated password
+
+Raises a RuntimeError if password cannot be created within allotted time
 
 #### **simplib::ipaddresses**
 
 Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
 
-*Type*: `array`
+*Arguments*:
+* only\_remote (Optional) Whether to exclude local addresses
+     from the return value.
+
+
+*Returns*: `Array`
+
 
 #### **simplib::ip_to_cron**
 
-Provides a "random" value to cron based on the passed integer value.
-Used to avoid starting a certain cron job at the same time on all
-servers.  If used with no parameters, it will return a single value between
-0-59. first argument is the occurrence within a timeframe, for example if you
-want it to run 2 times per hour the second argument is the timeframe, by
-default its 60 minutes, but it could also be 24 hours etc
+Transforms an IP address to one or more interval values for `cron`.
+This can be used to avoid starting a certain cron job at the same
+time on all servers.ovides a "random" value to cron based on the passed integer value.
 
-Pulled from: http://projects.puppetlabs.com/projects/puppet/wiki/Cron_Patterns/8/diff
-Author: ohadlevy@gmail.com
-License: None
+*Arguments*:
+* occurs     (Optional) The occurrence within an interval, i.e.,
+                the number of values to be generated for the interval.
+* max\_value (Optional) The maximum value for the interval.  The values
+                generated will be in the inclusive range [0, max_value].
+* algorithm  (Optional) When 'ip_mod', the modulus of the IP number is used as the basis
+                for the returned values.  This algorithm works well to create
+                cron job intervals for multiple hosts, when the number of hosts
+                exceeds the `max_value` and the hosts have largely, linearly-
+                assigned IP addresses.
+                When 'sha256', a random number generated using the IP address
+                string is the basis for the returned values.  This algorithm
+                works well to create cron job intervals for multiple hosts,
+                when the number of hosts is less than the `max_value` or the
+                hosts do not have linearly-assigned IP addresses.
+* ip         (Optional) The IP address to use as the basis for the generated values.
+                 When `nil`, the 'ipaddress' fact (IPv4) is used.
 
-Example:
+*Examples*:
+  Generate one value for the `minute` cron interval
 
 ```ruby
-simplib::ip_to_cron()     - returns one value between 0..59
-simplib::ip_to_cron(2)    - returns an array of two values between 0..59
-simplib::ip_to_cron(2,24) - returns an array of two values between 0..23
+    simplib::ip_to_cron()
 ```
+  Generate 2 values for the `hour` cron interval, using the
+  sha256' algorithm and a provided IP address
+```ruby
+     simplib::ip_to_cron(2,23,'sha256','10.0.23.45')
+```
+*Returns*: `Array[Integer]` Array of integers suitable for use in the
+  ``minute`` or ``hour`` cron field.
 
-Returns: `integer` or `array`
 
 #### **simplib::join_mount_opts**
 
 Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
-*Type*: `string`
+*Arguments*:
+* system\_mount\_opts System mount options
+* new\_mount\_opts    New mount options, which will override
+                        `system_opts` when there are conflicts
+
+*Returns*: `String`
 
 #### **simplib::knockout**
 
 Uses the knockout prefix of '--' to remove elements from an array.
 
-Arguments:
-* array (The array to work on)
+*Arguments*:
+* array  The array to work on
 
-*Type*: `array`
+*Examples*:
+```puppet
+  array = [
+    'ssh',
+    'sudo',
+    '--ssh',
+  ]
+  result = simplib::knockout(array)
+# returns: result => [ 'sudo' ]
+```
+*Returns*: `Array`
 
 
 #### **simplib::ldap::domain_to_dn**
@@ -240,85 +305,164 @@ Arguments:
 Takes a DNS domain name and converts it to an LDAP domain name.
 
 Arguments:
-* domain (The dns domain name)
-* downcase_attributes (Whether or not to downcase the LDAP attributes)
+* domain               (Optional) The dns domain name, defaults to fact domain.
+* downcase\_attributes (Optional) Whether or not to downcase the LDAP attributes, false
 
-*Type*: `string`
+*Returns*: `String`
 
 #### **simplib::lookup**
+A function for falling back to global scope variable lookups when the
+Puppet 4 ``lookup()`` function cannot find a value.
+
+While ``lookup()`` will stop at the back-end data sources, ``lookup()`` will
+check the global scope first to see if the variable has been defined.
+
+This means that you can pre-declare a class and/or use an ENC and look up the
+variable whether it is declared this way or via Hiera or some other back-end.
+  # @param param The parameter that you wish to look up
+*Arguments*:
+* param     The parameter you wish to look up.
+* options   (Optional)Hash of options for regular ``lookup()``
+            This **must** follow the syntax rules for the
+            Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+            No other formats are supported!
+*Examples*:
+```puppet
+  # No defaults
+  simplib::lookup('foo::bar::baz')
+  # With a default
+  simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana' })
+  # With a typed default
+  simplib::lookup('foo::bar::baz', { 'default_value' => 'Banana', 'value_type' => String })
+```
+
+*Returns*: `Any` The value that is found in the system for the passed
 
 
 #### **simplib::mock_data**
+A mock data function
 
+*Arguments*:
+* options
+* context
+
+*Returns*: `Any`
 
 #### **simplib::nets2cidr**
+Take an input list of networks and returns an equivalent `Array` in
+CIDR notation.
+Hostnames are passed through untouched.
 
-Convert an array of networks into CIDR notation
+*Arguments*:
+* networks\_list  List of 1 or more networks separated by spaces,
+                 commas, or semicolons
 
-*Type*: `array`
+*Returns* `Array[String]` Array of networks in CIDR notation
 
 #### **simplib::nets2ddq**
+Tranforms a list of networks into an equivalent array in
+dotted quad notation.
 
-Convert an array of networks into dotted quad notation
+CIDR networks are converted to dotted quad notation networks.
+IP addresses and hostnames are left untouched.
 
-*Type*: `array`
+*Arguments*:
+* networks  The networks to convert
+
+*Examples*:
+```puppet
+  # Convert Array input
+  $foo = [ '10.0.1.0/24',
+           '10.0.2.0/255.255.255.0',
+           '10.0.3.25',
+           'myhost' ]
+  $bar = simplib::nets2ddq($foo)
+  #
+  # returns  $bar = [ '10.0.1.0/255.255.255.0',
+  #                   '10.0.2.0/255.255.255.0',
+  #                   '10.0.3.25',
+```
+
+*Returns*: `Array[String]` Converted input
+           raise RuntimeError if any input item is not a valid network
+           or hostname
 
 #### **simplib::parse_hosts**
+Convert an `Array` of items that may contain port numbers or protocols
+into a structured `Hash` of host information.
 
-Take an array of items that may contain port numbers or protocols and return
-the host information, ports, and protocols. Works with hostnames, IPv4, and
-IPv6.
+Works with Hostnames as well as IPv4 and IPv6 addresses.
 
-Example:
+**NOTE:** IPv6 addresses will be returned normalized with square brackets
+around them for clarity.
 
-```ruby
-simplib::parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
-# returns: '1.2.3.4' => {
-#           ports => ['443'],
-#           protocols => {
-#             'http' => [],
-#             'https' => ['443']
-#           }
-#         }
-```
------------------
+*Arguments*:
+hosts   Array of host entries, where each entry may contain
+        a protocol or both a protocol and port
 
-> **NOTE**
->
-> IPv6 addresses will be returned normalized with square brackets
+*Examples*:
+```puppet
+  # Input with multiple host formats:
+  simplib::parse_hosts([
+    '1.2.3.4',
+    'http://1.2.3.4',
+    'https://1.2.3.4:443'
+  ])
+  #   Returns:
+  #
+  #   {
+  #     '1.2.3.4' => {
+  #       :ports     => ['443'],
+  #       :protocols => {
+  #         'http'  => [],
+  #         'https' => ['443']
+  #       }
+  #     }
+  #   }
 
------------------
-
-*Type*: `hash`
+*Returns*: `Hash` Structured Hash of the host information
 
 #### **simplib::passgen**
-
 Generates a random password string for a passed identifier. Uses
 Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
 destination directory.
 
-```
 The minimum length password that this function will return is 6
 characters.
 
-    Arguments: identifier, <modifier hash>; in that order.
-
-    <modifier hash> may contain any of the following options:
-      - 'last' => false(*) or true
-        * Return the last generated password
-      - 'length' => Integer
-        * Length of the new password
-      - 'hash' => false(*), true, md5, sha256 (true), sha512
-        * Return a hash of the password instead of the password itself.
-      - 'complexity' => 0(*), 1, 2
-        * 0 => Use only Alphanumeric characters in your password (safest) 1 =>
-        * Add reasonably safe symbols 2 => Printable ASCII
+*Arguments*:
+* identifier      Unique `String` to identify the password usage.
+* modifier\_hash  (Optional) may contain any of the following options:
+                    - 'last' => false(*) or true
+                      * Return the last generated password
+                    - 'length' => Integer
+                      * Length of the new password
+                    - 'hash' => false(*), true, md5, sha256 (true), sha512
+                      * Return a hash of the password instead of the password itself.
+                    - 'complexity' => 0(*), 1, 2
+                      * 0 => Use only Alphanumeric characters in your password (safest) 1 =>
+                      * Add reasonably safe symbols 2 => Printable ASCII
 
     If no, or an invalid, second argument is provided then it will return the
     currently stored string.
 ```
+*Examples*:
+```puppet
+    #run pasgen for the firstime
+    password = simplib::passgen('myfavpasswd',{'length'=> 34})
+    #returns password = string of length 34 plain text.
 
-*Type*: `string`
+    # Generate the password and return the hash
+    password = simplib::passgen('yourfavpasswd',{ hash => 'sha256' })
+    # returns sha256 hash of generated password and salt.
+
+    # To retrieve the above password (assuming the above command
+    #  was run previously in the catalog or on an earlier catalog run:
+    password = simplib::passgen('yourfavpasswd')
+    # returns the 32 character password generated by the first call
+```
+
+*Returns*: `String` Password specified
 
 #### **simplib::rand_cron**
 
@@ -327,61 +471,67 @@ This can be used to avoid starting a certain cron job at the same
 time on all servers.
 
 Arguments:
-* modifier
-* algorithm
-* occurs
-* max\_value
+* modifier    The input string to use as the basis for the generated values
+* algorithm   Randomization algorithm to apply to transform the input string.
+* occurs      (Optional) The occurrence within an interval
+* max\_value  (Optional) The maximum value for the interval.
 
 Example:
-```ruby
-simplib::rand_cron('100')     - returns one value between 0..59 based on the value 100
-simplib::rand_cron(100,2)    - returns an array of two values between 0..59 based on the value 100
-simplib::rand_cron(100,2,24) - returns an array of two values between 0..23 based on the value 100
+```puppet
+   # Generate one value for the `minute` cron interval using using sha256
+   simplib::rand_cron('myhost.test.local','sha256')
+
+  *Generate 2 values for the `hour` cron interval, using the
+  #   'ip_mod' algorithm
+  simplib::rand_cron('10.0.6.78', 'ip_mod', 2, 23)
 ```
 
-*Type*: Array[Integer]
+*Returns*: `Array[Integer]` Array of integers suitable for use
+            in the ``minute`` or ``hour`` cron field
 
 #### **simplib::strip_ports**
+Extract list of unique hostnames and/or IP addresses from an `Array`
+of hosts, each of which may may contain protocols and/or port numbers
 
-Take an array of items that may contain port numbers and appropriately return
-the non-port portion. Works with hostnames, IPv4, and IPv6.
+*Arguments*:
+* hosts   Array of hosts which may contain protocols and port numbers
 
-```
+*Examples*:
+```puppet
 $foo = ['https://mysite.net:8443',
         'http://yoursite.net:8081',
         'https://theirsite.com']
 
 $bar = strip_ports($foo)
 
-$bar contains: ['https://mysite.net','http://yoursite.net','theirsite.com']
+# results  $bar = ['https://mysite.net','http://yoursite.net','theirsite.com']
 ```
 
-Returns: `array`
+*Returns*: `Array` Non-port portion of hostnames
 
 #### **simplib::to_integer**
-
 Converts the argument into an Integer.
+Only works if the passed argument responds to the 'to\_i' Ruby method.
 
-Only works if the passed argument responds to the 'to_i' Ruby method.
-
-Returns: `integer`
+*Returns*: `integer`
 
 #### **simplib::to_string**
-
 Converts the argument into a String.
-
 Only works if the passed argument responds to the 'to\_s' Ruby method.
 
-Returns: `string`
-
+*Returns*: `string`
 
 #### **simplib::validate_array_member**
-
 Validate that the first string (or array) passed is a member of the second
 array passed. An optional third argument of i can be passed, which ignores
 the case of the objects inside the array.
 
-Examples:
+*Arguments*:
+* input    The element to find in the target array.
+* target   The array to search.
+* modifier (Optional) If 'i' ignores case.
+
+*Examples*:
 
 ```ruby
 validate_array_member('foo',['foo','bar'])     # => true
@@ -392,19 +542,23 @@ validate_array_member('foo',['FOO','BAR'])     # => false
 validate_array_member('foo',['FOO','BAR'],'i') # => true
 ```
 
-Returns: `boolean`
+*Returns*: `Boolean` Whether or not the argument is an element of the
+            array.
 
 #### **simplib::validate_between**
-
 Validate that the first value is between the second and third values
-numerically.
+numerically, inclusively. Fail catalog compile if not.
 
-This is a pure Ruby comparison, not a human comparison.
+Deprecated:  You should be able to use type declarions instead of this.
 
-Returns: `boolean`
+*Arguments*:
+* value       Value to validate
+* min\_value   Minimum value that is valid
+* max\_value   Maximum value that is valid
+
+*Returns*: `nil`
 
 #### **simplib::validate_bool**
-
 Validate that all passed values are either true or false. Abort catalog
 compilation if any value fails this check.
 
@@ -413,6 +567,10 @@ Modified from the stdlib validate\_bool to handle the strings 'true' and
 
 The following values will pass:
 
+*Arguments*:
+* values\_to\_validate   The value to validate.
+
+*Examples*:
 ```ruby
 $iamtrue = true
 
@@ -430,148 +588,159 @@ $some_array = [ true ]
 validate_bool($some_array)
 ```
 
-Returns: `boolean`
+*Returns*: `nil` Fails catalog compilation if it is not a Boolean'
 
 #### **simplib::validate_deep_hash**
-
-Perform a deep validation on two passed hashes.
+Perform a deep validation on two passed `Hashes`.
 
 The first hash is the one to validate against, and the second is the one being
-validated. The first hash (i.e. the source) exists to define a valid structure
-and potential regular expression to validate against, or to skip an
-entry. Arrays of values will match each entry to the given regular expression.
-Below are examples of a source hash and a hash to compare against it:
+validated.
 
-```ruby
-    'source' = {
-       'foo' => {
-         'bar' => {
-           #NOTE: Use single quotes for regular expressions
-           'baz' => '^\d+$',
-           'abc' => '^\w+$',
-           'def' => nil #NOTE: not 'nil' in quotes
-         },
-         'baz' => {
-           'xyz' => '^true|false$'
-         }
+All keys must be defined in the reference `Hash` that is being
+validated against.
+
+Unknown keys in the `Hash` being compared will cause a failure in
+validation
+
+All values in the final leaves of the 'reference 'Hash' must
+be a String, Boolean, or nil.
+
+All values in the final leaves of the `Hash` being compared must
+support a to\_s() method.
+
+*Arguments*:
+* reference   Reference Hash
+* to\_check   Hash to validate.
+
+*Examples*:
+```puppet
+  # Passing Examples
+   reference = {
+     'foo' => {
+       'bar' => {
+         #NOTE: Use quotes for regular expressions instead of '/'
+         'baz' => '^\d+$',
+         'abc' => '^\w+$',
+         'def' => nil
+       },
+       'baz' => {
+         'qrs' => false
+         'xyz' => '^true|false$'
        }
      }
+   }
 
-    'to_check' = {
-       'foo' => {
-         'bar' => {
-           'baz' => '123',
-           'abc' => [ 'these', 'are', 'words' ],
-           'def' => 'Anything will work here!'
-         },
-         'baz' => {
-           'xyz' => 'false'
-         }
+   to_check = {
+     'foo' => {
+       'bar' => {
+         'baz' => ['123', 45]
+         'abc' => [ 'these', 'are', 'words' ],
+         'def' => 'Anything will work here!'
+       },
+       'baz' => {
+         'qrs' => false
+         'xyz' => true
        }
+     }
+   }
+  simplib::validate_deep_hash(reference, to_check)
+
+  # Failing Examples
+  reference => { 'foo' => '^\d+$' }
+  to_check  => { 'foo' => 'abc' }
+
+  simplib::validate_deep_hash(reference, to_check)
+
 ```
-
-This fails because we expect the value of 'foo' to be a series of digits, not
-letters.
-
-Additionally, all keys must be defined in the source hash that is being
-validated against. Unknown keys in the hash being compared will cause a
-
-Returns: `boolean`
+*Returns*: `nil` Fails catalog compilation they do not match.
 
 #### **simplib::validate_port**
-
 Validates whether or not the passed argument is a valid port (i.e.  between
-1 - 65535).
+1 - 65535).  It will work on strings ot integers.
 
-The following values will pass:
 
+*Arguments*:
+* port\_args  A port or array of ports.
+
+*Examples*:
 ```puppet
+# Examples that pass
 $port = '10541'
-$ports = ['5555', '7777', '1', '65535']
+$ports = [5555, 7777, 1, 65535]
 
-validate_port($port)
-validate_port($ports)
-validate_port('11', '22')
+simplib::validate_port($port)
+simplib::validate_port($ports)
+simplib::validate_port($port, $ports)
 ```
 
 The following values will not pass:
 
 ```puppet
 validate_port('0')
-validate_port('65536')
+validate_port(65536)
 ```
 
-Returns: `boolean`
+*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
-#### **simplib::validate_net_list**
+#### **simplib::validate\_net\_list**
+Validate that a passed list (`Array` or single `String`) of networks
+is filled with valid IP addresses, network addresses (CIDR notation),
+or hostnames. Hostnames are checked per RFC 1123. Ports appended with
+a colon `:` are allowed for hostnames and individual IP addresses.
 
-Validate that a passed list (Array or single String) of networks is filled
-with valid IP addresses or hostnames. Hostnames are checked per
-[RFC 1123](https://tools.ietf.org/html/rfc1123).Ports appended with a colon (:)
-are allowed.
+*Arguments*:
+* net         Single network to be validated.
+* str\_match  (Optional) A regex of `String` that should be ignored
+              from the list. Omit the beginning and ending `/` delimiter.
+*Examples*:
+```puppet
+#  Passing
 
-There is a second, optional argument that is a regex of strings that should be
-ignored from the list. Omit the beginning and ending '/' delimiters.
+  $trusted_nets = '10.10.10.0/24'
+   simplib::validate_net_list($trusted_nets)
 
-The following values will pass:
+   $trusted_nets = '1.2.3.5:400'
+   simplib::validate_net_list($trusted_nets)
 
-```ruby
-$trusted_nets = ['10.10.10.0/24','1.2.3.4','1.3.4.5:400']
-validate_net_list($trusted_nets)
+   $trusted_nets = 'ALL'
+   simplib::validate_net_list($trusted_nets,'^(%any|ALL)$')
 
-$trusted_nets = '10.10.10.0/24'
-validate_net_list($trusted_nets)
+# Failing
 
-$trusted_nets = ['10.10.10.0/24','1.2.3.4','any','ALL']
-validate_net_list($trusted_nets,'^(any|ALL)$')
+   $trusted_nets = '10.10.10.0/24,1.2.3.4'
+   simplib::validate_net_list($trusted_nets)
+
+   $trusted_nets = 'bad stuff'
+   simplib::validate_net_list($trusted_nets)
 ```
 
-The following values will fail:
+*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
-```ruby
-$trusted_nets = '10.10.10.0/24,1.2.3.4'
-validate_net_list($trusted_nets)
+#### **simplib::validate\_re\_array**
+Perform simple validation of a `String`, or `Array` of `Strings`,
+against one or more regular expressions.
+Derived from the Puppet Labs stdlib validate\_re.
 
-$trusted_nets = 'bad stuff'
-validate_net_list($trusted_nets)
+*Arguments*:
+* input   String to be validated
+* regex   Stringified regex expression (regex without the `//`
+   delimiters)
+* err\_msg  (Optional) error message to emit upon failure
+
+*Examples*:
+```puppet
+  #  Passing
+  simplib::validate_re_array('one', '^one$')
+  #
+  #  Failing
+  simplib::validate_re_array('one', '^two')
+  #
+  # Custom Error Message
+  simplib::validate_re_array($::puppetversion, '^2.7', 'The $puppetversion fact value does not match 2.7')
+  #
 ```
 
-Returns: `boolean`
-
-#### **simplib::validate_re_array**
-
-Perform simple validation of a string, or array of strings, against one or
-more regular expressions. The first argument of this function should be a
-string to test, and the second argument should be a stringified regular
-expression (without the // delimiters) or an array of regular expressions. If
-none of the regular expressions match the string passed in, compilation will
-abort with a parse error.
-
-If a third argument is specified, this will be the error message raised and
-seen by the user.
-
-The following strings will validate against the regular expressions:
-
-```ruby
-validate_re_array('one', '^one$')
-validate_re_array('one', [ '^one','^two' ])
-validate_re_array(['one','two'], [ '^one', '^two' ])
-```
-
-The following strings will fail to validate, causing compilation to abort:
-
-```ruby
-validate_re_array('one', [ '^two', '^three' ])
-```
-
-A helpful error message can be returned like this:
-
-```ruby
-validate_re_array($::puppetversion, '^2.7', 'The $puppetversion fact
-value does not match 2.7')
-```
-
-Returns: `boolean`
+*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 #### **simplib::validate_sysctl_value****
 
@@ -579,28 +748,33 @@ Validate that the passed value is correct for the passed sysctl key.
 
 If a key is not know, simply returns that the value is valid.
 
-Example:
+*Arguments*:
+* key    sysctl setting whose value is to be validated
+* value  Value to be validated
 
-Returns: `boolean`
+*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 #### **simplib::validate_uri_list**
+Validate that a passed list (`Array` or single `String`) of URIs is
+valid according to Ruby's URI parser.
+Caution:  No scheme (protocol type) validation is done the scheme_list
+parameter is not set.
 
-Usage: validate\_uri\_list(\[LIST\],\[\])
+*Arguments*:
+* uri          URI to be validated.
+* scheme\_list (Optional) List of schemes (protocol types) allowed for the URI.
 
-Validate that a passed list (Array or single String) of URIs is valid
-according to Ruby's URI parser.
-
-The following values will pass:
-
-```ruby
+*Examples*:
+```puppet
+# The following values will pass:
 $uris = [http://foo.bar.baz:1234','ldap://my.ldap.server']
-validate_uri_list($uris)
+simplib::validate_uri_list($uris)
 
 $uris = ['ldap://my.ldap.server','ldaps://my.ldap.server']
-validate_uri_list($uris,['ldap','ldaps'])
+simplib::validate_uri_list($uris,['ldap','ldaps'])
 ```
 
-Returns: `boolean`
+*Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 ### Puppet 3 Functions
 
@@ -758,14 +932,14 @@ hierarchy: # Each hierarchy consists of multiple levels
   - name: "datamodules"
     data_hash: simplib::filtered
     datadir: "delegated-data"
-    paths: 
+    paths:
             - "%{facts.sitename}/osfamily/%{facts.osfamily}.yaml"
             - "%{facts.sitename}/os/%{facts.operatingsystem}.yaml"
             - "%{facts.sitename}/host/%{facts.fqdn}.yaml"
             - "%{facts.sitename}/common.yaml"
-    options: 
+    options:
        function: yaml_data
-       filter: 
+       filter:
          - profiles::ntp::servers
          - profiles::.*
   - name: "Common"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Fails a puppet catalog compile if the client system is not compatible
 with the module's `meta_data.json`
 
 *Arguments:*
-* ``module\_name``  module name
+* ``module_name``  module name
 * ``options``       (Optional) Behavior modifiers for the function)
 
 Options takes the form:
@@ -158,7 +158,7 @@ Options takes the form:
   os
     validate => Whether or not to validate the OS settings
     options
-      release\_match => Enum['none','full','major']
+      release_match => Enum['none','full','major']
         none  -> No match on minor release (default)
         full  -> Full release must match
         major -> Only the major release must match
@@ -208,8 +208,8 @@ Generates a random password string.
                      `0` => Use only Alphanumeric characters (safest)
                      `1` => Use Alphanumeric characters and reasonably safe symbols
                      `2` => Use any printable ASCII characters
-* ``complex\_only``    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
-* ``timeout\_seconds`` (Optional) Integer or Float - Maximum time allotted to generate
+* ``complex_only``    (Optional) Boolean - Use only the characters explicitly added by the complexity rules)
+* ``timeout_seconds`` (Optional) Integer or Float - Maximum time allotted to generate
                      the password; a value of 0 disables the timeout
 
 *Returns*: `String` Generated password
@@ -222,7 +222,7 @@ Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
 
 *Arguments*:
-* only\_remote (Optional) Whether to exclude local addresses
+* only_remote (Optional) Whether to exclude local addresses
      from the return value.
 
 
@@ -238,7 +238,7 @@ time on all servers.ovides a "random" value to cron based on the passed integer 
 *Arguments*:
 * ``occurs``     (Optional) The occurrence within an interval, i.e.,
                 the number of values to be generated for the interval.
-* ``max\_value`` (Optional) The maximum value for the interval.  The values
+* ``max_value`` (Optional) The maximum value for the interval.  The values
                 generated will be in the inclusive range [0, max_value].
 * ``algorithm``  (Optional) When 'ip_mod', the modulus of the IP number is used as the basis
                 for the returned values.  This algorithm works well to create
@@ -274,8 +274,8 @@ Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
 *Arguments*:
-* ``system\_mount\_opts`` System mount options
-* ``new\_mount\_opts``    New mount options, which will override
+* ``system_mount_opts`` System mount options
+* ``new_mount_opts``    New mount options, which will override
                         `system_opts` when there are conflicts
 
 *Returns*: `String`
@@ -306,7 +306,7 @@ Takes a DNS domain name and converts it to an LDAP domain name.
 
 Arguments:
 * ``domain``               (Optional) The dns domain name, defaults to fact domain.
-* ``downcase\_attributes`` (Optional) Whether or not to downcase the LDAP attributes, false
+* ``downcase_attributes`` (Optional) Whether or not to downcase the LDAP attributes, false
 
 *Returns*: `String`
 
@@ -354,7 +354,7 @@ CIDR notation.
 Hostnames are passed through untouched.
 
 *Arguments*:
-* ``networks\_list``  List of 1 or more networks separated by spaces,
+* ``networks_list``  List of 1 or more networks separated by spaces,
                  commas, or semicolons
 
 *Returns* `Array[String]` Array of networks in CIDR notation
@@ -432,7 +432,7 @@ characters.
 
 *Arguments*:
 * ``identifier``      Unique `String` to identify the password usage.
-* ``modifier\_hash``  (Optional) may contain any of the following options:
+* ``modifier_hash``  (Optional) may contain any of the following options:
                     - 'last' => false(*) or true
                       * Return the last generated password
                     - 'length' => Integer
@@ -474,7 +474,7 @@ time on all servers.
 * ``modifier``    The input string to use as the basis for the generated values
 * ``algorithm``   Randomization algorithm to apply to transform the input string.
 * ``occurs``      (Optional) The occurrence within an interval
-* ``max\_value``  (Optional) The maximum value for the interval.
+* ``max_value``  (Optional) The maximum value for the interval.
 
 *Examples*:
 ```puppet
@@ -552,8 +552,8 @@ Deprecated:  You should be able to use type declarions instead of this.
 
 *Arguments*:
 * ``value``       Value to validate
-* ``min\_value``   Minimum value that is valid
-* ``max\_value``   Maximum value that is valid
+* ``min_value``   Minimum value that is valid
+* ``max_value``   Maximum value that is valid
 
 *Returns*: `nil`
 
@@ -567,7 +567,7 @@ Modified from the stdlib validate\_bool to handle the strings 'true' and
 The following values will pass:
 
 *Arguments*:
-* ``values\_to\_validate``   The value to validate.
+* ``values_to_validate``   The value to validate.
 
 *Examples*:
 ```ruby
@@ -609,7 +609,7 @@ support a to\_s() method.
 
 *Arguments*:
 * ``reference``   Reference Hash
-* ``to\_check``   Hash to validate.
+* ``to_check``   Hash to validate.
 
 *Examples*:
 ```puppet
@@ -657,7 +657,7 @@ Validates whether or not the passed argument is a valid port (i.e.  between
 1 - 65535).  It will work on strings ot integers.
 
 *Arguments*:
-* ``port\_args``  A port or array of ports.
+* ``port_args``  A port or array of ports.
 
 *Examples*:
 ```puppet
@@ -677,7 +677,7 @@ simplib::validate_port(65536)
 
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
 
-#### **simplib::validate\_net\_list**
+#### **simplib::validate_net_list**
 Validate that a passed list (`Array` or single `String`) of networks
 is filled with valid IP addresses, network addresses (CIDR notation),
 or hostnames. Hostnames are checked per RFC 1123. Ports appended with
@@ -685,7 +685,7 @@ a colon `:` are allowed for hostnames and individual IP addresses.
 
 *Arguments*:
 * ``net``         Single network to be validated.
-* ``str\_match``  (Optional) A regex of `String` that should be ignored
+* ``str_match``  (Optional) A regex of `String` that should be ignored
               from the list. Omit the beginning and ending `/` delimiter.
 *Examples*:
 ```puppet
@@ -711,7 +711,7 @@ a colon `:` are allowed for hostnames and individual IP addresses.
 
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
 
-#### **simplib::validate\_re\_array**
+#### **simplib::validate_re_array**
 Perform simple validation of a `String`, or `Array` of `Strings`,
 against one or more regular expressions.
 Derived from the Puppet Labs stdlib validate\_re.
@@ -720,7 +720,7 @@ Derived from the Puppet Labs stdlib validate\_re.
 * ``input``   String to be validated
 * ``regex``   Stringified regex expression (regex without the `//`
    delimiters)
-* ``err\_msg``  (Optional) error message to emit upon failure
+* ``err_msg``  (Optional) error message to emit upon failure
 
 *Examples*:
 ```puppet
@@ -757,7 +757,7 @@ parameter is not set.
 
 *Arguments*:
 * ``uri``          URI to be validated.
-* ``scheme\_list`` (Optional) List of schemes (protocol types) allowed for the URI.
+* ``scheme_list`` (Optional) List of schemes (protocol types) allowed for the URI.
 
 *Examples*:
 ```puppet
@@ -1220,8 +1220,8 @@ Returns: `string`
 
 This function has been deprecated
 
-Split an array into an array of arrays that contain groupings of 'max\_length'
-size. This is similar to 'each\_slice' in newer versions of Ruby.
+Split an array into an array of arrays that contain groupings of 'max_length'
+size. This is similar to 'each_slice' in newer versions of Ruby.
 
 ```ruby
   * Options *

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### assert\_metadata
+#### simplib::assert\_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`
@@ -163,7 +163,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### **deprecation**
+#### simplib::deprecation
 
 Function to print deprecation warnings, logging a warning once
 for a given key.
@@ -181,19 +181,19 @@ deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::
 
 Returns: `hash`
 
-#### **filtered**
+#### **simplib::filtered**
 
-#### **gen\_random\_password**
+#### **simplib::gen\_random\_password**
 
 
-#### **ipaddresses**
+#### **simplib::ipaddresses**
 
 Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
 
 **Type**: `array`
 
-#### **ip\_to\_cron**
+#### simplib::ip\_to\_cron
 
 Provides a "random" value to cron based on the passed integer value.
 Used to avoid starting a certain cron job at the same time on all
@@ -216,14 +216,14 @@ simplib::ip_to_cron(2,24) - returns an array of two values between 0..23
 
 Returns: `integer` or `array`
 
-#### **join\_mount\_opts**
+#### simplib::join\_mount\_opts
 
 Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
 **Type**: `string`
 
-#### knockout
+#### simplib::knockout
 
 Uses the knockout prefix of '--' to remove elements from an array.
 
@@ -233,7 +233,7 @@ Arguments:
 **Type**: `array`
 
 
-#### ldap::domain\_to\_dn
+#### simplib::ldap::domain\_to\_dn
 
 Takes a DNS domain name and converts it to an LDAP domain name.
 
@@ -243,25 +243,25 @@ Arguments:
 
 **Type**: `string`
 
-#### **lookup**
+#### simplib::lookup
 
 
-#### **mock\_data**
+#### simplib::mock\_data
 
 
-#### **nets2cidr**
+#### simplib::nets2cidr
 
 Convert an array of networks into CIDR notation
 
 **Type**: `array`
 
-#### **nets2ddq**
+#### simplib::nets2ddq
 
 Convert an array of networks into dotted quad notation
 
 **Type**: `array`
 
-#### **parse\_hosts**
+#### simplib::parse\_hosts
 
 Take an array of items that may contain port numbers or protocols and return
 the host information, ports, and protocols. Works with hostnames, IPv4, and
@@ -289,7 +289,7 @@ simplib::parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
 
 **Type**: `hash`
 
-#### **passgen**
+#### simplib::passgen
 
 Generates a random password string for a passed identifier. Uses
 Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
@@ -318,7 +318,7 @@ characters.
 
 **Type**: `string`
 
-#### **rand\_cron**
+#### simplib::rand\_cron
 
 Transforms an input string to one or more interval values for `cron`.
 This can be used to avoid starting a certain cron job at the same
@@ -339,7 +339,7 @@ simplib::rand_cron(100,2,24) - returns an array of two values between 0..23 base
 
 **Type**: Array[Integer]
 
-#### **strip\_ports**
+#### simplib::strip\_ports
 
 Take an array of items that may contain port numbers and appropriately return
 the non-port portion. Works with hostnames, IPv4, and IPv6.
@@ -356,7 +356,7 @@ $bar contains: ['https://mysite.net','http://yoursite.net','theirsite.com']
 
 Returns: `array`
 
-#### **to\_integer**
+#### simplib::to\_integer
 
 Converts the argument into an Integer.
 
@@ -364,7 +364,7 @@ Only works if the passed argument responds to the 'to\_i' Ruby method.
 
 Returns: `integer`
 
-#### **to\_string**
+#### simplib::to\_string
 
 Converts the argument into a String.
 
@@ -373,7 +373,7 @@ Only works if the passed argument responds to the 'to\_s' Ruby method.
 Returns: `string`
 
 
-#### **validate\_array\_member**
+#### simplib::validate\_array\_member
 
 Validate that the first string (or array) passed is a member of the second
 array passed. An optional third argument of i can be passed, which ignores
@@ -392,7 +392,7 @@ validate_array_member('foo',['FOO','BAR'],'i') # => true
 
 Returns: `boolean`
 
-#### **validate\_between**
+#### simplib::validate\_between
 
 Validate that the first value is between the second and third values
 numerically.
@@ -401,7 +401,7 @@ This is a pure Ruby comparison, not a human comparison.
 
 Returns: `boolean`
 
-#### **validate\_bool**
+#### simplib::validate\_bool
 
 Validate that all passed values are either true or false. Abort catalog
 compilation if any value fails this check.
@@ -430,7 +430,7 @@ validate_bool($some_array)
 
 Returns: `boolean`
 
-#### **validate\_deep\_hash**
+#### simplib::validate\_deep\_hash
 
 Perform a deep validation on two passed hashes.
 
@@ -476,7 +476,7 @@ validated against. Unknown keys in the hash being compared will cause a
 
 Returns: `boolean`
 
-#### **validate\_port**
+#### simplib::validate\_port
 
 Validates whether or not the passed argument is a valid port (i.e.  between
 1 - 65535).
@@ -501,7 +501,7 @@ validate_port('65536')
 
 Returns: `boolean`
 
-#### **validate\_net\_list**
+#### simplib::validate\_net\_list
 
 Validate that a passed list (Array or single String) of networks is filled
 with valid IP addresses or hostnames. Hostnames are checked per
@@ -536,7 +536,7 @@ validate_net_list($trusted_nets)
 
 Returns: `boolean`
 
-#### **validate\_re\_array**
+#### simplib::validate\_re\_array
 
 Perform simple validation of a string, or array of strings, against one or
 more regular expressions. The first argument of this function should be a
@@ -571,7 +571,7 @@ value does not match 2.7')
 
 Returns: `boolean`
 
-#### **validate\_sysctl\_value**
+#### simplib::validate\_sysctl\_value
 
 Validate that the passed value is correct for the passed sysctl key.
 
@@ -581,7 +581,7 @@ Example:
 
 Returns: `boolean`
 
-#### **validate\_uri\_list**
+#### simplib::validate\_uri\_list
 
 Usage: validate\_uri\_list(\[LIST\],\[\])
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib::assert_metadata
+#### simplib::assert\_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
     * [Facts](#facts)
     * [Functions](#functions)
+    * [Puppet 3 Functions](#puppet-3-functions)
     * [Types](#types)
     * [Data Types](#data-types)
 6. [Development - Guide for contributing to the module](#development)
@@ -112,7 +113,7 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [assert\_metadata](#simplib::assert_metadata)
+- [simplib::assert\_metadata][simplib::assert_metadata]
 - [deprecation](#simplib::deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
@@ -163,7 +164,7 @@ Options takes the form:
 
 *Type*: `nil`
 
-#### **simplib::deprecation
+#### **simplib::deprecation**
 
 Function to print deprecation warnings, logging a warning once
 for a given key.
@@ -171,7 +172,7 @@ for a given key.
 Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
 environment variable is set to 'true'
 
-**Examples:**
+*Examples:*
 
 ```puppet
 deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::dconf and will be removed in a future version')

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ If you find any issues, they can be submitted to our
 
 ## Module Description
 
-*simp/simplib* is a collection custom functions, facts, and small types.
+*simp/simplib* provides a standard library of resources for SIMP modules. It adds the following
+resources to Puppet:
+  * Stages
+  * Data Types
+  * Custom Types and Providers
+  * Facts
+  * Functions
+  * Puppet 3 Functions (deprecated functions that will be removed in the near future)
 
 ## Setup
 
@@ -43,6 +50,7 @@ Agents will need to enable `pluginsync`.
 
 ## Usage
 
+
 Please see [reference](#reference) for usage.
 
 Full documentation can be found in the [module docs](https://simp.github.io/pupmod-simp-simplib)
@@ -53,6 +61,17 @@ A list of things provided by simplib is below.
 
 Please reference the `doc/` directory in the top level of the repo or the code
 itself for more detailed documentation.
+
+### Stages
+
+ simplib::stages are added to ensure that anyone using the stdlib stages was not
+ tripped up by any simp modules that may enable, or disable, various system,
+ components; particularly ones that require a reboot.
+
+ Added Stages:
+
+   * ``simp_prep`` -> Comes before stdlib's ``setup``
+   * ``simp_finalize`` -> Comes after stdlib's ``deploy``
 
 ### Facts
 
@@ -93,229 +112,86 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [array\_include](#array_include)
-- [array\_size](#array_size)
-- [array\_union](#array_union)
-- [bracketize](#bracketize)
-- [deep\_merge](#deep_merge)
-- [filtered](#filtered)
-- [generate\_reboot\_msg](#generate_reboot_msg)
-- [get\_ports](#get_ports)
-- [h2n](#h2n)
-- [host\_is\_me](#host_is_me)
-- [inspect](#inspect)
-- [ip\_is\_me](#ip_is_me)
-- [ip\_to\_cron](#ip_to_cron)
-- [ipaddresses](#ipaddresses)
-- [join\_mount\_opts](#join_mount_opts)
-- [localuser](#localuser)
-- [mapval](#mapval)
-- [nets2cidr](#nets2cidr)
-- [nets2ddq](#nets2ddq)
-- [parse\_hosts](#parse_hosts)
-- [passgen](#passgen)
-- [rand\_cron](#rand_cron)
-- [simp\_version](#simp_version)
-- [slice\_array](#slice_array)
-- [strip\_ports](#strip_ports)
-- [to\_integer](#to_integer)
-- [to\_string](#to_string)
-- [validate\_array\_member](#validate_array_member)
-- [validate\_array\_of\_hashes](#validate_array_of_hashes)
-- [validate\_between](#validate_between)
-- [validate\_bool\_simp](#validate_bool_simp)
-- [validate\_deep\_hash](#validate_deep_hash)
-- [validate\_float](#validate_float)
-- [validate\_integer](#validate_integer)
-- [validate\_macaddress](#validate_macaddress)
-- [validate\_net\_list](#validate_net_list)
-- [validate\_port](#validate_port)
-- [validate\_re\_array](#validate_re_array)
-- [validate\_sysctl\_value](#validate_sysctl_value)
-- [validate\_umask](#validate_umask)
-- [validate\_uri\_list](#validate_uri_list)
+- [assert\_metadata](#simplib::assert_metadata)
+- [deprecation](#simplib::deprecation)
+- [filtered](#simplib::filtered)
+- [gen\_random\_password](#simplib::gen_random_password)
+- [ip\_to\_cron](#simplib::ip_to_cron)
+- [ipaddresses](#simplib::ipaddresses)
+- [join\_mount\_opts](#simplib::join_mount_opts)
+- [knockout](#simplib::knockout)
+- [ldap::domain\_to\_dn](#simplib::ldap::domain_to_dn)
+- [lookup](#simplib::lookup)
+- [mock\_data](#simplib::mock_data)
+- [nets2cidr](#simplib::nets2cidr)
+- [nets2ddq](#simplib::nets2ddq)
+- [parse\_hosts](#simplib::parse_hosts)
+- [passgen](#simplib::passgen)
+- [rand\_cron](#simplib::rand_cron)
+- [strip\_ports](#simplib::strip_ports)
+- [to\_integer](#simplib::to_integer)
+- [to\_string](#simplib::to_string)
+- [validate\_array\_member](#simplib::validate_array_member)
+- [validate\_between](#simplib::validate_between)
+- [validate\_bool](#simplib::validate_bool)
+- [validate\_deep\_hash](#simplib::validate_deep_hash)
+- [validate\_net\_list](#simplib::validate_net_list)
+- [validate\_port](#simplib::validate_port)
+- [validate\_re\_array](#simplib::validate_re_array)
+- [validate\_sysctl\_value](#simplib::validate_sysctl_value)
+- [validate\_uri\_list](#simplib::validate_uri_list)
 
-#### **array\_include**
 
-Determine if the first passed array contains the contents of another array or
-string.
+#### assert\_metadata
 
-Example:
+Fails a compile if the client system is not compatible with the module's
+`meta_data.json`
 
-```ruby
-$arr_x = [ 'foo', 'bar' ]
-$arr_y = [ 'foo', 'baz', 'bar' ]
+Arguments:
+* module\_name
+* options (Behavior modifiers for the function)
 
-if array_include($arr_x, $arr_y) {
-  notice('this will be printed')
-}
-if array_include($arr_x, 'bar') {
-  notice('this will be printed')
-}
-if array_include($arr_x, 'baz') {
-  notice('this will not be printed')
-}
-```
+Options takes the form:
+* enable => If set to `false` disable all validation
+* os
+  * validate => Whether or not to validate the OS settings
+  * options
+    * release\_match => Enum['none','full','major']
+      none  -> No match on minor release (default)
+      full  -> Full release must match
+      major -> Only the major release must match
 
-Returns: `boolean`
+*Type*: `nil`
 
-#### **array\_size**
+#### **deprecation**
 
-Returns the number of elements in an array. If a string is passed, simply
-returns '1'.
+Function to print deprecation warnings, logging a warning once
+for a given key.
 
-This is in contrast to the Puppet Labs stdlib 'size' function which returns
-the size of an array or the length of a string when called.
+Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS
+environment variable is set to 'true'
 
-Returns: `integer`
+**Examples:**
 
-#### **array\_union**
+```puppet
+deprecation('gnome::dconf::add','gnome::dconf::add is a shim for gnome::config::dconf and will be removed in a future version')
+# Writes message to log if SIMPLIB_LOG_DEPRECATIONS is true.
 
-Return the union of two arrays.
-
-Example:
-
-```ruby
-$arr_x = ['1','2']
-$arr_y = ['2','3','4']
-
-$res = array_union($arr_x, $arr_y)
-
-$res contains: ['1','2','3','4']
-```
-
-Returns: `array`
-
-#### **bracketize**
-
-Add brackets to IP addresses and arrays of IP addresses based on the
-rules for bracketing IPv6 addresses. Ignore anything that doesn't
-look like an IPv6 address.
-
-Returns: `string` or `array`
-
-#### **deep\_merge**
-
-Perform a deep merge on two passed hashes.
-
-This code is shamelessly stolen from the guts of
-ActiveSupport::CoreExtensions::Hash::DeepMerge and munged together with the
-Puppet Labs stdlib 'merge' function.
+*Type*: `nil`
 
 Returns: `hash`
 
 #### **filtered**
-##### data_hash variant
 
-Hiera v5 backend that takes a list of allowed hiera key names, and only returns
-results from the underlying backend function that match those keys.
+#### **gen\_random\_password**
 
-This allows hiera data to be delegated to end users in a multi-tenant environment
-without allowing them the ability to override every hiera data point (and potentially break systems)
-
-Usage:
-```yaml
----
-version: 5 # Specific version of hiera we are using, required for v4 and v5
-defaults:  # Used for any hierarchy level that omits these keys.
-  datadir: "data"         # This path is relative to hiera.yaml's directory.
-  data_hash: "yaml_data"  # Use the built-in YAML backend.
-hierarchy: # Each hierarchy consists of multiple levels
-  - name: "OSFamily"
-    path: "osfamily/%{facts.osfamily}.yaml"
-  - name: "datamodules"
-    data_hash: simplib::filtered
-    datadir: "delegated-data"
-    paths: 
-            - "%{facts.sitename}/osfamily/%{facts.osfamily}.yaml"
-            - "%{facts.sitename}/os/%{facts.operatingsystem}.yaml"
-            - "%{facts.sitename}/host/%{facts.fqdn}.yaml"
-            - "%{facts.sitename}/common.yaml"
-    options: 
-       function: yaml_data
-       filter: 
-         - profiles::ntp::servers
-         - profiles::.*
-  - name: "Common"
-    path: "common.yaml"
-```
-
-Returns: `hash`
-
-#### **generate\_reboot\_msg**
-
-Generate a reboot message from a passed hash.
-
-Requires a hash of the following form:
-
-```ruby
-{
-  'id'  => 'reason',
-  'id2' => 'reason2',
-  ...
-}
-```
-
-Will return a message such as:
-
-```ruby
-A system reboot is required due to:
-  id => reason
-  id2 => reason2
-```
-
-Returns: `hash`
-
-#### **get\_ports**
-
-Take an array of items that may contain port numbers and appropriately return
-the port portion. Works with hostnames, IPv4, and IPv6.
-
-```
-$foo = ['https://mysite.net:8443','http://yoursite.net:8081']
-
-$bar = strip_ports($foo)
-
-$bar contains: ['8443','8081']
-```
-
-Returns: `array`
-
-#### **h2n**
-
-Return an IP address for the passed hostname.
-
-Returns: `string`
-
-#### **host\_is\_me**
-
-Detect if a local system identifier Hostname/IP address is contained in the
-passed whitespace delimited list. Whitespace and comma delimiters and passed
-arrays are accepted. 127.0.0.1 and ::1 are never matched, use 'localhost' or
-'localhost6' for that if necessary.
-
-Returns: `boolean`
-
-#### **inspect**
-
-Prints out Puppet warning messages that display the passed variable.
-
-This is mainly meant for debugging purposes.
-
-Returns: `string`
 
 #### **ipaddresses**
 
 Return an array of all IP addresses known to be associated with the client. If
 an argument is passed, and is not false, then only return non-local addresses.
 
-Returns: `array`
-
-#### **ip\_is\_me**
-
-Detect if an IP address is contained in the passed whitespace delimited list.
-
-Returns: `boolean`
+**Type**: `array`
 
 #### **ip\_to\_cron**
 
@@ -333,9 +209,9 @@ License: None
 Example:
 
 ```ruby
-ip_to_cron()     - returns one value between 0..59
-ip_to_cron(2)    - returns an array of two values between 0..59
-ip_to_cron(2,24) - returns an array of two values between 0..23
+simplib::ip_to_cron()     - returns one value between 0..59
+simplib::ip_to_cron(2)    - returns an array of two values between 0..59
+simplib::ip_to_cron(2,24) - returns an array of two values between 0..23
 ```
 
 Returns: `integer` or `array`
@@ -345,44 +221,45 @@ Returns: `integer` or `array`
 Merge two sets of 'mount' options in a reasonable fashion. The second set will
 always override the first.
 
-Returns: `string`
+**Type**: `string`
 
-#### **localuser**
+#### knockout
 
-Pull a pre-set password from a password list and return an array of user
-details associated with the passed hostname.
-
-If the password starts with the string '\$1\$' and the length is 34
-characters, then it will be assumed to be an MD5 hash to be directly applied
-to the system.
-
-If the password is in plain text form, then it will be hashed and stored back
-into the source file for future use. The plain text version will be commented
-out in the file.
+Uses the knockout prefix of '--' to remove elements from an array.
 
 Arguments:
-* filename (path to the file containing the local users)
-* hostname (host that you are trying to match against)
+* array (The array to work on)
 
-Returns: `array`
+**Type**: `array`
 
-#### **mapval**
 
-Pull a mapped value from a text file. Must provide a Ruby regex!.
+#### ldap::domain\_to\_dn
 
-Returns: `string`
+Takes a DNS domain name and converts it to an LDAP domain name.
+
+Arguments:
+* domain (The dns domain name)
+* downcase_attributes (Whether or not to downcase the LDAP attributes)
+
+**Type**: `string`
+
+#### **lookup**
+
+
+#### **mock\_data**
+
 
 #### **nets2cidr**
 
 Convert an array of networks into CIDR notation
 
-Returns: `array`
+**Type**: `array`
 
 #### **nets2ddq**
 
 Convert an array of networks into dotted quad notation
 
-Returns: `array`
+**Type**: `array`
 
 #### **parse\_hosts**
 
@@ -393,15 +270,14 @@ IPv6.
 Example:
 
 ```ruby
-parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
-
-Returns: '1.2.3.4' => {
-           ports => ['443'],
-           protocols => {
-             'http' => [],
-             'https' => ['443']
-           }
-         }
+simplib::parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
+# returns: '1.2.3.4' => {
+#           ports => ['443'],
+#           protocols => {
+#             'http' => [],
+#             'https' => ['443']
+#           }
+#         }
 ```
 -----------------
 
@@ -411,7 +287,7 @@ Returns: '1.2.3.4' => {
 
 -----------------
 
-Returns: `hash`
+**Type**: `hash`
 
 #### **passgen**
 
@@ -440,53 +316,28 @@ characters.
     currently stored string.
 ```
 
-Returns: `string`
+**Type**: `string`
 
 #### **rand\_cron**
 
-Provides a "random" value to cron based on the passed integer value.
-Used to avoid starting a certain cron job at the same time on all
-servers.  If used with no parameters, it will return a single value between
-0-59 first argument is the occurrence within a timeframe, for example if you
-want it to run 2 times per hour the second argument is the timeframe, by
-default its 60 minutes, but it could also be 24 hours etc
+Transforms an input string to one or more interval values for `cron`.
+This can be used to avoid starting a certain cron job at the same
+time on all servers.
 
-Based on: http://projects.puppetlabs.com/projects/puppet/wiki/Cron_Patterns/8/diff
-Author: ohadlevy@gmail.com
-License: None Posted
+Arguments:
+* modifier
+* algorithm
+* occurs
+* max\_value
 
 Example:
 ```ruby
-int_to_cron('100')     - returns one value between 0..59 based on the value 100
-int_to_cron(100,2)    - returns an array of two values between 0..59 based on the value 100
-int_to_cron(100,2,24) - returns an array of two values between 0..23 based on the value 100
+simplib::rand_cron('100')     - returns one value between 0..59 based on the value 100
+simplib::rand_cron(100,2)    - returns an array of two values between 0..59 based on the value 100
+simplib::rand_cron(100,2,24) - returns an array of two values between 0..23 based on the value 100
 ```
 
-Returns: `integer` or `array`
-
-#### **simp\_version**
-
-Return the version of SIMP that this server is running.
-
-Returns: `string`
-
-#### **slice\_array**
-
-Split an array into an array of arrays that contain groupings of 'max\_length'
-size. This is similar to 'each\_slice' in newer versions of Ruby.
-
-```ruby
-  * Options *
-
-  to_slice => The array to slice. This will be flattened if necessary.
-
-  max_length => The maximum length of each slice.
-
-  split_char => An optional character upon which to count sub-elements
-  as multiples. Only one per subelement is supported.
-```
-
-Returns: `array of arrays`
+**Type**: Array[Integer]
 
 #### **strip\_ports**
 
@@ -521,20 +372,6 @@ Only works if the passed argument responds to the 'to\_s' Ruby method.
 
 Returns: `string`
 
-#### **validate\_array\_of\_hashes**
-
-Validate that the passed argument is either an empty array or an array that
-only contains hashes.
-
-Examples:
-
-```ruby
-validate_array_of_hashes([{'foo' => 'bar'}]) # => OK
-validate_array_of_hashes([])                 # => OK
-validate_array_of_hashes(['FOO','BAR'])      # => BAD
-```
-
-Returns: `boolean`
 
 #### **validate\_array\_member**
 
@@ -564,7 +401,7 @@ This is a pure Ruby comparison, not a human comparison.
 
 Returns: `boolean`
 
-#### **validate\_bool\_simp**
+#### **validate\_bool**
 
 Validate that all passed values are either true or false. Abort catalog
 compilation if any value fails this check.
@@ -636,34 +473,6 @@ letters.
 
 Additionally, all keys must be defined in the source hash that is being
 validated against. Unknown keys in the hash being compared will cause a
-
-Returns: `boolean`
-
-#### **validate\_float**
-
-Validates whether or not the passed argument is a float.
-
-Returns: `boolean`
-
-#### **validate\_integer**
-
-Validates whether or not the passed argument is an integer.
-
-Returns: `boolean`
-
-#### **validate\_macaddress**
-
-Validate that all passed values are valid MAC addresses.
-
-The following values will pass:
-
-```ruby
-$macaddress = 'CA:FE:BE:EF:00:11'
-
-validate_macaddress($macaddress)
-validate_macaddress($macaddress,'00:11:22:33:44:55')
-validate_macaddress([$macaddress,'00:11:22:33:44:55'])
-```
 
 Returns: `boolean`
 
@@ -772,7 +581,818 @@ Example:
 
 Returns: `boolean`
 
+#### **validate\_uri\_list**
+
+Usage: validate\_uri\_list(\[LIST\],\[\])
+
+Validate that a passed list (Array or single String) of URIs is valid
+according to Ruby's URI parser.
+
+The following values will pass:
+
+```ruby
+$uris = [http://foo.bar.baz:1234','ldap://my.ldap.server']
+validate_uri_list($uris)
+
+$uris = ['ldap://my.ldap.server','ldaps://my.ldap.server']
+validate_uri_list($uris,['ldap','ldaps'])
+```
+
+Returns: `boolean`
+
+### Puppet 3 Functions
+
+These functions have all been deprecated.  This is here for information purposes only.
+Use functions from the `Functions` section in new code.
+Many of them have been replaced by standard puppet functions or functionality in
+later versionis of puppet.
+If there is a corresponding simplib function for versions of puppet later than
+version 3, it is noted in the comments.
+
+- [array\_include](#array_include)
+- [array\_size](#array_size)
+- [array\_union](#array_union)
+- [bracketize](#bracketize)
+- [deep\_merge](#deep_merge)
+- [filtered](#filtered)
+- [generate\_reboot\_msg](#generate_reboot_msg)
+- [get\_ports](#get_ports)
+- [h2n](#h2n)
+- [host\_is\_me](#host_is_me)
+- [inspect](#inspect)
+- [ip\_is\_me](#ip_is_me)
+- [ip\_to\_cron](#ip_to_cron)
+- [ipaddresses](#ipaddresses)
+- [join\_mount\_opts](#join_mount_opts)
+- [localuser](#localuser)
+- [mapval](#mapval)
+- [nets2cidr](#nets2cidr)
+- [nets2ddq](#nets2ddq)
+- [parse\_hosts](#parse_hosts)
+- [passgen](#passgen)
+- [rand\_cron](#rand_cron)
+- [simp\_version](#simp_version)
+- [slice\_array](#slice_array)
+- [strip\_ports](#strip_ports)
+- [to\_integer](#to_integer)
+- [to\_string](#to_string)
+- [validate\_array\_member](#validate_array_member)
+- [validate\_array\_of\_hashes](#validate_array_of_hashes)
+- [validate\_between](#validate_between)
+- [validate\_bool\_simp](#validate_bool_simp)
+- [validate\_deep\_hash](#validate_deep_hash)
+- [validate\_float](#validate_float)
+- [validate\_integer](#validate_integer)
+- [validate\_macaddress](#validate_macaddress)
+- [validate\_net\_list](#validate_net_list)
+- [validate\_port](#validate_port)
+- [validate\_re\_array](#validate_re_array)
+- [validate\_sysctl\_value](#validate_sysctl_value)
+- [validate\_umask](#validate_umask)
+- [validate\_uri\_list](#validate_uri_list)
+
+#### **array\_include**
+
+This function has been deprecated
+
+Determine if the first passed array contains the contents of another array or
+string.
+
+Example:
+
+```ruby
+$arr_x = [ 'foo', 'bar' ]
+$arr_y = [ 'foo', 'baz', 'bar' ]
+
+if array_include($arr_x, $arr_y) {
+  notice('this will be printed')
+}
+if array_include($arr_x, 'bar') {
+  notice('this will be printed')
+}
+if array_include($arr_x, 'baz') {
+  notice('this will not be printed')
+}
+```
+
+Returns: `boolean`
+
+#### **array\_size**
+
+This function has been deprecated
+
+Returns the number of elements in an array. If a string is passed, simply
+returns '1'.
+
+This is in contrast to the Puppet Labs stdlib 'size' function which returns
+the size of an array or the length of a string when called.
+
+Returns: `integer`
+
+#### **array\_union**
+
+This function has been deprecated
+
+Return the union of two arrays.
+
+Example:
+
+```ruby
+$arr_x = ['1','2']
+$arr_y = ['2','3','4']
+
+$res = array_union($arr_x, $arr_y)
+
+$res contains: ['1','2','3','4']
+```
+
+Returns: `array`
+
+#### **bracketize**
+
+This function has been deprecated
+
+Add brackets to IP addresses and arrays of IP addresses based on the
+rules for bracketing IPv6 addresses. Ignore anything that doesn't
+look like an IPv6 address.
+
+Returns: `string` or `array`
+
+#### **deep\_merge**
+
+This function has been deprecated
+
+Perform a deep merge on two passed hashes.
+
+This code is shamelessly stolen from the guts of
+ActiveSupport::CoreExtensions::Hash::DeepMerge and munged together with the
+Puppet Labs stdlib 'merge' function.
+
+Returns: `hash`
+
+#### **filtered**
+
+This function has been deprecated
+It has been replaced by simplib::filtered
+
+##### data\_hash variant
+
+Hiera v5 backend that takes a list of allowed hiera key names, and only returns
+results from the underlying backend function that match those keys.
+
+This allows hiera data to be delegated to end users in a multi-tenant environment
+without allowing them the ability to override every hiera data point (and potentially break systems)
+
+Usage:
+```yaml
+---
+version: 5 # Specific version of hiera we are using, required for v4 and v5
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: "data"         # This path is relative to hiera.yaml's directory.
+  data_hash: "yaml_data"  # Use the built-in YAML backend.
+hierarchy: # Each hierarchy consists of multiple levels
+  - name: "OSFamily"
+    path: "osfamily/%{facts.osfamily}.yaml"
+  - name: "datamodules"
+    data_hash: simplib::filtered
+    datadir: "delegated-data"
+    paths: 
+            - "%{facts.sitename}/osfamily/%{facts.osfamily}.yaml"
+            - "%{facts.sitename}/os/%{facts.operatingsystem}.yaml"
+            - "%{facts.sitename}/host/%{facts.fqdn}.yaml"
+            - "%{facts.sitename}/common.yaml"
+    options: 
+       function: yaml_data
+       filter: 
+         - profiles::ntp::servers
+         - profiles::.*
+  - name: "Common"
+    path: "common.yaml"
+```
+
+Returns: `hash`
+
+#### **generate\_reboot\_msg**
+
+This function has been deprecated
+
+Generate a reboot message from a passed hash.
+
+Requires a hash of the following form:
+
+```ruby
+{
+  'id'  => 'reason',
+  'id2' => 'reason2',
+  ...
+}
+```
+
+Will return a message such as:
+
+```ruby
+A system reboot is required due to:
+  id => reason
+  id2 => reason2
+```
+
+Returns: `hash`
+
+#### **get\_ports**
+
+This function has been deprecated
+
+Take an array of items that may contain port numbers and appropriately return
+the port portion. Works with hostnames, IPv4, and IPv6.
+
+```
+$foo = ['https://mysite.net:8443','http://yoursite.net:8081']
+
+$bar = strip_ports($foo)
+
+$bar contains: ['8443','8081']
+```
+
+Returns: `array`
+
+#### **h2n**
+
+This function has been deprecated
+
+Return an IP address for the passed hostname.
+
+Returns: `string`
+
+#### **host\_is\_me**
+
+This function has been deprecated.
+
+Detect if a local system identifier Hostname/IP address is contained in the
+passed whitespace delimited list. Whitespace and comma delimiters and passed
+arrays are accepted. 127.0.0.1 and ::1 are never matched, use 'localhost' or
+'localhost6' for that if necessary.
+
+Returns: `boolean`
+
+#### **inspect**
+
+This function has been deprecated.
+It has been replaced by simplib::inspect.
+Note: simplib::inspect is a puppet code function.
+
+Prints out Puppet warning messages that display the passed variable.
+
+This is mainly meant for debugging purposes.
+
+Returns: `string`
+
+#### **ipaddresses**
+
+This function has been deprecated
+It has been replaced by simplib::ipaddresses
+
+Return an array of all IP addresses known to be associated with the client. If
+an argument is passed, and is not false, then only return non-local addresses.
+
+Returns: `array`
+
+#### **ip\_is\_me**
+
+This function has been deprecated
+
+Detect if an IP address is contained in the passed whitespace delimited list.
+
+Returns: `boolean`
+
+#### **ip\_to\_cron**
+
+This function has been deprecated
+It has been replaced by simplib::ip\_to\_cron
+
+Provides a "random" value to cron based on the passed integer value.
+Used to avoid starting a certain cron job at the same time on all
+servers.  If used with no parameters, it will return a single value between
+0-59. first argument is the occurrence within a timeframe, for example if you
+want it to run 2 times per hour the second argument is the timeframe, by
+default its 60 minutes, but it could also be 24 hours etc
+
+Pulled from: http://projects.puppetlabs.com/projects/puppet/wiki/Cron_Patterns/8/diff
+Author: ohadlevy@gmail.com
+License: None
+
+Example:
+
+```ruby
+ip_to_cron()     - returns one value between 0..59
+ip_to_cron(2)    - returns an array of two values between 0..59
+ip_to_cron(2,24) - returns an array of two values between 0..23
+```
+
+Returns: `integer` or `array`
+
+#### **join\_mount\_opts**
+
+This function has been deprecated
+It has been replaced by simplib::join\_mount\_opts
+
+Merge two sets of 'mount' options in a reasonable fashion. The second set will
+always override the first.
+
+Returns: `string`
+
+#### **localuser**
+
+This function has been deprecated
+
+Pull a pre-set password from a password list and return an array of user
+details associated with the passed hostname.
+
+If the password starts with the string '\$1\$' and the length is 34
+characters, then it will be assumed to be an MD5 hash to be directly applied
+to the system.
+
+If the password is in plain text form, then it will be hashed and stored back
+into the source file for future use. The plain text version will be commented
+out in the file.
+
+Arguments:
+* filename (path to the file containing the local users)
+* hostname (host that you are trying to match against)
+
+Returns: `array`
+
+#### **mapval**
+
+This function has been deprecated
+
+Pull a mapped value from a text file. Must provide a Ruby regex!.
+
+Returns: `string`
+
+#### **nets2cidr**
+
+
+This function has been deprecated
+It has been replaced by simplib::nets2cidr
+
+Convert an array of networks into CIDR notation
+
+Returns: `array`
+
+#### **nets2ddq**
+
+This function has been deprecated
+It has been replaced by simplib::nets2ddq
+
+Convert an array of networks into dotted quad notation
+
+Returns: `array`
+
+#### **parse\_hosts**
+
+This function has been deprecated
+It has been replaced by simplib::parse\_hosts
+
+Take an array of items that may contain port numbers or protocols and return
+the host information, ports, and protocols. Works with hostnames, IPv4, and
+IPv6.
+
+Example:
+
+```ruby
+parse_hosts([ '1.2.3.4', '<http://1.2.3.4>', '<https://1.2.3.4:443>' ])
+
+Returns: '1.2.3.4' => {
+           ports => ['443'],
+           protocols => {
+             'http' => [],
+             'https' => ['443']
+           }
+         }
+```
+-----------------
+
+> **NOTE**
+>
+> IPv6 addresses will be returned normalized with square brackets
+
+-----------------
+
+Returns: `hash`
+
+#### **passgen**
+
+This function has been deprecated
+It has been replaced by simplib::passgen
+
+Generates a random password string for a passed identifier. Uses
+Puppet\[:environmentpath\]/\$environment/simp\_autofiles/gen\_passwd/ as the
+destination directory.
+
+```
+The minimum length password that this function will return is 6
+characters.
+
+    Arguments: identifier, <modifier hash>; in that order.
+
+    <modifier hash> may contain any of the following options:
+      - 'last' => false(*) or true
+        * Return the last generated password
+      - 'length' => Integer
+        * Length of the new password
+      - 'hash' => false(*), true, md5, sha256 (true), sha512
+        * Return a hash of the password instead of the password itself.
+      - 'complexity' => 0(*), 1, 2
+        * 0 => Use only Alphanumeric characters in your password (safest) 1 =>
+        * Add reasonably safe symbols 2 => Printable ASCII
+
+    If no, or an invalid, second argument is provided then it will return the
+    currently stored string.
+```
+
+Returns: `string`
+
+#### **rand\_cron**
+
+This function has been deprecated
+It has been replaced by simplib::rand\_cron
+
+Provides a "random" value to cron based on the passed integer value.
+Used to avoid starting a certain cron job at the same time on all
+servers.  If used with no parameters, it will return a single value between
+0-59 first argument is the occurrence within a timeframe, for example if you
+want it to run 2 times per hour the second argument is the timeframe, by
+default its 60 minutes, but it could also be 24 hours etc
+
+Based on: http://projects.puppetlabs.com/projects/puppet/wiki/Cron_Patterns/8/diff
+Author: ohadlevy@gmail.com
+License: None Posted
+
+Example:
+```ruby
+int_to_cron('100')     - returns one value between 0..59 based on the value 100
+int_to_cron(100,2)    - returns an array of two values between 0..59 based on the value 100
+int_to_cron(100,2,24) - returns an array of two values between 0..23 based on the value 100
+```
+
+Returns: `integer` or `array`
+
+#### **simp\_version**
+
+This function has been deprecated
+
+Return the version of SIMP that this server is running.
+
+Returns: `string`
+
+#### **slice\_array**
+
+This function has been deprecated
+
+Split an array into an array of arrays that contain groupings of 'max\_length'
+size. This is similar to 'each\_slice' in newer versions of Ruby.
+
+```ruby
+  * Options *
+
+  to_slice => The array to slice. This will be flattened if necessary.
+
+  max_length => The maximum length of each slice.
+
+  split_char => An optional character upon which to count sub-elements
+  as multiples. Only one per subelement is supported.
+```
+
+Returns: `array of arrays`
+
+#### **strip\_ports**
+
+This function has been deprecated
+It has been replaced by simplib::strip\_ports
+
+Take an array of items that may contain port numbers and appropriately return
+the non-port portion. Works with hostnames, IPv4, and IPv6.
+
+```
+$foo = ['https://mysite.net:8443',
+        'http://yoursite.net:8081',
+        'https://theirsite.com']
+
+$bar = strip_ports($foo)
+
+$bar contains: ['https://mysite.net','http://yoursite.net','theirsite.com']
+```
+
+Returns: `array`
+
+#### **to\_integer**
+
+This function has been deprecated
+It has been replaced by simplib::to\_integer
+
+Converts the argument into an Integer.
+
+Only works if the passed argument responds to the 'to\_i' Ruby method.
+
+Returns: `integer`
+
+#### **to\_string**
+
+This function has been deprecated
+It has been replaced by simplib::to\_string
+
+Converts the argument into a String.
+
+Only works if the passed argument responds to the 'to\_s' Ruby method.
+
+Returns: `string`
+
+#### **validate\_array\_of\_hashes**_
+
+This function has been deprecated
+
+Validate that the passed argument is either an empty array or an array that
+only contains hashes.
+
+Examples:
+
+```ruby
+validate_array_of_hashes([{'foo' => 'bar'}]) # => OK
+validate_array_of_hashes([])                 # => OK
+validate_array_of_hashes(['FOO','BAR'])      # => BAD
+```
+
+Returns: `boolean`
+
+#### **validate\_array\_member**
+
+This function has been deprecated
+It has been replaced by simplib::validate\_array\_member
+
+Validate that the first string (or array) passed is a member of the second
+array passed. An optional third argument of i can be passed, which ignores
+the case of the objects inside the array.
+
+Examples:
+
+```ruby
+validate_array_member('foo',['foo','bar'])     # => true
+validate_array_member('foo',['FOO','BAR'])     # => false
+
+#Optional 'i' as third object, ignoring case of FOO and BAR#
+
+validate_array_member('foo',['FOO','BAR'],'i') # => true
+```
+
+Returns: `boolean`
+
+#### **validate\_between**
+
+This function has been deprecated
+It has been replaced by simplib::validate\_between
+
+Validate that the first value is between the second and third values
+numerically.
+
+This is a pure Ruby comparison, not a human comparison.
+
+Returns: `boolean`
+
+#### **validate\_bool\_simp**
+
+This function has been deprecated
+It has been replaced by simplib::validate\_bool
+
+Validate that all passed values are either true or false. Abort catalog
+compilation if any value fails this check.
+
+Modified from the stdlib validate\_bool to handle the strings 'true' and
+'false'.
+
+The following values will pass:
+
+```ruby
+$iamtrue = true
+
+validate_bool(true)
+validate_bool("false")
+validate_bool("true")
+validate_bool(true, 'true', false, $iamtrue)
+```
+
+The following values will fail, causing compilation to abort:
+
+```ruby
+$some_array = [ true ]
+
+validate_bool($some_array)
+```
+
+Returns: `boolean`
+
+#### **validate\_deep\_hash**
+
+This function has been deprecated
+It has been replaced by simplib::validate\_deep\_hash
+
+Perform a deep validation on two passed hashes.
+
+The first hash is the one to validate against, and the second is the one being
+validated. The first hash (i.e. the source) exists to define a valid structure
+and potential regular expression to validate against, or to skip an
+entry. Arrays of values will match each entry to the given regular expression.
+Below are examples of a source hash and a hash to compare against it:
+
+```ruby
+    'source' = {
+       'foo' => {
+         'bar' => {
+           #NOTE: Use single quotes for regular expressions
+           'baz' => '^\d+$',
+           'abc' => '^\w+$',
+           'def' => nil #NOTE: not 'nil' in quotes
+         },
+         'baz' => {
+           'xyz' => '^true|false$'
+         }
+       }
+     }
+
+    'to_check' = {
+       'foo' => {
+         'bar' => {
+           'baz' => '123',
+           'abc' => [ 'these', 'are', 'words' ],
+           'def' => 'Anything will work here!'
+         },
+         'baz' => {
+           'xyz' => 'false'
+         }
+       }
+```
+
+This fails because we expect the value of 'foo' to be a series of digits, not
+letters.
+
+Additionally, all keys must be defined in the source hash that is being
+validated against. Unknown keys in the hash being compared will cause a
+
+Returns: `boolean`
+
+#### **validate\_float**
+
+This function has been deprecated.
+
+Validates whether or not the passed argument is a float.
+
+Returns: `boolean`
+
+#### **validate\_integer**
+
+This function has been deprecated.
+
+Validates whether or not the passed argument is an integer.
+
+Returns: `boolean`
+
+#### **validate\_macaddress**
+
+This function has been deprecated.
+
+Validate that all passed values are valid MAC addresses.
+
+The following values will pass:
+
+```ruby
+$macaddress = 'CA:FE:BE:EF:00:11'
+
+validate_macaddress($macaddress)
+validate_macaddress($macaddress,'00:11:22:33:44:55')
+validate_macaddress([$macaddress,'00:11:22:33:44:55'])
+```
+
+Returns: `boolean`
+
+#### **validate\_port**
+
+This function has been deprecated.
+It has been replaced by simplib::validate\_port
+
+Validates whether or not the passed argument is a valid port (i.e.  between
+1 - 65535).
+
+The following values will pass:
+
+```puppet
+$port = '10541'
+$ports = ['5555', '7777', '1', '65535']
+
+validate_port($port)
+validate_port($ports)
+validate_port('11', '22')
+```
+
+The following values will not pass:
+
+```puppet
+validate_port('0')
+validate_port('65536')
+```
+
+Returns: `boolean`
+
+#### **validate\_net\_list**
+
+This function has been deprecated.
+It has been replaced by simplib::validate\_net\_list
+
+Validate that a passed list (Array or single String) of networks is filled
+with valid IP addresses or hostnames. Hostnames are checked per
+[RFC 1123](https://tools.ietf.org/html/rfc1123).Ports appended with a colon (:)
+are allowed.
+
+There is a second, optional argument that is a regex of strings that should be
+ignored from the list. Omit the beginning and ending '/' delimiters.
+
+The following values will pass:
+
+```ruby
+$trusted_nets = ['10.10.10.0/24','1.2.3.4','1.3.4.5:400']
+validate_net_list($trusted_nets)
+
+$trusted_nets = '10.10.10.0/24'
+validate_net_list($trusted_nets)
+
+$trusted_nets = ['10.10.10.0/24','1.2.3.4','any','ALL']
+validate_net_list($trusted_nets,'^(any|ALL)$')
+```
+
+The following values will fail:
+
+```ruby
+$trusted_nets = '10.10.10.0/24,1.2.3.4'
+validate_net_list($trusted_nets)
+
+$trusted_nets = 'bad stuff'
+validate_net_list($trusted_nets)
+```
+
+Returns: `boolean`
+
+#### **validate\_re\_array**
+
+This function has been deprecated.
+It has been replaced by simplib::validate\_re\_array
+
+Perform simple validation of a string, or array of strings, against one or
+more regular expressions. The first argument of this function should be a
+string to test, and the second argument should be a stringified regular
+expression (without the // delimiters) or an array of regular expressions. If
+none of the regular expressions match the string passed in, compilation will
+abort with a parse error.
+
+If a third argument is specified, this will be the error message raised and
+seen by the user.
+
+The following strings will validate against the regular expressions:
+
+```ruby
+validate_re_array('one', '^one$')
+validate_re_array('one', [ '^one','^two' ])
+validate_re_array(['one','two'], [ '^one', '^two' ])
+```
+
+The following strings will fail to validate, causing compilation to abort:
+
+```ruby
+validate_re_array('one', [ '^two', '^three' ])
+```
+
+A helpful error message can be returned like this:
+
+```ruby
+validate_re_array($::puppetversion, '^2.7', 'The $puppetversion fact
+value does not match 2.7')
+```
+
+Returns: `boolean`
+
+#### **validate\_sysctl\_value**
+
+This function has been deprecated.
+It has been replaced by simplib::validate\_sysctl\_value
+
+Validate that the passed value is correct for the passed sysctl key.
+
+If a key is not know, simply returns that the value is valid.
+
+Example:
+
+Returns: `boolean`
+
 #### **validate\_umask**
+
+This function has been deprecated.
 
 Validate that the passed value is a valid umask string.
 
@@ -787,6 +1407,9 @@ $val = '0078' validate_umask($val) # => BAD
 Returns: `boolean`
 
 #### **validate\_uri\_list**
+
+This function is deprecated and is replaced by
+simplib::validate\_uri\_list
 
 Usage: validate\_uri\_list(\[LIST\],\[\])
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [assert\_metadata](#simplib::assert_metadata)
+- [assert\_metadata](#simplib::assert\_metadata)
 - [deprecation](#simplib::deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [simplib::assert\_metadata][simplib::assert_metadata]
+- [simplib::assert\_metadata](#simplib::assert_metadata)
 - [deprecation](#simplib::deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
@@ -143,7 +143,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### **simplib::assert_metadata**
+#### simplib::assert_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ environment variable is set to 'true'
 *Returns*: `nil`
 
 #### **simplib::filtered**
+
 Hiera v5 backend that takes a list of allowed hiera key names, and only
 returns results from the underlying backend function that match those keys.
 
@@ -485,6 +486,7 @@ time on all servers.
             in the ``minute`` or ``hour`` cron field
 
 #### **simplib::strip_ports**
+
 Extract list of unique hostnames and/or IP addresses from an `Array`
 of hosts, each of which may may contain protocols and/or port numbers
 
@@ -511,12 +513,14 @@ Only works if the passed argument responds to the 'to\_i' Ruby method.
 *Returns*: `integer`
 
 #### **simplib::to_string**
+
 Converts the argument into a String.
 Only works if the passed argument responds to the 'to\_s' Ruby method.
 
 *Returns*: `string`
 
 #### **simplib::validate_array_member**
+
 Validate that the first string (or array) passed is a member of the second
 array passed. An optional third argument of i can be passed, which ignores
 the case of the objects inside the array.
@@ -533,7 +537,7 @@ validate_array_member('foo',['FOO','BAR'])     # => false
 
 #Optional 'i' as third object, ignoring case of FOO and BAR#
 
-validate_array_member('foo',['FOO','BAR'],'i') # => true
+simplib::validate_array_member('foo',['FOO','BAR'],'i') # => true
 ```
 
 *Returns*: `Boolean` Whether or not the argument is an element of the
@@ -559,34 +563,30 @@ compilation if any value fails this check.
 Modified from the stdlib validate\_bool to handle the strings 'true' and
 'false'.
 
-The following values will pass:
-
 *Arguments*:
 * ``values_to_validate``   The value to validate.
 
 *Examples*:
 ```ruby
+# The following will pass
 $iamtrue = true
 
-validate_bool(true)
-validate_bool("false")
-validate_bool("true")
-validate_bool(true, 'true', false, $iamtrue)
-```
+simplib::validate_bool(true)
+simplib::validate_bool("false")
+simplib::validate_bool("true")
+simplib::validate_bool(true, 'true', false, $iamtrue)
 
-The following values will fail, causing compilation to abort:
+#The following values will fail, causing compilation to abort:
 
-```ruby
 $some_array = [ true ]
 
-validate_bool($some_array)
+simplib::validate_bool($some_array)
 ```
 
 *Returns*: `nil` Fails catalog compilation if it is not a Boolean'
 
 #### **simplib::validate_deep_hash**
 Perform a deep validation on two passed `Hashes`.
-
 The first hash is the one to validate against, and the second is the one being
 validated.
 
@@ -682,6 +682,7 @@ a colon `:` are allowed for hostnames and individual IP addresses.
 * ``net``         Single network to be validated.
 * ``str_match``  (Optional) A regex of `String` that should be ignored
               from the list. Omit the beginning and ending `/` delimiter.
+
 *Examples*:
 ```puppet
 #  Passing
@@ -790,6 +791,7 @@ NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
   PuppetX::SIMP::Simplib.hostname?('hostname.me.com:5454')
 
 ```
+
 *Returns*: `Boolean`
 
 #### **hostname?**
@@ -799,6 +801,7 @@ Returns false if is not comprised of ASCII letters (upper or lower case),
 digits, hypens (except at the beginning and end), and dots (except at
 beginning and end), optional pluss ':<number>' or '/<number>'
 NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+
 *Examples*:
 ```ruby
   # Returns True

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ itself for more detailed documentation.
 ### Functions
 
 
-- [assert\_metadata](#assert_metadata)
+- [assert\_metadata](#assert\_metadata)
 - [deprecation](#simplibdeprecation)
 - [filtered](#simplib\:\:filtered)
 - [gen\_random\_password](#simplib::gen_random_password)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ itself for more detailed documentation.
 
 
 - [simplib::assert\_metadata](#simplib+assert_metadata)
-- [deprecation](#simplib::deprecation)
+- [deprecation](#simplib\:\:deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
 - [ip\_to\_cron](#simplib::ip_to_cron)
@@ -144,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib assert\_metadata
+#### simplib assert_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ itself for more detailed documentation.
 
 ### Functions
 
-- [simplib::assert\_metadata](#simplib::assert_metadata)
+
+- [simplib::assert\_metadata](#simplib+assert_metadata)
 - [deprecation](#simplib::deprecation)
 - [filtered](#simplib::filtered)
 - [gen\_random\_password](#simplib::gen_random_password)
@@ -143,7 +144,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib::assert\_metadata
+#### simplib assert\_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -767,10 +767,9 @@ simplib::validate_uri_list($uris,['ldap','ldaps'])
 *Returns*: `nil` Catalog compilation will fail if it does not pass.
 
 ### Puppet Extensions
-- [hostname_only?](#hostname_only?)
+- [hostname_only?](#hostname_only)
 - [hostname?](#hostname)
--
-
+- [splitport](#splitport)
 
 #### **hostname_only?**
 Determine whether or not the passed value is a valid hostname.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ itself for more detailed documentation.
 - [validate\_uri\_list](#simplib::validate_uri_list)
 
 
-#### simplib::assert_metadata
+#### simplib::assert\_metadata
 
 Fails a compile if the client system is not compatible with the module's
 `meta_data.json`

--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ simplib::validate_uri_list($uris,['ldap','ldaps'])
 ### Puppet Extensions
 - [hostname_only?](#hostname_only)
 - [hostname?](#hostname)
-- [splitport](#splitport)
+- [split_port](#split_port)
 
 #### **hostname_only?**
 Determine whether or not the passed value is a valid hostname.

--- a/functions/assert_metadata.pp
+++ b/functions/assert_metadata.pp
@@ -20,6 +20,8 @@
 #             * full  -> Full release must match
 #             * major -> Only the major release must match
 #
+# @return [None]
+#
 function simplib::assert_metadata (
   String[1] $module_name,
   Optional[Struct[{

--- a/functions/inspect.pp
+++ b/functions/inspect.pp
@@ -9,7 +9,7 @@
 # @param output_type
 #   The format that you wish to use to display the output during the
 #   run. 'json' and 'yaml' result in multi-line message content.
-#   oneline_json' results in single-line message content.
+#   'oneline_json' results in single-line message content.
 #
 # @return [None]
 #

--- a/functions/ldap/domain_to_dn.pp
+++ b/functions/ldap/domain_to_dn.pp
@@ -1,15 +1,28 @@
-# Provides a LDAP Base DN as generated from the ``domain`` fact
+# Generates a LDAP Base DN from a domain
 #
 # @param domain
-#   The domain to convert
+#   The domain to convert, defaults to the ``domain`` fact
 #
 # @param downcase_attributes
-#   Whether or not to downcase the LDAP attributes
+#   Whether to downcase the LDAP attributes
 #
-#     * Different tools have bugs where can can, or cannot, handle upcased (or
-#       downcased) LDAP attribute elements
+#     * Different tools have bugs where they cannot, handle
+#       both upcased and downcased LDAP attribute elements
 #
 # @return [String]
+#
+# @example Generate LDAP Base DN with uppercase attributes
+#
+#   $ldap_dn = simplib::ldap::domain_to_dn('test.local')
+#
+#   returns $ldap_dn = 'DC=test,DC=local'
+#
+# @example Generate LDAP Base DN with lowercase attributes
+#
+#   $ldap_dn = simplib::ldap::domain_to_dn('test.local', true)
+#
+#   returns $ldap_dn = 'dc=test,dc=local'
+#
 function simplib::ldap::domain_to_dn (
   String $domain               = $facts['domain'],
   Boolean $downcase_attributes = false

--- a/lib/puppet/functions/simplib/deprecation.rb
+++ b/lib/puppet/functions/simplib/deprecation.rb
@@ -6,10 +6,19 @@
 #
 Puppet::Functions.create_function(:'simplib::deprecation') do
 
-  # @param key Uniqueness key, which is used to dedupe of messages.
+  # @param key Uniqueness key, which is used to dedupe messages.
   # @param message Message to be printed, to which file and line
   #   information will be appended, if available.
   # @return [Nil]
+  #
+  # @example Emit a warning about a function that will be removed
+  #
+  #  simplib::deprecation('simplib::foo', 'simplib::foo is deprecated and will be removed in a future version')
+  #
+  # @example Emit a Warning about function that has been replaced
+  #
+  #  simplib::deprecation('simplib::foo', 'simplib::foo is deprecated.  Please use simplib::foo2 instead')
+  #
   dispatch :deprecation do
     required_param 'String', :key
     required_param 'String', :message

--- a/lib/puppet/functions/simplib/gen_random_password.rb
+++ b/lib/puppet/functions/simplib/gen_random_password.rb
@@ -1,5 +1,8 @@
 # Generates a random password string.
 #
+# Terminates catalog compilation if the password cannot be created
+# in the allotted time.
+#
 Puppet::Functions.create_function(:'simplib::gen_random_password') do
 
   # @param length Length of the new password.

--- a/lib/puppet/functions/simplib/ipaddresses.rb
+++ b/lib/puppet/functions/simplib/ipaddresses.rb
@@ -1,10 +1,10 @@
 # Return an `Array` of all IP addresses known to be associated with the
-# client.
+# client, optionally excluding local addresses.
 #
 Puppet::Functions.create_function('simplib::ipaddresses') do
 
   # @param only_remote Whether to exclude local addresses
-  #   from the return value.
+  #   from the return value (e.g., '127.0.0.1').
   #
   # @return [Array[String]] List of IP addresses for the client
   dispatch :ipaddresses do

--- a/lib/puppet/functions/simplib/join_mount_opts.rb
+++ b/lib/puppet/functions/simplib/join_mount_opts.rb
@@ -4,8 +4,8 @@ Puppet::Functions.create_function(:'simplib::join_mount_opts') do
 
   # @param system_mount_opts System mount options
   # @param new_mount_opts  New mount options, which will override
-  #   `system_opts` when there are conflicts
-  # @return [String] Merged options string in which `new_opts`
+  #   `system_mount_opts` when there are conflicts
+  # @return [String] Merged options string in which `new_mount_opts`
   #   mount options take precedence; options are comma delimited
   #
   dispatch :join_mount_opts do

--- a/lib/puppet/functions/simplib/lookup.rb
+++ b/lib/puppet/functions/simplib/lookup.rb
@@ -1,8 +1,9 @@
 # A function for falling back to global scope variable lookups when the
 # Puppet 4 ``lookup()`` function cannot find a value.
 #
-# While ``lookup()`` will stop at the back-end data sources, ``lookup()`` will
-# check the global scope first to see if the variable has been defined.
+# While ``lookup()`` will stop at the back-end data sources,
+# ``simplib::lookup()`` will check the global scope first to see if the
+# variable has been defined.
 #
 # This means that you can pre-declare a class and/or use an ENC and look up the
 # variable whether it is declared this way or via Hiera or some other back-end.

--- a/lib/puppet/functions/simplib/nets2cidr.rb
+++ b/lib/puppet/functions/simplib/nets2cidr.rb
@@ -1,17 +1,48 @@
 # Take an input list of networks and returns an equivalent `Array` in
 # CIDR notation.
-# Hostnames are passed through untouched.
+#
+# * Hostnames are passed through untouched.
+# * Terminates catalog compilation if any input item is not a
+#   valid network or hostname.
+#
 Puppet::Functions.create_function(:'simplib::nets2cidr') do
 
   # @param network_list List of 1 or more networks separated by spaces,
   #   commas, or semicolons
   # @return [Array[String]] Array of networks in CIDR notation
+  # @raise RuntimeError if any input item is not a valid network
+  #   or hostname
+  #
+  # @example Convert space-separated network string
+  #    $networks = '1.2.0.0/255.255.0.0 myhost.test.local'
+  #    $cidrs = nets2cidr($networks)
+  #
+  #    returns $cidrs = [ '1.2.0.0/16',
+  #                       'myhost.test.local'
+  #                     ]
   dispatch :nets2cidr_list do
     required_param 'String', :network_list
   end
 
   # @param networks Array of networks
   # @return [Array[String]] Array of networks in CIDR notation
+  # @raise RuntimeError if any input item is not a valid network
+  #   or hostname
+  #
+  # @example Convert array of networks
+  #    $networks = [ '1.2.0.0/255.255.0.0',
+  #                  '2001:db8:85a3::8a2e:370:0/112',
+  #                  '1.2.3.4',
+  #                  'myhost.test.local'
+  #                ]
+  #    $cidrs = nets2cidr($networks)
+  #
+  #    returns $cidrs = [ '1.2.0.0/16',
+  #                       '2001:db8:85a3::8a2e:370:0/112',
+  #                       '1.2.3.4',
+  #                       'myhost.test.local'
+  #                     ]
+  #
   dispatch :nets2cidr do
     required_param 'Array', :networks
   end

--- a/lib/puppet/functions/simplib/nets2ddq.rb
+++ b/lib/puppet/functions/simplib/nets2ddq.rb
@@ -1,9 +1,11 @@
 # Tranforms a list of networks into an equivalent array in
 # dotted quad notation.
 #
-# CIDR networks are converted to dotted quad notation networks.
-# IP addresses and hostnames are left untouched.
-
+# * CIDR networks are converted to dotted quad notation networks.
+#   IP addresses and hostnames are left untouched.
+# * Terminates catalog compilation if any input item is not a
+#   valid network or hostname.
+#
 Puppet::Functions.create_function(:'simplib::nets2ddq') do
 
   # @param networks The networks to convert

--- a/lib/puppet/functions/simplib/parse_hosts.rb
+++ b/lib/puppet/functions/simplib/parse_hosts.rb
@@ -1,17 +1,23 @@
 # Convert an `Array` of items that may contain port numbers or protocols
 # into a structured `Hash` of host information.
 #
-# Works with Hostnames as well as IPv4 and IPv6 addresses.
+# * Works with Hostnames as well as IPv4 and IPv6 addresses.
+# * IPv6 addresses will be returned normalized with square brackets
+#   around them for clarity.
+# * Terminates catalog compilation if
 #
-# **NOTE:** IPv6 addresses will be returned normalized with square brackets
-# around them for clarity.
+#     * A valid network or hostname cannot be extracted from all input items.
+#     * Any input item that contains a port specifies an invalid port.
 #
 Puppet::Functions.create_function(:'simplib::parse_hosts') do
 
   # @param hosts Array of host entries, where each entry may contain
   #   a protocol or both a protocol and port
   # @return [Hash] Structured Hash of the host information
-  #
+  # @raise RuntimeError if a valid network or hostname cannot be
+  #   extracted from all input items
+  # @raise RuntimeError if any input item that contains a port
+  #   specifies an invalid port
   # @example Input with multiple host formats:
   #
   #   simplib::parse_hosts([

--- a/lib/puppet/functions/simplib/passgen.rb
+++ b/lib/puppet/functions/simplib/passgen.rb
@@ -1,10 +1,14 @@
-# Generates a random password string for a passed identifier.
+# Generates/retrieves a random password string or its hash for a
+# passed identifier.
 #
-# Uses `Puppet.settings[:vardir]/simp/environments/$environment/simp_autofiles/gen_passwd/`
-# as the destination directory.
-#
-# The minimum length password that this function will return is `8`
-# characters.
+# * Uses `Puppet.settings[:vardir]/simp/environments/$environment/simp_autofiles/gen_passwd/`
+#   as the destination directory for password storage.
+# * The minimum length password that this function will return is `8`
+#   characters.
+# * Terminates catalog compilation if the password storage directory
+#   cannot be created/accessed by the Puppet user, the password cannot
+#   be created in the allotted time, or files not owned by the Puppet
+#   user are present in the password storage directory.
 #
 Puppet::Functions.create_function(:'simplib::passgen') do
 
@@ -27,8 +31,9 @@ Puppet::Functions.create_function(:'simplib::passgen') do
   #   * `salt` => contains the string literal salt to use (used for testing)
   #   * `complex_only` => use only the characters explicitly added by the complexity rules (used for testing)
   #
-  # @return [String] Password specified. If no, or an invalid, second
-  #   argument is provided then it will return the currently stored `String`.
+  # @return [String] Password or password hash specified. If no
+  #   `modifier_hash` or an invalid `modifier_hash` is provided,
+  #   it will return the currently stored/generated password.
   #
   dispatch :passgen do
     required_param 'String[1]', :identifier

--- a/lib/puppet/functions/simplib/strip_ports.rb
+++ b/lib/puppet/functions/simplib/strip_ports.rb
@@ -1,11 +1,18 @@
 # Extract list of unique hostnames and/or IP addresses from an `Array`
 # of hosts, each of which may may contain protocols and/or port numbers
 #
+# Terminates catalog compilation if
+#
+# * A valid network or hostname cannot be extracted from all input items.
+# * Any input item that contains a port specifies an invalid port.
+#
 Puppet::Functions.create_function(:'simplib::strip_ports') do
 
   # @param hosts List of hosts which may contain protocols and port numbers.
   #
   # @return [Array[String]] Non-port portion of hostnames
+  # @raise RuntimeError if any input item that contains a port
+  #   specifies an invalid port
   #
   # @example
   #

--- a/lib/puppet/functions/simplib/to_integer.rb
+++ b/lib/puppet/functions/simplib/to_integer.rb
@@ -1,10 +1,14 @@
 # Converts the argument into an `Integer`.
-# Only works if the passed argument responds to the `to_i()` Ruby method.
+#
+# Terminates catalog compilation if the argument's class
+# does not respond to the `to_i()` Ruby method.
 #
 Puppet::Functions.create_function(:'simplib::to_integer') do
 
   # @param input The argument to convert into an `Integer`
   # @return [Integer] Converted input
+  # @raise 'RuntimeError' if ``input`` does not implement a ``to_i()``
+  #   method
   dispatch :to_integer do
     required_param 'Any', :input
   end

--- a/lib/puppet/functions/simplib/to_string.rb
+++ b/lib/puppet/functions/simplib/to_string.rb
@@ -1,5 +1,4 @@
 # Converts the argument into a `String`.
-# Only works if the passed argument responds to the `to_s()` Ruby method.
 #
 Puppet::Functions.create_function(:'simplib::to_string') do
 
@@ -15,6 +14,8 @@ Puppet::Functions.create_function(:'simplib::to_string') do
     if input.respond_to?(:to_s)
       return input.to_s
     else
+      # Should not be able to get here with Puppet, especially since
+      # Ruby provides a `to_s()` method for all objects
       fail("simplib::to_string(): Object type '#{input.class}' cannot be converted to a String")
     end
   end

--- a/lib/puppet/functions/simplib/validate_array_member.rb
+++ b/lib/puppet/functions/simplib/validate_array_member.rb
@@ -1,6 +1,9 @@
 # Validate that an single input is a member of another `Array` or an
-# `Array` input is a subset of another `Array`. The comparison
-# can optionally ignore the case of `String` elements.
+# `Array` input is a subset of another `Array`.
+#
+# * The comparison can optionally ignore the case of `String` elements.
+# * Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_array_member') do
 
   local_types do

--- a/lib/puppet/functions/simplib/validate_between.rb
+++ b/lib/puppet/functions/simplib/validate_between.rb
@@ -1,11 +1,15 @@
 # Validate that the first value is between the second and third values
 # numerically. The range is inclusive.
+#
+# Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_between') do
 
   # @param value Value to validate
   # @param min_value Minimum value that is valid
   # @param max_value Maximum value that is valid
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   #
   # @example Passing
   #   simplib::validate_between('-1', -3, 0)

--- a/lib/puppet/functions/simplib/validate_bool.rb
+++ b/lib/puppet/functions/simplib/validate_bool.rb
@@ -1,9 +1,13 @@
 # Validate that all passed values are either `true`, 'true',
 # `false` or 'false'.
+#
+# Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_bool') do
 
   # @param values_to_validate One or more values to validate
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   # @example Passing validation
   #
   #     $iamtrue = true

--- a/lib/puppet/functions/simplib/validate_deep_hash.rb
+++ b/lib/puppet/functions/simplib/validate_deep_hash.rb
@@ -1,16 +1,15 @@
 # Perform a deep validation on two passed `Hashes`.
 #
-# All keys must be defined in the reference `Hash` that is being
-# validated against.
+# * All keys must be defined in the reference `Hash` that is being
+#   validated against.
+# * Unknown keys in the `Hash` being compared will cause a failure in
+#   validation
+# * All values in the final leaves of the 'reference 'Hash' must
+#   be a String, Boolean, or nil.
+# * All values in the final leaves of the `Hash` being compared must
+#   support a to_s() method.
+# * Terminates catalog compilation if validation fails.
 #
-# Unknown keys in the `Hash` being compared will cause a failure in
-# validation
-#
-# All values in the final leaves of the 'reference 'Hash' must
-# be a String, Boolean, or nil.
-#
-# All values in the final leaves of the `Hash` being compared must
-# support a to_s() method.
 Puppet::Functions.create_function(:'simplib::validate_deep_hash') do
 
   # @param reference Hash to validate against. Keys at all levels of
@@ -37,6 +36,7 @@ Puppet::Functions.create_function(:'simplib::validate_deep_hash') do
   #
   # @param to_check Hash to be validated against the reference
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   #
   # @example Passing Examples
   #   reference = {

--- a/lib/puppet/functions/simplib/validate_net_list.rb
+++ b/lib/puppet/functions/simplib/validate_net_list.rb
@@ -1,14 +1,19 @@
 # Validate that a passed list (`Array` or single `String`) of networks
 # is filled with valid IP addresses, network addresses (CIDR notation),
-# or hostnames. Hostnames are checked per RFC 1123. Ports appended with
-# a colon `:` are allowed for hostnames and individual IP addresses.
+# or hostnames.
+#
+# * Hostnames are checked per RFC 1123.
+# * Ports appended with # a colon `:` are allowed for hostnames and
+#   individual IP addresses.
+# * Terminates catalog compilation if validation fails.
 #
 Puppet::Functions.create_function(:'simplib::validate_net_list') do
 
   # @param net Single network to be validated.
-  # @param str_match A regex of `String` that should be ignored
-  #   from the list. Omit the beginning and ending `/` delimiter.
+  # @param str_match Stringified regular expression (regex without
+  #   the `//` delimiters)
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   #
   # @example Passing
   #
@@ -35,9 +40,10 @@ Puppet::Functions.create_function(:'simplib::validate_net_list') do
   end
 
   # @param net_list `Array` of networks to be validated.
-  # @param str_match A regex of `String` that should be ignored
-  #   from the list. Omit the beginning and ending `/` delimiter.
+  # @param str_match Stringified regular expression (regex without
+  #   the `//` delimiters)
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   #
   # @example Passing
   #

--- a/lib/puppet/functions/simplib/validate_port.rb
+++ b/lib/puppet/functions/simplib/validate_port.rb
@@ -1,5 +1,9 @@
-# Validates whether or not the passed argument is a valid port
-# (i.e. between `1` - `65535`).
+# Validates whether each passed argument contains valid port(s).
+#
+# * Each element of each argument must, numerically, be in the
+#   range [1, 65535].
+# * Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_port') do
   local_types do
     type 'StringOrInteger = Variant[String[1],Integer]'
@@ -9,6 +13,7 @@ Puppet::Functions.create_function(:'simplib::validate_port') do
   # @param port_args Arguments each of which contain either an
   #   individual port or an array of ports.
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   #
   # @example Passing
   #   $port = '10541'

--- a/lib/puppet/functions/simplib/validate_re_array.rb
+++ b/lib/puppet/functions/simplib/validate_re_array.rb
@@ -1,6 +1,9 @@
 # Perform simple validation of a `String`, or `Array` of `Strings`,
 # against one or more regular expressions.
-# Derived from the Puppet Labs stdlib validate_re.
+#
+# * Derived from the Puppet Labs stdlib validate_re.
+# * Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_re_array') do
 
   # @param input String to be validated

--- a/lib/puppet/functions/simplib/validate_sysctl_value.rb
+++ b/lib/puppet/functions/simplib/validate_sysctl_value.rb
@@ -1,5 +1,8 @@
-#    Validate that the passed value is correct for the passed `sysctl` key.
-#    If a key is not known, assumes the value is valid.
+# Validate that the passed value is correct for the passed `sysctl` key.
+#
+# * If a key is not known, assumes the value is valid.
+# * Terminates catalog compilation if validation fails.
+#
 Puppet::Functions.create_function(:'simplib::validate_sysctl_value') do
 
   # @param key sysctl setting whose value is to be validated

--- a/lib/puppet/functions/simplib/validate_uri_list.rb
+++ b/lib/puppet/functions/simplib/validate_uri_list.rb
@@ -1,13 +1,16 @@
 # Validate that a passed list (`Array` or single `String`) of URIs is
 # valid according to Ruby's URI parser.
-# Caution:  No scheme (protocol type) validation is done the scheme_list
-# parameter is not set.
+# 
+# * *Caution*:  No scheme (protocol type) validation is done if the
+#    `scheme_list` parameter is not set.
+# * Terminates catalog compilation if validation fails.
 #
 Puppet::Functions.create_function(:'simplib::validate_uri_list') do
 
   # @param uri URI to be validated.
   # @param scheme_list List of schemes (protocol types) allowed for the URI.
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   # @example Passing
   #   $uri = 'http://foo.bar.baz:1234'
   #   simplib::validate_uri_list($uri)
@@ -23,6 +26,7 @@ Puppet::Functions.create_function(:'simplib::validate_uri_list') do
   # @param uri_list 1 or more URIs to be validated.
   # @param scheme_list List of schemes (protocol types) allowed for the URI.
   # @return [Nil]
+  # @raise RuntimeError if validation fails
   # @example Passing
   #   $uris = ['http://foo.bar.baz:1234','ldap://my.ldap.server']
   #   simplib::validate_uri_list($uris)

--- a/lib/puppetx/simp/simplib.rb
+++ b/lib/puppetx/simp/simplib.rb
@@ -18,10 +18,12 @@ module PuppetX
       end
 
       # Determine whether or not the passed value is a valid hostname.
+      #
       # Returns false if is not comprised of ASCII letters (upper or lower case),
       # digits, hypens (except at the beginning and end), and dots (except at
       # beginning and end)
-      # NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+      #
+      # *NOTE*:  This returns true for an IPv4 address, as it conforms to RFC 1123.
       def self.hostname_only?(obj)
         # This regex shamelessly lifted from
         # http://stackoverflow.com/questions/106179/regular-expression-to-match-hostname-or-ip-address
@@ -38,12 +40,15 @@ module PuppetX
         !hname_regex.match(obj).nil?
       end
 
-      # Determine whether or not the passed value is a valid hostname optionally
-      # postpended with ':<number>' or '/<number>'.
+      # Determine whether or not the passed value is a valid hostname,
+      # optionally postpended with ':<number>' or '/<number>'.
+      #
       # Returns false if is not comprised of ASCII letters (upper or lower case),
       # digits, hypens (except at the beginning and end), and dots (except at
-      # beginning and end), optional pluss ':<number>' or '/<number>'
-      # NOTE:  This returns true for an IPv4 address, as it conforms to RFC 1123.
+      # beginning and end), excluding an optional, trailing ':<number>' or
+      # '/<number>'
+      #
+      # *NOTE*:  This returns true for an IPv4 address, as it conforms to RFC 1123.
       def self.hostname?(obj)
         # This regex shamelessly lifted from
         # http://stackoverflow.com/questions/106179/regular-expression-to-match-hostname-or-ip-address

--- a/spec/functions/simplib_spec.rb
+++ b/spec/functions/simplib_spec.rb
@@ -119,6 +119,10 @@ describe 'PuppetX::SIMP::Simplib' do
       expect(PuppetX::SIMP::Simplib.split_port('')).to eq [nil, nil]
     end
 
+    it 'extracts hostname and port' do
+      expect(PuppetX::SIMP::Simplib.split_port('myhost.name:5656')).to eq ['myhost.name', '5656']
+    end
+
     it 'extracts IPv4 address and port' do
       expect(PuppetX::SIMP::Simplib.split_port('1.2.3.4:255')).to eq ['1.2.3.4', '255']
     end

--- a/types/port/dynamic.pp
+++ b/types/port/dynamic.pp
@@ -1,2 +1,2 @@
-# Corresponds to the usual privileged port range
+# Corresponds to the usual unprivileged port range
 type Simplib::Port::Dynamic = Integer[49152,65535]


### PR DESCRIPTION
- Seperated Puppet 3 and Puppet later functions.
- Marked Puppet 3 functions as derecated.
- Added info about stages, extentions, and custom types.
- Added examples for funstions that had them.

SIMP-4262 #close
SIMP-4369 close
SIMP-4370 close
SIMP-4371 close
