### PR TITLE
(SIMP-4447) Add 'assert_optional_dependency' func

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Aug 01 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.11.0-0
+- Added a function `assert_optional_dependency` that allows users to fail if
+  expected functionality is not present in the current environment's module
+  set. This provides the ability for users to support multiple vendor modules
+  without forking.
+
 * Fri Jul 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.1-0
 - Added timeout for changing runlevels based on issues discovered in the field
 - Fixed bugs in the EL6 runlevel persistence where, in some cases, the runlevel

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ itself for more detailed documentation.
 ### Functions
 
 - [simplib::assert\_metadata](#simplibassert_metadata)
+- [simplib::assert\_optional\_dependency](#simplibassert_optional_dependency)
 - [simplib::deprecation](#simplibdeprecation)
 - [simplib::filtered](#simplibfiltered)
 - [simplib::gen\_random\_password](#simplibgen_random_password)
@@ -168,6 +169,52 @@ with the module's `metadata.json`
 
 ```puppet
     simplib::assert_metadata('mymodule')
+```
+
+#### simplib::assert\_optional\_dependency
+
+Fails a puppet catalog compile if the client system is not compatible
+with a set of dependencies as specified in an optional dependency Hash
+
+*Arguments*:
+
+* ``source_module`` The module for which you are checking the dependencies
+* ``target_module`` (Optional) The target dependency to check. If not
+  specified, all modules will be checked
+* ``dependency_tree`` (Optional) A colon (`:`) separated path that specifies
+  the keys for the target dependency Hash
+
+  * Defaults to { 'simp' => 'optional_dependencies' => [{}] }
+
+*Returns*: `nil`
+
+*Example*:
+```json
+    {
+      "name": "my-module",
+      "version": "1.2.3",
+      "simp":
+        "optional_dependencies": [
+          {
+            "name": "simp/foo",
+            "version_requirement": ">= 3.4.5 < 6.7.8"
+          }
+        ]
+     }
+```
+
+```puppet
+    # Check the current module for all specified dependencies
+    simplib::assert_optional_dependency($module_name)
+
+    # Check the current module for the 'foo' dependency
+    simplib::assert_optional_dependency($module_name, 'foo')
+
+    # Check the current module for the 'foo' dependency by a specific author
+    simplib::assert_optional_dependency($module_name, 'simp/foo')
+
+    # Check the { 'my' => 'deps' => [{}] } dependency target in the current module metadata
+    simplib::assert_optional_dependency($module_name, 'simp/foo', 'my:deps')
 ```
 
 #### **simplib::deprecation**

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,6 +47,7 @@
 * [`rand_cron`](#rand_cron): Provides a 'random' value to `cron` based on the passed `Integer` value.  Used to avoid starting a certain `cron` job at the same time on all
 * [`simp_version`](#simp_version): Return the version of SIMP that this server is running
 * [`simplib::assert_metadata`](#simplibassert_metadata): Fails a compile if the client system is not compatible with the module's `metadata.json`
+* [`simplib::assert_optional_dependency`](#simplibassert_optional_dependency): Fails a compile if the system does not contain a correct version of the required module in the current environment.  Provides a message about
 * [`simplib::deprecation`](#simplibdeprecation): Function to print deprecation warnings, logging a warning once for a given key.  Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS envi
 * [`simplib::filtered`](#simplibfiltered): Hiera v5 backend that takes a list of allowed hiera key names, and only returns results from the underlying backend function that match those
 * [`simplib::gen_random_password`](#simplibgen_random_password): Generates a random password string.  Terminates catalog compilation if the password cannot be created in the allotted time.
@@ -1261,6 +1262,51 @@ Behavior modifiers for the function
           * none  -> No match on minor release (default)
           * full  -> Full release must match
           * major -> Only the major release must match
+
+### simplib::assert_optional_dependency
+
+Type: Ruby 4.x API
+
+Fails a compile if the system does not contain a correct version of the
+required module in the current environment.
+
+Provides a message about exactly which version of the module is required.
+
+#### `simplib::assert_optional_dependency(String[1] $source_module, Optional[String[1]] $target_module, Optional[String[1]] $dependency_tree)`
+
+Fails a compile if the system does not contain a correct version of the
+required module in the current environment.
+
+Provides a message about exactly which version of the module is required.
+
+Returns: `None`
+
+##### `source_module`
+
+Data type: `String[1]`
+
+The name of the module containing the dependency information (usually the
+module that this function is being called from)
+
+##### `target_module`
+
+Data type: `Optional[String[1]]`
+
+The target module to check. If not specified, all optional dependencies
+in the tree will be checked.
+
+* This may optionally be the full module name with the author in
+  `author/module` form which allows for different logic paths that can use
+  multiple vendor modules
+
+##### `dependency_tree`
+
+Data type: `Optional[String[1]]`
+
+The root of the dependency tree in the module's `metadata.json` that
+contains the optional dependencies.
+
+* Nested levels should be separated by colons (`:`)
 
 ### simplib::deprecation
 

--- a/lib/puppet/functions/simplib/assert_optional_dependency.rb
+++ b/lib/puppet/functions/simplib/assert_optional_dependency.rb
@@ -1,0 +1,170 @@
+# Fails a compile if the system does not contain a correct version of the
+# required module in the current environment.
+#
+# Provides a message about exactly which version of the module is required.
+#
+Puppet::Functions.create_function(:'simplib::assert_optional_dependency') do
+  # @param source_module
+  #   The name of the module containing the dependency information (usually the
+  #   module that this function is being called from)
+  #
+  # @param target_module
+  #   The target module to check. If not specified, all optional dependencies
+  #   in the tree will be checked.
+  #
+  #   * This may optionally be the full module name with the author in
+  #     `author/module` form which allows for different logic paths that can use
+  #     multiple vendor modules
+  #
+  # @param dependency_tree
+  #   The root of the dependency tree in the module's `metadata.json` that
+  #   contains the optional dependencies.
+  #
+  #   * Nested levels should be separated by colons (`:`)
+  #
+  # @example Check for the 'puppet/foo' optional dependency
+  #
+  #   ### metadata.json ###
+  #   "simp": {
+  #     "optional_dependencies" [
+  #       {
+  #         "name": "puppet/foo",
+  #         "version_requirement": ">= 1.2.3 < 4.5.6"
+  #       }
+  #     ]
+  #   }
+  #
+  #   ### myclass.pp ###
+  #   # Check all dependencies
+  #   simplib::assert_optional_dependency($module_name)
+  #
+  #   # Check the module 'foo'
+  #   simplib::assert_optional_dependency($module_name, 'foo')
+  #
+  #   # Check the module 'foo' by author 'puppet'
+  #   simplib::assert_optional_dependency($module_name, 'puppet/foo')
+  #
+  #   # Check an alternate dependency target
+  #   simplib::assert_optional_dependency($module_name, 'puppet/foo', 'my:deps')
+  #
+  # @return [None]
+  #
+  dispatch :assert_optional_dependency do
+    required_param 'String[1]', :source_module
+    optional_param 'String[1]', :target_module
+    optional_param 'String[1]', :dependency_tree
+  end
+
+  def get_module_dependencies(dependency_tree_levels, module_metadata)
+    _levels = Array(dependency_tree_levels.dup)
+    current_level = _levels.shift
+    metadata_level = module_metadata
+
+    while !_levels.empty?
+      if metadata_level[current_level]
+        metadata_level = metadata_level[current_level]
+        current_level = _levels.shift
+      else
+        return nil
+      end
+    end
+
+    return metadata_level[current_level]
+  end
+
+  def check_dependency(module_name, module_dependency)
+    require 'semantic_puppet'
+
+    _module_author, _module_name = module_name.split('/')
+
+    unless _module_name
+      _module_name = _module_author.dup
+      _module_author = nil
+    end
+
+    unless call_function('module_exist', _module_name)
+      return "no module '#{_module_name}' found"
+    end
+
+    if module_dependency
+      module_metadata = call_function('load_module_metadata', _module_name)
+
+      if _module_author
+        cmp_author = module_metadata['name'].strip.gsub('-','/').split('/').first
+        unless _module_author.strip == cmp_author
+          return %('#{module_name}' does not match '#{module_metadata['name']}')
+        end
+      end
+
+      if module_dependency['version_requirement']
+        begin
+          version_requirement = SemanticPuppet::VersionRange.parse(module_dependency['version_requirement'])
+        rescue ArgumentError
+          return %(invalid version range '#{module_dependency['version_requirement']}' for '#{_module_name}')
+        end
+
+        module_version = module_metadata['version']
+
+        begin
+          module_version = SemanticPuppet::Version.parse(module_version)
+        rescue ArgumentError
+          return %(invalid version '#{module_version}' found for '#{_module_name}')
+        end
+
+        unless version_requirement.include?(module_version)
+          return %('#{_module_name}-#{module_version}' does not satisfy '#{version_requirement}')
+        end
+      end
+    end
+  end
+
+  def raise_error(msg, env)
+    raise(Puppet::ParseError, %(assert_optional_dependency(): #{msg} in environment '#{env}'))
+  end
+
+  def assert_optional_dependency(
+    source_module,
+    target_module = nil,
+    dependency_tree = 'simp:optional_dependencies'
+  )
+
+    current_environment = closure_scope.compiler.environment.to_s
+
+    module_dependencies = get_module_dependencies(
+      dependency_tree.split(':'),
+      call_function(
+        'load_module_metadata',
+        source_module
+      )
+    )
+
+    if module_dependencies
+      if target_module
+        tgt = target_module.gsub('-','/')
+
+        if tgt.include?('/')
+          target_dependency = module_dependencies.find {|d| d['name'].gsub('-','/') == tgt}
+        else
+          target_dependency = module_dependencies.find {|d| d['name'] =~ %r((/|-)#{tgt}$)}
+        end
+
+        if target_dependency
+          result = check_dependency(tgt, target_dependency)
+
+          raise_error(result, current_environment) if result
+        end
+      else
+        results = []
+
+        module_dependencies.each do |dependency|
+          result = check_dependency(dependency['name'].gsub('-','/'), dependency)
+          results << result if result
+        end
+
+        unless results.empty?
+          raise_error(%(\n* #{results.join("\n* ")}\n), current_environment)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/functions/simplib/assert_optional_dependency.rb
+++ b/lib/puppet/functions/simplib/assert_optional_dependency.rb
@@ -82,8 +82,8 @@ Puppet::Functions.create_function(:'simplib::assert_optional_dependency') do
       _module_author = nil
     end
 
-    unless call_function('module_exist', _module_name)
-      return "no module '#{_module_name}' found"
+    unless call_function('simplib::module_exist', _module_name)
+      return "optional dependency '#{_module_name}' not found"
     end
 
     if module_dependency
@@ -152,6 +152,8 @@ Puppet::Functions.create_function(:'simplib::assert_optional_dependency') do
           result = check_dependency(tgt, target_dependency)
 
           raise_error(result, current_environment) if result
+        else
+          raise_error(%(module '#{target_module}' not found in metadata.json for '#{source_module}'), current_environment)
         end
       else
         results = []

--- a/lib/puppet/functions/simplib/module_exist.rb
+++ b/lib/puppet/functions/simplib/module_exist.rb
@@ -1,5 +1,7 @@
 # Determines if a module exists in the current environment
 #
+# If passed with an author, such as `simp/simplib` or `simp-simplib`, will
+# return whether or not that *specific* module exists.
 Puppet::Functions.create_function(:'simplib::module_exist') do
 
   # @param module_name The module name to check
@@ -9,8 +11,23 @@ Puppet::Functions.create_function(:'simplib::module_exist') do
   end
 
   def module_exist(module_name)
-    if Puppet::Module.find(module_name, closure_scope.compiler.environment.to_s)
-      return true
+    _module_author, _module_name = module_name.split(%r(/|-))
+
+    unless _module_name
+      _module_name = _module_author.dup
+      _module_author = nil
+    end
+
+    if Puppet::Module.find(_module_name, closure_scope.compiler.environment.to_s)
+      if _module_author
+        if _module_author.strip == call_function('load_module_metadata', _module_name)['name'].strip.split(%r(/|-)).first
+          return true
+        else
+          return false
+        end
+      else
+        return true
+      end
     else
       return false
     end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/assert_optional_dependency_spec.rb
+++ b/spec/functions/simplib/assert_optional_dependency_spec.rb
@@ -50,9 +50,9 @@ describe 'simplib::assert_optional_dependency' do
   context 'with a source module' do
     it 'should run with no errors' do
       subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'one').returns(true).once
       subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'two').returns(true).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'two').returns(true).once
       subject.func.expects(:call_function).with('load_module_metadata', 'two').returns(dep_two_metadata).once
 
       is_expected.to run.with_params('my/module')
@@ -60,56 +60,74 @@ describe 'simplib::assert_optional_dependency' do
 
     it 'should fail on one missing module' do
       subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'one').returns(true).once
       subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'two').returns(false).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'two').returns(false).once
       subject.func.expects(:call_function).with('load_module_metadata', 'two').never
 
-      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(no module 'two' found)m)
+      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(optional dependency 'two' not found)m)
     end
 
     it 'should fail on all missing modules' do
       subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'one').returns(false).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'one').returns(false).once
       subject.func.expects(:call_function).with('load_module_metadata', 'one').never
-      subject.func.expects(:call_function).with('module_exist', 'two').returns(false).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'two').returns(false).once
       subject.func.expects(:call_function).with('load_module_metadata', 'two').never
 
-      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(no module 'one' found.+no module 'two' found)m)
+      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(optional dependency 'one' not found.+optional dependency 'two' not found)m)
     end
   end
 
   context 'with a target module' do
     before(:each) do
       subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
-      subject.func.expects(:call_function).with('module_exist', 'two').never
+      subject.func.expects(:call_function).with('simplib::module_exist', 'two').never
       subject.func.expects(:call_function).with('load_module_metadata', 'two').never
     end
 
-    context 'valid' do
+    context 'that exists' do
       before(:each) do
-        subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
+        subject.func.expects(:call_function).with('simplib::module_exist', 'one').returns(true).once
       end
 
-      it 'long name' do
-        is_expected.to run.with_params('my/module', 'dep/one')
+      context 'valid' do
+        before(:each) do
+          subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
+        end
+
+        it 'long name' do
+          is_expected.to run.with_params('my/module', 'dep/one')
+        end
+
+        it 'hyphen name' do
+          is_expected.to run.with_params('my/module', 'dep/one')
+        end
+
+        it 'short name' do
+          is_expected.to run.with_params('my/module', 'one')
+        end
       end
 
-      it 'hyphen name' do
-        is_expected.to run.with_params('my/module', 'dep/one')
-      end
+      context 'invalid' do
+        it 'author' do
+          subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_bad_author).once
 
-      it 'short name' do
-        is_expected.to run.with_params('my/module', 'one')
+          expect{is_expected.to run.with_params('my/module', 'dep/one')}.to raise_error(%r('dep/one' does not match 'narp/one'))
+        end
+
       end
     end
 
-    context 'invalid' do
-      it 'author' do
-        subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_bad_author).once
+    context 'that is not in the metadata' do
+      before(:each) do
+        subject.func.expects(:call_function).with('simplib::module_exist', 'one').never
+      end
 
-        expect{is_expected.to run.with_params('my/module', 'dep/one')}.to raise_error(%r('dep/one' does not match 'narp/one'))
+      it 'should fail' do
+        subject.func.expects(:call_function).with('simplib::module_exist', 'one').never
+
+        expect{is_expected.to run.with_params('my/module', 'three')}.to raise_error(%r('three' not found in metadata.json))
       end
     end
   end
@@ -117,9 +135,9 @@ describe 'simplib::assert_optional_dependency' do
   context 'with an out of range module' do
     it 'should fail on the invalid module' do
       subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
-      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'one').returns(true).once
       subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_bad_version).once
-      subject.func.expects(:call_function).with('module_exist', 'two').returns(true).once
+      subject.func.expects(:call_function).with('simplib::module_exist', 'two').returns(true).once
       subject.func.expects(:call_function).with('load_module_metadata', 'two').returns(dep_two_metadata).once
 
       expect{is_expected.to run.with_params('my/module')}.to raise_error(%r('one-.+' does not satisfy)m)

--- a/spec/functions/simplib/assert_optional_dependency_spec.rb
+++ b/spec/functions/simplib/assert_optional_dependency_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe 'simplib::assert_optional_dependency' do
+  let(:source_metadata) {
+    {
+      'name'    => 'my/module',
+      'version' => '1.2.3',
+      'simp'    => {
+        'optional_dependencies' => [
+          {
+            'name'                => 'dep-one',
+            'version_requirement' => '>= 0.0.1 < 2.0.0'
+          },
+          {
+            'name'                => 'dep/two'
+          }
+        ]
+      }
+    }
+  }
+
+  let(:dep_one_metadata) {
+    {
+      'name'    => 'dep/one',
+      'version' => '1.0.0'
+    }
+  }
+
+  let(:dep_two_metadata) {
+    {
+      'name'    => 'dep-two',
+      'version' => '3.4.5'
+    }
+  }
+
+  let(:dep_one_bad_author) {
+    {
+      'name'    => 'narp/one',
+      'version' => '1.0.0'
+    }
+  }
+
+  let(:dep_one_bad_version) {
+    {
+      'name'    => 'dep/one',
+      'version' => '5.5.5'
+    }
+  }
+
+  context 'with a source module' do
+    it 'should run with no errors' do
+      subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'two').returns(true).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'two').returns(dep_two_metadata).once
+
+      is_expected.to run.with_params('my/module')
+    end
+
+    it 'should fail on one missing module' do
+      subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'two').returns(false).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'two').never
+
+      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(no module 'two' found)m)
+    end
+
+    it 'should fail on all missing modules' do
+      subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'one').returns(false).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'one').never
+      subject.func.expects(:call_function).with('module_exist', 'two').returns(false).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'two').never
+
+      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r(no module 'one' found.+no module 'two' found)m)
+    end
+  end
+
+  context 'with a target module' do
+    before(:each) do
+      subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('module_exist', 'two').never
+      subject.func.expects(:call_function).with('load_module_metadata', 'two').never
+    end
+
+    context 'valid' do
+      before(:each) do
+        subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_metadata).once
+      end
+
+      it 'long name' do
+        is_expected.to run.with_params('my/module', 'dep/one')
+      end
+
+      it 'hyphen name' do
+        is_expected.to run.with_params('my/module', 'dep/one')
+      end
+
+      it 'short name' do
+        is_expected.to run.with_params('my/module', 'one')
+      end
+    end
+
+    context 'invalid' do
+      it 'author' do
+        subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_bad_author).once
+
+        expect{is_expected.to run.with_params('my/module', 'dep/one')}.to raise_error(%r('dep/one' does not match 'narp/one'))
+      end
+    end
+  end
+
+  context 'with an out of range module' do
+    it 'should fail on the invalid module' do
+      subject.func.expects(:call_function).with('load_module_metadata', 'my/module').returns(source_metadata).once
+      subject.func.expects(:call_function).with('module_exist', 'one').returns(true).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'one').returns(dep_one_bad_version).once
+      subject.func.expects(:call_function).with('module_exist', 'two').returns(true).once
+      subject.func.expects(:call_function).with('load_module_metadata', 'two').returns(dep_two_metadata).once
+
+      expect{is_expected.to run.with_params('my/module')}.to raise_error(%r('one-.+' does not satisfy)m)
+    end
+  end
+end

