### PR TITLE
(SIMP-2519) Add ability to silence reboot notify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,13 @@
 * Mon Apr 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
-- Adds two parameters :log_level and :control_only to the 'reboot_notify'
-  custom type.
+- The following changes allow users to disable reboot notify messages
+  - Adds two parameters :log_level and :control_only to the 'reboot_notify'
+    custom type.
     * :log_level    => Set the Puppet log level of the generated message
     * :control_only => Indicate that this entry should not be added to
                        the generated file
-- Added a `Simplib::PuppetLogLevel` Data Type
-- Added a 'reboot_control_metadata' section to the on-system record file
-- Added a `simplib::reboot_notify` class to allow for ease of global
+  - Added a `Simplib::PuppetLogLevel` Data Type
+  - Added a 'reboot_control_metadata' section to the on-system record file
+  - Added a `simplib::reboot_notify` class to allow for ease of global
   metadata manipulation.
 - Fixed file paths that were not Windows compatible
 - Improved error handling in `reboot_notify` and fixed a few small bugs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,16 @@
 * Mon Apr 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
+- Adds two parameters :log_level and :control_only to the 'reboot_notify'
+  custom type.
+    * :log_level    => Set the Puppet log level of the generated message
+    * :control_only => Indicate that this entry should not be added to
+                       the generated file
+- Added a `Simplib::PuppetLogLevel` Data Type
+- Added a 'reboot_control_metadata' section to the on-system record file
+- Added a `simplib::reboot_notify` class to allow for ease of global
+  metadata manipulation.
+- Fixed file paths that were not Windows compatible
 - Improved error handling in `reboot_notify` and fixed a few small bugs
+- Improved some tests
 
 * Fri Jan 19 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.0-0
 - Updated the simplib::ldap::domain_to_dn function to allow users to choose

--- a/lib/puppet/provider/reboot_notify/notify.rb
+++ b/lib/puppet/provider/reboot_notify/notify.rb
@@ -1,6 +1,19 @@
 Puppet::Type.type(:reboot_notify).provide(:notify) do
   desc 'Management of the reboot notification metadata file.'
 
