### PR TITLE
(SIMP-4885) Add hash_to_opts function

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,68 +1,259 @@
-# 
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+#
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
-puppet-syntax:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    # A broad attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
+
+
+.validation_checks: &validation_checks
   script:
-    - bundle install
     - bundle exec rake syntax
-puppet-lint:
-  stage: test
-  tags:
-    - docker
-  image: ruby:2.1
-  script:
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
-puppet-metadata:
-  stage: test
+    - bundle exec rake clean
+    - bundle exec puppet module build
+
+.spec_tests: &spec_tests
+  script:
+    - bundle exec rake spec
+
+stages:
+  - validation
+  - unit
+  - acceptance
+  - deploy
+
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4_7-validation:
+  stage: validation
   tags:
     - docker
   image: ruby:2.1
-  script:
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_7-unit:
+  stage: unit
   tags:
     - docker
   image: ruby:2.1
-  script:
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4_8-validation:
+  stage: validation
   tags:
     - docker
-  image: ruby:2.2
-  allow_failure: true
-  script:
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_8-unit:
+  stage: unit
   tags:
     - docker
-  image: ruby:2.3
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4_10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+
+pup4_10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5_3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
   allow_failure: true
-  script:
-    - bundle install
-    - bundle exec rake spec
 
-acceptance-test-no-fips:
-  stage: test
+pup5_3-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5_latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5_latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+
+# Acceptance tests
+# ==============================================================================
+default:
+  stage: acceptance
   tags:
     - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake beaker:suites
+    - bundle exec rake beaker:suites[default]
 
-acceptance-test-fips:
-  stage: test
+default-fips:
+  stage: acceptance
   tags:
     - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
   script:
-    - bundle install --no-binstubs --path=vendor
-    - BEAKER_fips=yes bundle exec rake beaker:suites
+    - bundle exec rake beaker:suites[default]
+
+ipa_fact:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+  script:
+    - bundle exec rake beaker:suites[ipa_fact]
+
+ipa_fact-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[ipa_fact]
+
+prelink_fact:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+  script:
+    - bundle exec rake beaker:suites[prelink_fact]
+
+prelink_fact-fips:
+  stage: acceptance
+  tags:
+    - beaker
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[prelink_fact]

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,8 +2,4 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
 --no-trailing_comma-check
-# This is here because the code can't handle lookups in parameters and we have
-# a LOT of those
---no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,19 @@ jobs:
 
   include:
     - stage: check
-      rvm: 2.1.9
+      rvm: 2.4.1
       script:
         - bundle exec rake check:dot_underscore
         - bundle exec rake check:test_file
-        - bundle exec rake pkg:check_version
+        - bundle exec rake lint
         - bundle exec rake metadata_lint
+        - bundle exec rake pkg:check_version
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
+        - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.1.9
+      rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -69,9 +71,8 @@ jobs:
       script:
         - bundle exec rake spec
 
-    # This needs to be last since we have an acceptance test
     - stage: deploy
-      rvm: 2.1.9
+      rvm: 2.4.1
       script:
         - true
       before_deploy:
@@ -91,5 +92,5 @@ jobs:
             secure: "famEX4O8TJM5Ch2miBoLVK3sZW4HhqsDyz+lL5J2WfZV++M4TcISlbLuKlcW/lo605WdoQcJCPunW1svT/eP4MEfz3rSOjGlmNeF4dgGSCM9oQ2xAXzAWBvII6mpleWrXIVwNv4n7eiQ+5lOCoA+7gddfszRwD7a0yiamBkL/c7Ne/ZUHWZUW3Er+SWggLhmc94ZTwDtf7SDFTKBp6DYB2RlYVo1u7iFWzq6PFAuKIF/5O4r3SyOHx9bFKbsQGVOsS5MfcgmUF3NgJFt5oUhCPMIohIKa9+69tbrs00aJDGJ/wk49pabSNu4GVBtJm+j70eQwDBJiBpDtZp/Kjath/edAkW95Cy7zSql9BFGuX6RohzJ0pdjgAb31PpQ3+4ZhqxwReEzH/EjDXj6tezRrBFvCQNZiaTChNND+nsl8RqPmaP8FGU4jh3PS7TAx6Vvimd8ZFUXrfPIv6xk12NOT9jjNiWKOL/SgJNQLmXR+Kqol/h5Yz0dR1zlzdz5i/Px7HpyxZDzV01He6VVcwcBDia1+F8vvj/4sG0mPQ4VLvWqZv4tyhFaX17GtSrGZQEcK9LYkgmjAmdit3gSnHxYCrFv8IVarRNGhhUCp/kFssvpZToE0INWWQCqzGIef35tZ/bafAdNjGPfP6O0JoThEWEXg+P3JVyMmn48t10D3CQ="
           on:
             tags: true
