### PR TITLE
(SIMP-4956) Fix parsing of multiple values for parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jun 14 2018 dforste <dforste@users.noreply.github.com> - 3.10.0
+- Fixed bug in cmdline face where duplicate parameters would be ignored
+  - Duplicate parameters now turn the value of the parameter into an array
+
 * Fri Jun 01 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.0-0
 - Add a 'simplib::install' defined type that allows users to provide a Hash of
   packages to install along with a Hash of defaults to apply to those packages

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu Jun 14 2018 dforste <dforste@users.noreply.github.com> - 3.10.0
+* Thu Jun 14 2018 dforste <dforste@users.noreply.github.com> - 3.10.0-0
 - Fixed bug in cmdline face where duplicate parameters would be ignored
   - Duplicate parameters now turn the value of the parameter into an array
 

--- a/lib/facter/cmdline.rb
+++ b/lib/facter/cmdline.rb
@@ -6,14 +6,15 @@ Facter.add('cmdline') do
   setcode do
     retval = {}
     begin
-      File.read('/proc/cmdline').chomp.split.each{
-        |x| i,j = x.split('=');
+      File.read('/proc/cmdline').chomp.split.each do |x|
+        i,j = x.split('=')
+
         if retval.has_key?(i)
-          retval[i] = [retval[i] , j].flatten()
+          retval[i] = [retval[i], j].flatten()
         else
           retval[i] = j
         end
-      }
+      end
     rescue => details
       Facter.warn("Could not gather data from /proc/cmdline: #{details.message}")
     end

--- a/lib/facter/cmdline.rb
+++ b/lib/facter/cmdline.rb
@@ -6,7 +6,14 @@ Facter.add('cmdline') do
   setcode do
     retval = {}
     begin
-      File.read('/proc/cmdline').chomp.split.each{|x| i,j = x.split('='); retval[i] = j}
+      File.read('/proc/cmdline').chomp.split.each{
+        |x| i,j = x.split('=');
+        if retval.has_key?(i)
+          retval[i] = [retval[i] , j].flatten()
+        else
+          retval[i] = j
+        end
+      }
     rescue => details
       Facter.warn("Could not gather data from /proc/cmdline: #{details.message}")
     end

--- a/spec/unit/facter/cmdline_spec.rb
+++ b/spec/unit/facter/cmdline_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'cmdline' do
+  before :each do
+    Facter.clear
+  end
+
+  let(:unique_line) {
+    'root=/dev/mapper/VolGroup00-RootVol ro console=ttyS1,57600 rd.lvm.lv=VolGroup00/RootVol rhgb quiet rd.shell=0'
+  }
+  let(:dup_line) {
+    'root=/dev/mapper/VolGroup00-RootVol ro console=ttyS1,57600 rd.lvm.lv=VolGroup00/RootVol rd.lvm.lv=VolGroup00/SwapVol rhgb quiet rd.shell=0'
+  }
+
+  context '/proc/cmdline exists' do
+    it 'and has no duplicate entries' do
+      File.stubs(:read).with('/proc/cmdline').returns(unique_line)
+      expect(Facter.fact(:cmdline).value).to eq({
+        'root'      => '/dev/mapper/VolGroup00-RootVol',
+        'ro'        => nil,
+        'console'   => 'ttyS1,57600',
+        'rd.lvm.lv' => 'VolGroup00/RootVol',
+        'rhgb'      => nil,
+        'quiet'     => nil,
+        'rd.shell'  => '0'
+      })
+    end
+
+    it 'and has duplicate entries' do
+      File.stubs(:read).with('/proc/cmdline').returns(dup_line)
+      expect(Facter.fact(:cmdline).value).to eq({
+        'root'      => '/dev/mapper/VolGroup00-RootVol',
+        'ro'        => nil,
+        'console'   => 'ttyS1,57600',
+        'rd.lvm.lv' => [
+          'VolGroup00/RootVol',
+          'VolGroup00/SwapVol'
+        ],
+        'rhgb'      => nil,
+        'quiet'     => nil,
+        'rd.shell'  => '0'
+      })
+    end
+  end
+
+  context '/proc/cmdline does not exist' do
+    it 'returns nil' do
+      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter.fact(:defaultgateway).value).to eq('unknown')
+    end
+  end
+end


### PR DESCRIPTION
Currently only the last value is captured where the key appears multiple times. This commit fixes this into an array.