+  # Simple accessor for common data
+  def self.target
+    File.join(Puppet[:vardir], 'reboot_notifications.json')
+  end
+
+  # Instance syntactic sugar
+   def target
+     self.class.target
+   end
+
+  # The default control metadata if none other is specified
+  #
+  # Used in both class and instance methods
   def self.default_control_metadata
     return {
       'reboot_control_metadata' => {
@@ -12,8 +25,6 @@ Puppet::Type.type(:reboot_notify).provide(:notify) do
   def initialize(*args)
     super(*args)
 
-    @target = File.join(Puppet[:vardir], 'reboot_notifications.json')
-
     @records = self.class.default_control_metadata
   end
 
@@ -21,58 +32,61 @@ Puppet::Type.type(:reboot_notify).provide(:notify) do
     begin
       require 'deep_merge'
 
-      @records = JSON.parse(File.read(@target)).deep_merge(
-        self.class.default_control_metadata
-      )
+      @records = JSON.parse(File.read(target))
+
+      if @resource[:control_only]
+        @records = @records.deep_merge( self.class.default_control_metadata )
+      end
 
     rescue => e
+      # Cheap and easy way to ensure that the file gets created and/or fixed if
+      # there is something wrong with it.
+
       Puppet.debug("reboot_notify: #exists? => #{e}")
       return false
     end
 
-    retval = false
     if @resource[:control_only]
-      if @records['reboot_control_metadata']
-        if @records['reboot_control_metadata']['log_level'] == @resource[:log_level]
-          retval = true
-        end
-      end
-    else
-      retval = @records[@resource[:name]] &&
-      (@records[@resource[:name]]['reason'] == @resource[:reason])
+      # If this is the control resource, the control components need to match
+      #
+      # We *may* want to split this out into a separate type in the future
+
+      return @records['reboot_control_metadata']['log_level'] == @resource[:log_level]
     end
 
-    return retval
+    return true
   end
 
   def create
     add_record
 
     begin
-      File.open(@target,'w'){|fh| fh.puts(JSON.pretty_generate(@records))}
+      File.open(target,'w'){|fh| fh.puts(JSON.pretty_generate(@records))}
     rescue => e
-      raise(Puppet::Error, "reboot_notify: Could not create '#{@target}': #{e}")
+      raise(Puppet::Error, "reboot_notify: Could not create '#{target}': #{e}")
     end
   end
 
   def destroy
-    File.unlink(@target) if File.exist?(@target)
+    # This resource is all or nothing so it doesn't make sense to cherry pick
+    # items out of the results
+
+    File.unlink(target) if File.exist?(target)
   end
 
   def update
     add_record
 
     begin
-      File.open(@target,'w') { |fh| fh.puts(JSON.pretty_generate(@records)) }
+      File.open(target,'w') { |fh| fh.puts(JSON.pretty_generate(@records)) }
     rescue => e
-      raise(Puppet::Error, "reboot_notify: Could not update '#{@target}': #{e}")
+      raise(Puppet::Error, "reboot_notify: Could not update '#{target}': #{e}")
     end
   end
 
+  # This happens after *all* resources of this type have executed but, being a
+  # class method, cannot access any items in the instance methods.
   def self.post_resource_eval
-    # Have to repeat this here because everything in the provider is
-    # now out of scope.
-    target = File.join(Puppet[:vardir], 'reboot_notifications.json')
     records = {}
     content = ''
 
@@ -90,6 +104,7 @@ Puppet::Type.type(:reboot_notify).provide(:notify) do
 
     current_time = Time.now.tv_sec
 
+    # Need to pull this out of the data structure
     if records['reboot_control_metadata']
       reboot_control_metadata = records.delete('reboot_control_metadata')
     else
@@ -100,6 +115,9 @@ Puppet::Type.type(:reboot_notify).provide(:notify) do
     records.delete_if{|k,v|
       next unless v['updated']
 
+      # If the number of seconds between the time that the record was written
+      # and the current time is greater than the system uptime then we should
+      # remove the record
       (current_time - v['updated']) > Facter.value(:uptime_seconds)
     }
 
@@ -128,7 +146,7 @@ Puppet::Type.type(:reboot_notify).provide(:notify) do
       reboot_control_hash = { 'reboot_control_metadata' => reboot_control_metadata }
       File.open(target,'w'){|fh| fh.puts(JSON.pretty_generate(reboot_control_hash.merge(records)))}
     rescue
-      raise(Puppet::Error, "reboot_notify: Could not update '#{@target}': #{e}")
+      raise(Puppet::Error, "reboot_notify: Could not update '#{target}': #{e}")
     end
   end
 

--- a/lib/puppet/type/reboot_notify.rb
+++ b/lib/puppet/type/reboot_notify.rb
@@ -42,6 +42,10 @@ Puppet::Type.newtype(:reboot_notify) do
 
     defaultto(:notice)
     newvalues(:alert, :crit, :debug, :notice, :emerg, :err, :info, :warning)
+
+    munge do |value|
+      value.to_s
+    end
   end
 
   newparam(:control_only, :boolean => true, :parent => Puppet::Parameter::Boolean) do
@@ -55,13 +59,15 @@ Puppet::Type.newtype(:reboot_notify) do
   end
 
   validate do
-    existing_resource = catalog.resources.find { |res| (res.type == self.type) && res[:control_only] }
+    if self[:control_only]
+      existing_resource = catalog.resources.find { |res| (res.type == self.type) && res[:control_only] }
 
-    if existing_resource
-      err = ["You can only have one #{self.type} resource with :control_only set to 'true'"]
-      err << "Conflicting resource found in file '#{existing_resource.file}' on line '#{existing_resource.line}'"
+      if existing_resource
+        err = ["You can only have one #{self.type} resource with :control_only set to 'true'"]
+        err << "Conflicting resource found in file '#{existing_resource.file}' on line '#{existing_resource.line}'"
 
-      raise(Puppet::Error, err.join("\n"))
+        raise(Puppet::Error, err.join("\n"))
+      end
     end
   end
 

--- a/lib/puppet/type/reboot_notify.rb
+++ b/lib/puppet/type/reboot_notify.rb
@@ -33,21 +33,6 @@ Puppet::Type.newtype(:reboot_notify) do
     defaultto('modified')
   end
 
-  newparam(:log_level) do
-    desc <<-EOM
-    Set the message log level for notifications
-
-    If this is set in *any* instance then it takes effect for *all* instances!
-    EOM
-
-    defaultto(:notice)
-    newvalues(:alert, :crit, :debug, :notice, :emerg, :err, :info, :warning)
-
-    munge do |value|
-      value.to_s
-    end
-  end
-
   newparam(:control_only, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc <<-EOM
     This resource is only for control and should not add an item to the notification list
@@ -56,6 +41,21 @@ Puppet::Type.newtype(:reboot_notify) do
     EOM
 
     defaultto(:false)
+  end
+
+  newparam(:log_level) do
+    desc <<-EOM
+    Set the message log level for notifications
+
+    This is only active with :control_only set to `true`
+    EOM
+
+    defaultto(:notice)
+    newvalues(:alert, :crit, :debug, :notice, :emerg, :err, :info, :warning)
+
+    munge do |value|
+      value.to_s
+    end
   end
 
   validate do

--- a/lib/puppet/type/reboot_notify.rb
+++ b/lib/puppet/type/reboot_notify.rb
@@ -1,5 +1,5 @@
 Puppet::Type.newtype(:reboot_notify) do
-  @doc = "Notifies users when a system reboot is required.
+  @doc = 'Notifies users when a system reboot is required.
 
     This type creates a file at $target the contents of which
     provide a summary of the reasons why the system requires a
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:reboot_notify) do
     other use of the type will not report the necessary reboot.
 
     A reboot notification will be printed at each puppet run until
-    the system is successfully rebooted."
+    the system is successfully rebooted.'
 
   ensurable do
     defaultto(:present)
@@ -24,12 +24,45 @@ Puppet::Type.newtype(:reboot_notify) do
   end
 
   newparam(:name) do
-    desc "The item that is being modified that requires a reboot"
+    desc 'The item that is being modified that requires a reboot'
   end
 
   newparam(:reason) do
-    desc "An optional reason for rebooting."
+    desc 'An optional reason for rebooting'
+
     defaultto('modified')
+  end
+
+  newparam(:log_level) do
+    desc <<-EOM
+    Set the message log level for notifications
+
+    If this is set in *any* instance then it takes effect for *all* instances!
+    EOM
+
+    defaultto(:notice)
+    newvalues(:alert, :crit, :debug, :notice, :emerg, :err, :info, :warning)
+  end
+
+  newparam(:control_only, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc <<-EOM
+    This resource is only for control and should not add an item to the notification list
+
+    You may only have ONE resource with this set to `true` in your catalog
+    EOM
+
+    defaultto(:false)
+  end
+
+  validate do
+    existing_resource = catalog.resources.find { |res| (res.type == self.type) && res[:control_only] }
+
+    if existing_resource
+      err = ["You can only have one #{self.type} resource with :control_only set to 'true'"]
+      err << "Conflicting resource found in file '#{existing_resource.file}' on line '#{existing_resource.line}'"
+
+      raise(Puppet::Error, err.join("\n"))
+    end
   end
 
   # We only update on refresh

--- a/manifests/reboot_notify.pp
+++ b/manifests/reboot_notify.pp
@@ -3,9 +3,13 @@
 #
 # @param log_level
 #   The Puppet log_level to use when generating output
+#   
+#   To change the level of the reboot_notify messages add this class 
+#   to the class list in hiera and set simplib::reboot_notify::log_level to
+#   the level you want.
 #
-#   * Set to ``debug`` if you wish to disable output unless you're running in
-#     debug mode.
+#   * Set to  log_level to``debug`` if you wish to disable output unless you're
+#     running in debug mode.
 #
 class simplib::reboot_notify (
   Simplib::PuppetLogLevel $log_level = 'notice'

--- a/manifests/reboot_notify.pp
+++ b/manifests/reboot_notify.pp
@@ -4,6 +4,9 @@
 # @param log_level
 #   The Puppet log_level to use when generating output
 #
+#   * Set to ``debug`` if you wish to disable output unless you're running in
+#     debug mode.
+#
 class simplib::reboot_notify (
   Simplib::PuppetLogLevel $log_level = 'notice'
 ){

--- a/manifests/reboot_notify.pp
+++ b/manifests/reboot_notify.pp
@@ -1,0 +1,14 @@
+# This is a simple controller class for global settings related to the
+# 'reboot_notify' custom type
+#
+# @param log_level
+#   The Puppet log_level to use when generating output
+#
+class simplib::reboot_notify (
+  Simplib::PuppetLogLevel $log_level = 'notice'
+){
+  reboot_notify { '__simplib_control__':
+    log_level    => $log_level,
+    control_only => true
+  }
+}

--- a/spec/acceptance/suites/default/reboot_notify_spec.rb
+++ b/spec/acceptance/suites/default/reboot_notify_spec.rb
@@ -74,9 +74,10 @@ describe 'reboot_notify' do
           apply_manifest_on(host, manifest, :catch_changes => true)
         end
 
-        it 'should be idempotent after reboot' do
+        it 'should not display notifications after reboot' do
           host.reboot
-          apply_manifest_on(host, manifest, :catch_changes => true)
+          result = apply_manifest_on(host, manifest).stdout
+          expect(result).to_not match(/System Reboot Required Because:/)
         end
 
         it 'should remain idempotent' do

--- a/spec/acceptance/suites/default/reboot_notify_spec.rb
+++ b/spec/acceptance/suites/default/reboot_notify_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper_acceptance'
+
+test_name 'reboot_notify'
+describe 'reboot_notify' do
+
+  hosts.each do |host|
+    context "on #{host}" do
+      let (:manifest) {
+        <<-EOS
+        reboot_notify { 'test': }
+        include 'simplib::reboot_notify'
+        reboot_notify { 'test2': reason => 'second test' }
+        EOS
+      }
+      it 'should apply cleanly' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
+
+      it 'should display reboot notifications' do
+        result = apply_manifest_on(host, manifest).stdout
+        expect(result).to match(/System Reboot Required Because:/)
+      end
+
+      context 'with log_level set to debug' do
+        let (:manifest) {
+          <<-EOS
+          reboot_notify { 'test': }
+          class { 'simplib::reboot_notify':
+            log_level => 'debug'
+          }
+          reboot_notify { 'test2': reason => 'second test' }
+          EOS
+        }
+
+        it 'should apply cleanly' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, :catch_changes => true)
+        end
+
+        it 'should not display reboot notifications' do
+          result = apply_manifest_on(host, manifest).stdout
+          expect(result).to_not match(/System Reboot Required Because:/)
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/reboot_notify_spec.rb
+++ b/spec/classes/reboot_notify_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'simplib::reboot_notify' do
+  context 'on supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_reboot_notify('__simplib_control__').with_log_level('notice') }
+        it { is_expected.to create_reboot_notify('__simplib_control__').with_control_only(true) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |c|
     :production => {
       #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      :concat_basedir => '/tmp',
     }
   }
 
@@ -129,7 +129,6 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
-    Puppet[:digest_algorithm] = 'sha256'
 
     # sanitize hieradata
     if defined?(hieradata)
@@ -152,4 +151,9 @@ Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
   rescue
     fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
   end
+end
+
+if ENV['PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
 end

--- a/spec/unit/puppet/provider/reboot_notify/notify_spec.rb
+++ b/spec/unit/puppet/provider/reboot_notify/notify_spec.rb
@@ -51,12 +51,20 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
   end
 
   context '#create' do
-    it 'should create a valid, but empty JSON file' do
-      expect{ provider.create }.to_not raise_error
+    it 'should create a valid JSON file' do
+      content = nil
+
+      expect{
+        provider.create
+        content = JSON.parse(File.read(@target))
+      }.to_not raise_error
 
       expect(
-        JSON.parse(File.read(@target))
-      ).to eq({'reboot_control_metadata' => { 'log_level' => 'notice' }})
+        content['reboot_control_metadata']
+      ).to eq({ 'log_level' => 'notice' })
+
+      expect( content['Foo'] ).to_not be_nil
+      expect( content['Foo']['reason'] ).to eq('Bar')
     end
 
     context 'the target directory does not exist' do

--- a/spec/unit/puppet/provider/reboot_notify/notify_spec.rb
+++ b/spec/unit/puppet/provider/reboot_notify/notify_spec.rb
@@ -12,6 +12,9 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
   }
 
   before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Reboot_notify.any_instance.stubs(:catalog).returns(@catalog)
+
     @tmpdir = Dir.mktmpdir('rspec_reboot_notify')
     @target = File.join(@tmpdir, 'reboot_notifications.json')
     Puppet.stubs(:[]).with(:vardir).returns @tmpdir
@@ -34,13 +37,13 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
       end
 
       it 'is invalid' do
-        File.open(@target, 'w'){|fh| fh.puts("{")}
+        File.open(@target, 'w'){|fh| fh.puts('{')}
 
         expect(provider.exists?).to be_falsey
       end
 
       it 'is json' do
-        File.open(@target, 'w'){|fh| fh.puts("{}")}
+        File.open(@target, 'w'){|fh| fh.puts('{}')}
 
         expect(provider.exists?).to be_truthy
       end
@@ -51,7 +54,9 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
     it 'should create a valid, but empty JSON file' do
       expect{ provider.create }.to_not raise_error
 
-      expect(JSON.parse(File.read(@target))).to eq({})
+      expect(
+        JSON.parse(File.read(@target))
+      ).to eq({'reboot_control_metadata' => { 'log_level' => 'notice' }})
     end
 
     context 'the target directory does not exist' do
@@ -122,6 +127,52 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
         expect{ provider.update}.to raise_error(/Could not update.*#{@target}/)
       end
     end
+
+    context 'control_only is set' do
+      let(:resource) {
+        Puppet::Type.type(:reboot_notify).new(
+          name: 'Foo',
+          reason: 'Bar',
+          control_only: true
+        )
+      }
+
+      it do
+        expect{ provider.update }.to_not raise_error
+        expect(
+          JSON.parse(File.read(@target))
+        ).to eq({'reboot_control_metadata' => { 'log_level' => 'notice' }})
+      end
+
+      [:alert, :crit, :debug, :notice, :emerg, :err, :info, :warning].each do |log_level|
+        context "log_level is #{log_level}" do
+          let(:resource) {
+            Puppet::Type.type(:reboot_notify).new(
+              name: 'Foo',
+              reason: 'Bar',
+              control_only: true,
+              log_level: log_level.to_s
+            )
+          }
+
+          it do
+            # This should always be prevented by the Type but is here in case
+            # of a regression in Puppet or a bad update to the type.
+            Puppet.expects(:warning).with(
+              regexp_matches(/Invalid log_level:/)
+            ).never
+            Puppet.expects(log_level).with(
+              regexp_matches(/System Reboot Required Because:/)
+            ).at_most_once
+
+            expect{ provider.update }.to_not raise_error
+            expect(
+              JSON.parse(File.read(@target))
+            ).to eq({'reboot_control_metadata' => { 'log_level' => log_level.to_s }})
+          end
+        end
+      end
+    end
   end
 
   context '#self.post_resource_eval' do
@@ -132,7 +183,13 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
 
     let(:output) { JSON.parse(File.read(@target)) }
 
-    it { expect{ provider.class.post_resource_eval }.to_not raise_error }
+    it do
+      Puppet.expects(:notice).with(
+        regexp_matches(/System Reboot Required Because:/)
+      ).at_most_once
+
+      expect{ provider.class.post_resource_eval }.to_not raise_error
+    end
 
     context 'the target has invalid json' do
       it 'should fail' do
@@ -172,6 +229,28 @@ describe Puppet::Type.type(:reboot_notify).provider(:notify) do
         expect(updates.keys).to_not include('ToDelete')
         expect(updates.keys).to include('ToKeep')
         expect(updates['ToKeep']).to eq(data['ToKeep'])
+      end
+    end
+
+    context 'log_level is set' do
+      let(:resource) {
+        Puppet::Type.type(:reboot_notify).new(
+          name: 'Foo',
+          reason: 'Bar',
+          log_level: 'debug'
+        )
+      }
+
+      it do
+        expect{ provider.update }.to_not raise_error
+        Puppet.expects(:debug).with(
+          regexp_matches(/System Reboot Required Because:/)
+        ).at_most_once
+        expect{ provider.class.post_resource_eval}.to_not raise_error
+
+        content = JSON.parse(File.read(@target))
+
+        expect(content.keys).to include('Foo')
       end
     end
   end

--- a/spec/unit/puppet/type/reboot_notify_spec.rb
+++ b/spec/unit/puppet/type/reboot_notify_spec.rb
@@ -5,15 +5,39 @@ require 'spec_helper'
 reboot_notify_type = Puppet::Type.type(:reboot_notify)
 
 describe reboot_notify_type do
+  before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Reboot_notify.any_instance.stubs(:catalog).returns(@catalog)
+  end
+
   context 'when setting parameters' do
     it 'should accept a name parameter' do
-      resource = reboot_notify_type.new :name => 'foo'
+      resource = reboot_notify_type.new :name => 'foo', :reason => 'Foo needs a reboot!'
       expect(resource[:name]).to eq('foo')
     end
 
     it 'should accept a reason parameter' do
       resource = reboot_notify_type.new :name => 'foo', :reason => 'Foo needs a reboot!'
       expect(resource[:reason]).to eq('Foo needs a reboot!')
+    end
+
+    it 'should accept a log_level parameter' do
+      resource = reboot_notify_type.new :name => 'foo', :log_level => 'warning'
+      expect(resource[:log_level]).to eq(:warning)
+    end
+
+    it 'should accept a control_only parameter' do
+      resource = reboot_notify_type.new :name => 'foo', :control_only => true
+      expect(resource[:control_only]).to eq(true)
+    end
+
+    it 'should raise an error if another resource has a control_only parameter' do
+      resource = reboot_notify_type.new :name => 'foo', :control_only => true
+      @catalog.add_resource(resource)
+
+      expect {
+        reboot_notify_type.new :name => 'bar', :control_only => true
+      }.to raise_error(/You can only have one reboot_notify.*Conflicting resource found in file.* on line/m)
     end
   end
 end

--- a/spec/unit/puppet/type/reboot_notify_spec.rb
+++ b/spec/unit/puppet/type/reboot_notify_spec.rb
@@ -23,7 +23,7 @@ describe reboot_notify_type do
 
     it 'should accept a log_level parameter' do
       resource = reboot_notify_type.new :name => 'foo', :log_level => 'warning'
-      expect(resource[:log_level]).to eq(:warning)
+      expect(resource[:log_level]).to eq('warning')
     end
 
     it 'should accept a control_only parameter' do

--- a/types/puppetloglevel.pp
+++ b/types/puppetloglevel.pp
@@ -1,0 +1,11 @@
+# A valid port Type
+type Simplib::PuppetLogLevel = Enum[
+  'alert',
+  'crit',
+  'debug',
+  'emerg',
+  'err',
+  'info',
+  'notice',
+  'warning'
+]

--- a/types/puppetloglevel.pp
+++ b/types/puppetloglevel.pp
@@ -1,4 +1,4 @@
-# A valid port Type
+# A valid log level Type
 type Simplib::PuppetLogLevel = Enum[
   'alert',
   'crit',


### PR DESCRIPTION
* Adds two parameters :disable_alerting and :control_only to the
  'reboot_notify' custom type.
  * :disable_alerting => Disable alerts for all reboot_notify resources
  * :control_only     => Indicate that this entry should not be added to
                         the generated file
* Added a 'reboot_control_metadata' section to the on-system record file
* Added a `simplib::reboot_notify` class to allow for ease of global
  metadata manipulation.
  * We may want to move this into its own module at some point
* Fixed file paths that were not Windows compatible
* Improved some tests

SIMP-4816 #close