--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -4,12 +4,14 @@ describe 'simplib::deprecation' do
   context 'with SIMPLIB_LOG_DEPRECATIONS environment variable = "true" ' do
     it 'should display a single warning' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
+      Puppet.expects(:warning).at_least_once
       Puppet.expects(:warning).with(includes('test_func is deprecated'))
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
 
     it 'should display a single warning, despite multiple calls' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
+      Puppet.expects(:warning).at_least_once
       Puppet.expects(:warning).with(includes('test_func is deprecated')).once
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
@@ -19,6 +21,8 @@ describe 'simplib::deprecation' do
   context 'with no SIMPLIB_LOG_DEPRECATIONS environment variable set' do
     it 'should not display a warning' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = nil
+      # This is working around deprecation warnings that get added by Puppet core
+      Puppet.expects(:warning).at_most(99)
       Puppet.expects(:warning).with(includes('test_func is deprecated')).never
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end

--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -4,15 +4,17 @@ describe 'simplib::deprecation' do
   context 'with SIMPLIB_LOG_DEPRECATIONS environment variable = "true" ' do
     it 'should display a single warning' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
-      Puppet.expects(:warning).at_least_once
       Puppet.expects(:warning).with(includes('test_func is deprecated'))
+      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
 
     it 'should display a single warning, despite multiple calls' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
