### PR TITLE
(SIMP-4936) Add 'simplib::install' defined type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Jun 01 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.0-0
+- Add a 'simplib::install' defined type that allows users to provide a Hash of
+  packages to install along with a Hash of defaults to apply to those packages
+  and override each package configuration if necessary.
+  - This was originally created by Nick Miller <nick.miller@onyxpoint.com>
+
 * Thu May 03 2018 Nick Miller <nick.miller@onyxpoint.com> - 3.10.0-0
 - Add `simplib::hash_to_opts` which turns a hash into a string. Useful for
   generating commands.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,53 @@
+# Manage packages based on Hash input
+#
+# This has been created as a Defined Type so that it can be properly referenced
+# in manifest ordering
+#
+# @param packages
+#   Hash of the packages to install
+#
+#   * If just a key is provided, will apply `package_ensure` to the item
+#   * A value may be provided to the package name key that will be passed along
+#     as the arguments for resource creation.
+#   * A special entry called `defaults` can be provided that will set the
+#     default package options for all packages in the `Hash`
+#
+#   @example Adding a package to be installed
+#     simplib::install({ 'my_package' => undef })
+#
+# @param defaults
+#   A `Hash` of default parameters to apply to all `$packages`
+#
+#   * This will be overridden by any options applied to individual packages
+#
+#   @example Adding some packages with defaults
+#     simplib::install(
+#       # The package list
+#       {
+#         'pkg1' => {
+#           'ensure' => 'installed'
+#         },
+#         'pkg2' => undef
+#       },
+#       # The defaults
+#       {
+#         'ensure'      => 'latest',
+#         'configfiles' => 'replace'
+#       }
+#     )
+#
+define simplib::install (
+  Hash[String[1], Optional[Hash]] $packages,
+  Hash[String[1], String[1]]      $defaults  = { 'ensure' => 'present' }
+){
+  $packages.each |String $package, Optional[Hash] $opts| {
+    if $opts =~ Hash {
+      $_opts = merge($defaults, $opts)
+    }
+    else {
+      $_opts = $defaults
+    }
+
+    ensure_packages($package, $_opts)
+  }
+}

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'simplib::install', :type => :define do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      let(:title) { 'Test' }
+
+      context 'with defaults' do
+        let(:params) {{
+          :packages => {
+            'foo' => :undef
+          }
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('foo').with_ensure('present') }
+      end
+
+      context 'with an empty hash for options' do
+        let(:params) {{
+          :packages => {
+            'foo' => {}
+          }
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('foo').with_ensure('present') }
+      end
+
+      context 'with alternate defaults' do
+        let(:params) {{
+          :packages => {
+            'foo' => :undef
+          },
+          :defaults => {
+            'ensure' => 'latest'
+          }
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('foo').with_ensure('latest') }
+      end
+
+      context 'with package specific overrides' do
+        let(:params) {{
+          :packages => {
+            'foo' => :undef,
+            'bar' => {
+              'ensure' => 'present'
+            }
+          },
+          :defaults => {
+            'ensure' => 'latest'
+          }
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('foo').with_ensure('latest') }
+        it { is_expected.to create_package('bar').with_ensure('present') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This moves and refactors the `gnome::install` defined type into simplib
since it was getting used in multiple modules.

SIMP-4936 #comment extracted 'gnome::install' into 'simplib::install'