-            rvm: 2.1.9
+            rvm: 2.4.1
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu May 03 2018 Nick Miller <nick.miller@onyxpoint.com> - 3.9.1-0
+- Add `simplib::hash_to_opts` which turns a hash into a string with each key
+  prefixed with '--' and connected to each value with '=', useful for generating
+  commands
+
 * Mon Apr 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
 - Made the `init_ulimit` custom type safe for `puppet generate types`
 - Fixed a typo in the composite namevar for `init_ulimit`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 * Thu May 03 2018 Nick Miller <nick.miller@onyxpoint.com> - 3.9.1-0
-- Add `simplib::hash_to_opts` which turns a hash into a string with each key
-  prefixed with '--' and connected to each value with '=', useful for generating
-  commands
+- Add `simplib::hash_to_opts` which turns a hash into a string. Useful for
+  generating commands.
 
 * Mon Apr 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.9.1-0
 - Made the `init_ulimit` custom type safe for `puppet generate types`

--- a/functions/hash_to_opts.pp
+++ b/functions/hash_to_opts.pp
@@ -1,25 +1,42 @@
-# Turn a hash into a string with eash key prefixed
-# with '--' and connected to each value with '='
+# Turn a hash into a options string, for use in a shell command
 #
 # @example simplib::hash_to_opts({'key' => 'value'})
-#   returns `--key=value`
+#   returns ``--key=value``
 # @example simplib::hash_to_opts({'key' => ['lo',7,false]})
-#   returns `--key="lo,7,false"`
+#   returns ``--key=lo,7,false``
 # @example simplib::hash_to_opts({'key' => Undef })
-#   returns `--key`
+#   returns ```--key``
+# @example simplib::hash_to_opts({'f' => '/tmp/file'}, {'connector' => ' ', 'prefix' => '-'})
+#   returns ``-f /tmp/file``
 #
 # @param input Input hash, with Strings as keys and either a String, Array,
 #   Numeric, Boolean, or Undef as a value.
 #
+# @param opts Options hash. It only takes 3 keys, none of them required:
+#   * ``connector``: String that joins each key and value pair. Defaults to '='
+#   * ``prefix``: String that prefixes each key value pair. Defaults to '--'
+#   * ``array_delimiter``: When a value is an array, the string that is used to
+#     deliminate each item. Defaults to ','
+#
 # @return [String]
 #