-      Puppet.expects(:warning).at_least_once
       Puppet.expects(:warning).with(includes('test_func is deprecated')).once
+      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
@@ -22,8 +24,9 @@ describe 'simplib::deprecation' do
     it 'should not display a warning' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = nil
       # This is working around deprecation warnings that get added by Puppet core
-      Puppet.expects(:warning).at_most(99)
       Puppet.expects(:warning).with(includes('test_func is deprecated')).never
+      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
   end

--- a/spec/functions/simplib/module_exist_spec.rb
+++ b/spec/functions/simplib/module_exist_spec.rb
@@ -5,6 +5,16 @@ describe 'simplib::module_exist' do
     it { is_expected.to run.with_params('simplib').and_return(true) }
   end
 
+  context 'with an author' do
+    it 'should be valid with simp/simplib' do
+      is_expected.to run.with_params('simp/simplib').and_return(true)
+    end
+
+    it 'should be invalid with foo/simplib' do
+      is_expected.to run.with_params('foo/simplib').and_return(false)
+    end
+  end
+
   context 'with an invalid module' do
     it { is_expected.to run.with_params('superbad').and_return(false) }
   end


### PR DESCRIPTION
Added a function `assert_optional_dependency` that allows users to fail
if expected functionality is not present in the current environment's
module set. This provides the ability for users to support multiple
vendor modules without forking.

SIMP-4447 #close