### PR TITLE
(SIMP-4826) Update init_ulimit for generate types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Mon Apr 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
+* Mon Apr 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
+- Made the `init_ulimit` custom type safe for `puppet generate types`
+- Fixed a typo in the composite namevar for `init_ulimit`
 - The following changes allow users to disable reboot notify messages
   - Adds two parameters :log_level and :control_only to the 'reboot_notify'
     custom type.

--- a/lib/puppet/type/init_ulimit.rb
+++ b/lib/puppet/type/init_ulimit.rb
@@ -90,10 +90,10 @@ Puppet::Type.newtype(:init_ulimit) do
   def self.title_patterns
     [
       [
-        /^(\|?)(.*)$/,
+        /^(.+?)\|?(.+)$/,
         [
-         [:item, lambda{|x| x}],
-         [:target, lambda{|x| x}]
+         [:item],
+         [:target]
         ]
       ]
     ]
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:init_ulimit) do
 
     validate do |value|
       unless $init_ulimit_opt_map.keys.include?(value.downcase)
-        raise(Puppet::Error, "'item' must be one of '#{$init_ulimit_opt_map.keys.join(', ')}")
+        raise(Puppet::Error, "'item' must be one of '#{$init_ulimit_opt_map.keys.join(', ')}, got #{value}")
       end
     end
   end

--- a/spec/unit/puppet/type/init_ulimit_spec.rb
+++ b/spec/unit/puppet/type/init_ulimit_spec.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+init_ulimit_type = Puppet::Type.type(:init_ulimit)
+
+describe init_ulimit_type do
+  before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Reboot_notify.any_instance.stubs(:catalog).returns(@catalog)
+  end
+
+  context 'when setting parameters' do
+    it 'should accept valid input' do
+      resource = init_ulimit_type.new(
+        :name       => 'foo',
+        :target     => 'foo_svc',
+        :limit_type => 'both',
+        :item       => 'max_nice',
+        :value      => '10'
+      )
+      expect(resource[:name]).to eq('foo')
+      expect(resource[:item]).to eq('e')
+    end
+
+    it 'should accept composite namevars' do
+      resource = init_ulimit_type.new(
+        :name       => 'v|foo_svc',
+        :limit_type => 'both',
+        :value      => '10'
+      )
+      expect(resource[:name]).to eq('v|foo_svc')
+      expect(resource[:item]).to eq('v')
+      expect(resource[:target]).to eq('foo_svc')
+    end
+
+    it 'should translate "unlimited" for "max_open_files"' do
+      resource = init_ulimit_type.new(
+        :name       => 'foo',
+        :target     => 'foo_svc',
+        :item       => 'max_open_files',
+        :value      => 'unlimited'
+      )
+      expect(resource[:name]).to eq('foo')
+      expect(resource[:item]).to eq('n')
+      expect(resource[:value]).to eq('1048576')
+    end
+  end
+end


### PR DESCRIPTION
* This updates init_ulimit to allow it to work properly with `puppet
  generate types`
* A typo was also fixed in the composite namevar

SIMP-4863 #close