-function simplib::hash_to_opts(Hash[String,Variant[Array,String,Numeric,Boolean,Undef]] $input) {
+function simplib::hash_to_opts (
+  Hash[String,Variant[Array,String,Numeric,Boolean,Undef]] $input,
+  Struct[{
+    Optional[connector]       => String[1],
+    Optional[prefix]          => String[1],
+    Optional[array_delimiter] => String[1],
+  }] $opts = {}
+) {
+  $connector       = pick($opts['connector'],       '=')
+  $prefix          = pick($opts['prefix'],          '--')
+  $array_delimiter = pick($opts['array_delimiter'], ',')
+
   $out = $input.map |$key, $val| {
     case $val {
-      Undef:         { "--${key}"                      }
-      Array:         { "--${key}=\"${val.join(',')}\"" }
-      /[[:blank:]]/: { "--${key}=\"${val}\""           }
-      default:       { "--${key}=${val}"               }
+      Undef:   { "${prefix}${key}" }
+      Array:   { "${prefix}${key}${connector}${val.join($array_delimiter).shellquote}" }
+      default: { "${prefix}${key}${connector}${String($val).shellquote}" }
     }
   }
   $out.join(' ')

--- a/functions/hash_to_opts.pp
+++ b/functions/hash_to_opts.pp
@@ -1,0 +1,26 @@
+# Turn a hash into a string with eash key prefixed
+# with '--' and connected to each value with '='
+#
+# @example simplib::hash_to_opts({'key' => 'value'})
+#   returns `--key=value`
+# @example simplib::hash_to_opts({'key' => ['lo',7,false]})
+#   returns `--key="lo,7,false"`
+# @example simplib::hash_to_opts({'key' => Undef })
+#   returns `--key`
+#
+# @param input Input hash, with Strings as keys and either a String, Array,
+#   Numeric, Boolean, or Undef as a value.
+#
+# @return [String]
+#
+function simplib::hash_to_opts(Hash[String,Variant[Array,String,Numeric,Boolean,Undef]] $input) {
+  $out = $input.map |$key, $val| {
+    case $val {
+      Undef:         { "--${key}"                      }
+      Array:         { "--${key}=\"${val.join(',')}\"" }
+      /[[:blank:]]/: { "--${key}=\"${val}\""           }
+      default:       { "--${key}=${val}"               }
+    }
+  }
+  $out.join(' ')
+}

--- a/spec/functions/hash_to_opts_spec.rb
+++ b/spec/functions/hash_to_opts_spec.rb
@@ -2,31 +2,72 @@ require 'spec_helper'
 
 describe 'simplib::hash_to_opts' do
 
+  tests = [
+    {
+      content: {'iface' => 'eth1'},
+      result: '--iface=eth1'
+    },
+    {
+      content: { 'iface' => 'eth1', 'arg2'  => 'junk value' },
+      result: '--iface=eth1 --arg2="junk value"'
+    },
+    {
+      content: {'key' => 8},
+      result: '--key=8'
+    },
+    {
+      content: {'key' => false},
+      result: '--key=false'
+    },
+    {
+      content: {'key' => ['yes',true,1]},
+      result: '--key=yes,true,1'
+    },
+    {
+      content: {'key' => :undef},
+      result: '--key'
+    },
+    {
+      content: {'key' => nil},
+      result: '--key'
+    },
+  ]
+
+
   it { is_expected.to run.with_params() \
-    .and_raise_error(/expects 1 argument, got none/) }
+    .and_raise_error(/between 1 and 2 arguments, got none/) }
 
-  # basic hash
-  it { is_expected.to run.with_params({'iface' => 'eth1'}).and_return('--iface=eth1') }
+  context 'with default secondary options' do
+    tests.each do |params|
+      it { is_expected.to run.with_params(params[:content]) \
+        .and_return(params[:result]) }
+    end
+  end
 
-  # with value that has a space
-  bigger_hash = {
-    'iface' => 'eth1',
-    'arg2'  => 'junk value'
-  }
-  it { is_expected.to run.with_params(bigger_hash) \
-    .and_return('--iface=eth1 --arg2="junk value"') }
+  context 'with some secondary options set' do
+    tests.each do |params|
+      opts = { 'connector' => ' ' }
+      result = params[:result].gsub(/=/,' ')
 
-  # value that is a number
-  it { is_expected.to run.with_params({'key' => 8}).and_return('--key=8') }
+      it { is_expected.to run.with_params(params[:content],opts) \
+        .and_return(result) }
+    end
+  end
 
-  # value that is a boolean
-  it { is_expected.to run.with_params({'key' => false}).and_return('--key=false') }
+  context 'with all secondary options set' do
+    tests.each do |params|
+      opts = {
+        'connector' => ' ',
+        'prefix'    => '-',
+        'array_delimiter' => ':'
+      }
+      result = params[:result] \
+        .gsub(/=/,' ')
+        .gsub(/--/,'-')
+        .gsub(/,/,':')
 
-  # value that is an array
-  it { is_expected.to run.with_params({'key' => ['yes',true,1]}).and_return('--key="yes,true,1"') }
-
-  # key with no value
-  it { is_expected.to run.with_params({'key' => :undef}).and_return('--key') }
-  it { is_expected.to run.with_params({'key' => nil}).and_return('--key') }
-
+      it { is_expected.to run.with_params(params[:content],opts) \
+        .and_return(result) }
+    end
+  end
 end

--- a/spec/functions/hash_to_opts_spec.rb
+++ b/spec/functions/hash_to_opts_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'simplib::hash_to_opts' do
+
+  it { is_expected.to run.with_params() \
+    .and_raise_error(/expects 1 argument, got none/) }
+
+  # basic hash
+  it { is_expected.to run.with_params({'iface' => 'eth1'}).and_return('--iface=eth1') }
+
+  # with value that has a space
+  bigger_hash = {
+    'iface' => 'eth1',
+    'arg2'  => 'junk value'
+  }
+  it { is_expected.to run.with_params(bigger_hash) \
+    .and_return('--iface=eth1 --arg2="junk value"') }
+
+  # value that is a number
+  it { is_expected.to run.with_params({'key' => 8}).and_return('--key=8') }
+
+  # value that is a boolean
+  it { is_expected.to run.with_params({'key' => false}).and_return('--key=false') }
+
+  # value that is an array
+  it { is_expected.to run.with_params({'key' => ['yes',true,1]}).and_return('--key="yes,true,1"') }
+
+  # key with no value
+  it { is_expected.to run.with_params({'key' => :undef}).and_return('--key') }
+  it { is_expected.to run.with_params({'key' => nil}).and_return('--key') }
+
+end


### PR DESCRIPTION
- Add `simplib::hash_to_opts` which turns a hash into a string with each
  key prefixed with '--' and connected to each value with '='. Useful
  for generating commands

SIMP-4885 #close