### PR TITLE
(SIMP-5096) Fixes to the runlevel type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Jul 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.10.2-0
+- Added timeout for changing runlevels based on issues discovered in the field
+- Fixed bugs in the EL6 runlevel persistence where, in some cases, the runlevel
+  line might not get written to /etc/inittab
+
 * Wed Jul 18 2018 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 3.10.1-0
 - Add support for Puppet 5
 - Add support for Oracle Linux

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -486,6 +486,14 @@ namevar
 
 The target runlevel of the system
 
+##### `transition_timeout`
+
+Valid values: /^\d+$/
+
+How many seconds to wait for a runlevel switch before failing
+
+Default value: 60
+
 ### script_umask
 
 Alters the umask settings in the passed file.

--- a/lib/puppet/provider/runlevel/systemd.rb
+++ b/lib/puppet/provider/runlevel/systemd.rb
@@ -13,7 +13,10 @@ Puppet::Type.type(:runlevel).provide(:systemd) do
   end
 
   def level=(should)
-    if execute([command(:pgrep),'-f',%('#{File.basename(command(:systemctl))} isolate')]).strip.empty?
+    systemctl_path = File.dirname(command(:systemctl))
+    systemctl_cmd = File.basename(command(:systemctl))
+
+    if execute([command(:pgrep),'-f',%('^(#{systemctl_path}/)?#{systemctl_cmd}[[:space:]]+isolate')]).strip.empty?
       require 'timeout'
 
       begin

--- a/lib/puppet/provider/runlevel/systemd.rb
+++ b/lib/puppet/provider/runlevel/systemd.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:runlevel).provide(:systemd) do
 
     # The `execute` method calls `Kernel.exec()` and that cannot accept quotes
     # around strings in arguments for some reason.
-    if execute([command(:pgrep),'-f', %(^(#{systemctl_path}/)?#{systemctl_cmd}[[:space:]]+isolate)]).strip.empty?
+    if execute([command(:pgrep),'-f', %(^(#{systemctl_path}/)?#{systemctl_cmd}[[:space:]]+isolate)], :failonfail => false).strip.empty?
       return should == is
     else
       Puppet.warning('System currently attempting to transition runlevels, will not respawn')

--- a/lib/puppet/provider/runlevel/systemd.rb
+++ b/lib/puppet/provider/runlevel/systemd.rb
@@ -4,6 +4,8 @@ Puppet::Type.type(:runlevel).provide(:systemd) do
   EOM
 
   commands :systemctl => '/usr/bin/systemctl'
+  commands :pgrep     => 'pgrep'
+
   defaultfor :kernel => 'Linux'
 
   def level
@@ -11,14 +13,18 @@ Puppet::Type.type(:runlevel).provide(:systemd) do
   end
 
   def level=(should)
-    require 'timeout'
+    if execute([command(:pgrep),'-f',%('#{File.basename(command(:systemctl))} isolate')]).strip.empty?
+      require 'timeout'
 
-    begin
-      Timeout::timeout(@resource[:transition_timeout]) do
-        execute([command(:systemctl),'isolate',init2systemd(@resource[:name])])
+      begin
+        Timeout::timeout(@resource[:transition_timeout]) do
+          execute([command(:systemctl),'isolate',init2systemd(@resource[:name])])
+        end
+      rescue Timeout::Error
+        raise(Puppet::Error, "Could not transition to runlevel #{@resource[:name]} within #{@resource[:transition_timeout]} seconds")
       end
-    rescue Timeout::Error
-      raise(Puppet::Error, "Could not transition to runlevel #{@resource[:name]} within #{@resource[:transition_timeout]} seconds")
+    else
+      Puppet.warning('System currently attempting to transition runlevels, will not respawn')
     end
   end
 

--- a/lib/puppet/provider/runlevel/systemd.rb
+++ b/lib/puppet/provider/runlevel/systemd.rb
@@ -12,22 +12,33 @@ Puppet::Type.type(:runlevel).provide(:systemd) do
     Facter.value(:runlevel)
   end
 
-  def level=(should)
+  def level_insync?(should, is)
     systemctl_path = File.dirname(command(:systemctl))
     systemctl_cmd = File.basename(command(:systemctl))
 
-    if execute([command(:pgrep),'-f',%('^(#{systemctl_path}/)?#{systemctl_cmd}[[:space:]]+isolate')]).strip.empty?
-      require 'timeout'
-
-      begin
-        Timeout::timeout(@resource[:transition_timeout]) do
-          execute([command(:systemctl),'isolate',init2systemd(@resource[:name])])
-        end
-      rescue Timeout::Error
-        raise(Puppet::Error, "Could not transition to runlevel #{@resource[:name]} within #{@resource[:transition_timeout]} seconds")
-      end
+    # The `execute` method calls `Kernel.exec()` and that cannot accept quotes
+    # around strings in arguments for some reason.
+    if execute([command(:pgrep),'-f', %(^(#{systemctl_path}/)?#{systemctl_cmd}[[:space:]]+isolate)]).strip.empty?
+      return should == is
     else
       Puppet.warning('System currently attempting to transition runlevels, will not respawn')
+
+      # Returning that the level is in sync here so that the system does not
+      # attempt to respawn a new systemctl instance while one is already
+      # running.
+      return true
+    end
+  end
+
+  def level=(should)
+    require 'timeout'
+
+    begin
+      Timeout::timeout(@resource[:transition_timeout]) do
+        execute([command(:systemctl),'isolate',init2systemd(@resource[:name])])
+      end
+    rescue Timeout::Error
+      raise(Puppet::Error, "Could not transition to runlevel #{@resource[:name]} within #{@resource[:transition_timeout]} seconds")
     end
   end
 

--- a/lib/puppet/provider/runlevel/telinit.rb
+++ b/lib/puppet/provider/runlevel/telinit.rb
@@ -65,9 +65,6 @@ Puppet::Type.type(:runlevel).provide(:telinit) do
 
     inittab.close
 
-    fh = IO.open(IO.sysopen('/tmp/foo','w'))
-    fh.puts(newfile)
-
     inittab = File.open('/etc/inittab', 'w')
     inittab.write(newfile)
     inittab.close

--- a/lib/puppet/provider/runlevel/telinit.rb
+++ b/lib/puppet/provider/runlevel/telinit.rb
@@ -9,6 +9,10 @@ Puppet::Type.type(:runlevel).provide(:telinit) do
     Facter.value(:runlevel)
   end
 
+  def level_insync?(should, is)
+    return should == is
+  end
+
   def level=(should)
     require 'timeout'
 

--- a/lib/puppet/provider/runlevel/telinit.rb
+++ b/lib/puppet/provider/runlevel/telinit.rb
@@ -10,19 +10,27 @@ Puppet::Type.type(:runlevel).provide(:telinit) do
   end
 
   def level=(should)
-    execute([command(:telinit),@resource[:name]])
+    require 'timeout'
+
+    begin
+      Timeout::timeout(@resource[:transition_timeout]) do
+        execute([command(:telinit), @resource[:name]])
+      end
+    rescue Timeout::Error
+      raise(Puppet::Error, "Could not transition to runlevel #{@resource[:name]} within #{@resource[:transition_timeout]} seconds")
+    end
   end
 
   def persist
     retval = :false
 
-    if @resource[:persist] == :true then
+    if @resource[:persist] == :true
       inittab = File.open('/etc/inittab', 'r')
       inittab.each_line do |line|
-        if line =~ /^\s*id/ then
+        if line =~ /^\s*id/
           # We have the initdefault line
           current_value = line.split(':').at(1)
-          if current_value.eql?(@resource[:name]) then
+          if current_value.eql?(@resource[:name])
             retval = :true
           end
         end
@@ -37,16 +45,28 @@ Puppet::Type.type(:runlevel).provide(:telinit) do
     # Essentially do the same as the read, but save contents to new file
     newfile = String.new
     inittab = File.open('/etc/inittab', 'r')
+
+    found_line = false
+
     inittab.each_line do |line|
-      if line =~ /^\s*id/ then
+      if line =~ /^\s*id/
         # We've found the default line, so rewrite
+        found_line = true
         newfile << "id:#{@resource[:name]}:initdefault:nil\n"
       else
         # Just add this line as is
         newfile << line
       end
     end
+
+    unless found_line
+      newfile << "id:#{@resource[:name]}:initdefault:nil\n"
+    end
+
     inittab.close
+
+    fh = IO.open(IO.sysopen('/tmp/foo','w'))
+    fh.puts(newfile)
 
     inittab = File.open('/etc/inittab', 'w')
     inittab.write(newfile)

--- a/lib/puppet/type/runlevel.rb
+++ b/lib/puppet/type/runlevel.rb
@@ -71,6 +71,10 @@ Puppet::Type.newtype(:runlevel) do
         @resource.runlevel_xlat(value)
       end
     end
+
+    def insync?(is)
+      provider.level_insync?(should, is)
+    end
   end
 
   newproperty(:persist) do

--- a/lib/puppet/type/runlevel.rb
+++ b/lib/puppet/type/runlevel.rb
@@ -47,6 +47,17 @@ Puppet::Type.newtype(:runlevel) do
     end
   end
 
+  newparam(:transition_timeout) do
+    desc 'How many seconds to wait for a runlevel switch before failing'
+    newvalues(/^\d+$/)
+
+    defaultto 60
+
+    munge do |value|
+      "#{value}".to_i
+    end
+  end
+
   newproperty(:level) do
     desc 'The target runlevel of the system. Defaults to what is specified in :name'
     newvalues(/^[1-5]$/, 'rescue', 'multi-user', 'graphical', 'default')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/puppet/provider/runlevel/systemd_spec.rb
+++ b/spec/unit/puppet/provider/runlevel/systemd_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
     context 'with a normal transition' do
       context 'when in sync' do
         it 'should run without a warning' do
-          provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}]).returns("\n")
+          provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}], :failonfail => false).returns("\n")
           Puppet.expects(:warning).never
 
           expect(provider.level_insync?('5','5')).to be true
@@ -38,7 +38,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
 
       context 'when out of sync' do
         it 'should run without a warning' do
-          provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}]).returns("\n")
+          provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}], :failonfail => false).returns("\n")
           Puppet.expects(:warning).never
 
           expect(provider.level_insync?('3','5')).to be false
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
 
     context 'with a systemctl isolation already running' do
       it 'should emit a warning' do
-        provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}]).returns("1234 systemctl isolate multi-user.target\n")
+        provider.expects(:execute).with(['/bin/pgrep', '-f', %{^(/usr/bin/)?systemctl[[:space:]]+isolate}], :failonfail => false).returns("1234 systemctl isolate multi-user.target\n")
         Puppet.expects(:warning)
 
         expect(provider.level_insync?('5','3')).to be true

--- a/spec/unit/puppet/provider/runlevel/systemd_spec.rb
+++ b/spec/unit/puppet/provider/runlevel/systemd_spec.rb
@@ -28,7 +28,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
   context '#level=' do
     context 'with a normal transition' do
       it 'should succeed' do
-        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'systemctl isolate'}]).returns("\n")
+        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'^(/usr/bin/)?systemctl[[:space:]]+isolate'}]).returns("\n")
         provider.expects(:execute).with(['/usr/bin/systemctl', 'isolate', 'graphical.target'])
 
         provider.level=(resource[:level])
@@ -37,8 +37,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
 
     context 'with a systemctl isolation already running' do
       it 'should emit a warning' do
-        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'systemctl isolate'}]).returns("1234\n")
-        #provider.expects(Puppet).to receive(:warning).with('System currently attempting to transition runlevels, will not respawn')
+        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'^(/usr/bin/)?systemctl[[:space:]]+isolate'}]).returns("1234 systemctl isolate multi-user.target\n")
         Puppet.expects(:warning)
 
         provider.level=(resource[:level])
@@ -47,7 +46,7 @@ describe Puppet::Type.type(:runlevel).provider(:systemd) do
 
     context 'with a timeout' do
       it 'should raise an exception' do
-        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'systemctl isolate'}]).returns("\n")
+        provider.expects(:execute).with(['/bin/pgrep', '-f', %{'^(/usr/bin/)?systemctl[[:space:]]+isolate'}]).returns("\n")
         provider.expects(:execute).with(['/usr/bin/systemctl', 'isolate', 'graphical.target']).raises(Timeout::Error)
 
         expect { provider.level=(resource[:level]) }.to raise_error(/Could not transition to runlevel/)

--- a/spec/unit/puppet/provider/runlevel/systemd_spec.rb
+++ b/spec/unit/puppet/provider/runlevel/systemd_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:runlevel).provider(:systemd) do
+  let(:resource) {
+    Puppet::Type.type(:runlevel).new( name: '5')
+  }
+  let(:provider) {
+    Puppet::Type.type(:runlevel).provider(:systemd).new(resource)
+  }
+
+  before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Runlevel.any_instance.stubs(:catalog).returns(@catalog)
+
+    described_class.stubs(:command).with(:systemctl).returns('/usr/bin/systemctl')
+    Facter.stubs(:value).with(:kernel).returns('Linux')
+  end
+
+  context '#level' do
+    it 'should return the runlevel' do
+      Facter.stubs(:value).with(:runlevel).returns('5')
+
+      expect(provider.level).to eq('5')
+    end
+  end
+
+  context '#level=' do
+    context 'with a normal transition' do
+      it 'should succeed' do
+        provider.expects(:execute).with(['/usr/bin/systemctl', 'isolate', 'graphical.target'])
+
+        provider.level=(resource[:level])
+      end
+    end
+
+    context 'with a timeout' do
+      it 'should raise an exception' do
+        provider.expects(:execute).with(['/usr/bin/systemctl', 'isolate', 'graphical.target']).raises(Timeout::Error)
+
+        expect { provider.level=(resource[:level]) }.to raise_error(/Could not transition to runlevel/)
+      end
+    end
+
+    context '#persist' do
+      it 'returns :true if in sync' do
+        provider.expects(:execute).with(['/usr/bin/systemctl', 'get-default']).returns('graphical.target')
+
+        expect(provider.persist).to eq(:true)
+      end
+
+      it 'returns :false if not in sync' do
+        provider.expects(:execute).with(['/usr/bin/systemctl', 'get-default']).returns('3')
+
+        expect(provider.persist).to eq(:false)
+      end
+    end
+
+    context '#persist=' do
+      it 'sets the system default runlevel' do
+        provider.expects(:execute).with(['/usr/bin/systemctl', 'set-default', 'graphical.target'])
+
+        provider.persist=(resource[:level])
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/runlevel/telinit_spec.rb
+++ b/spec/unit/puppet/provider/runlevel/telinit_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:runlevel).provider(:telinit) do
+  let(:resource) {
+    Puppet::Type.type(:runlevel).new( name: '5')
+  }
+  let(:provider) {
+    Puppet::Type.type(:runlevel).provider(:telinit).new(resource)
+  }
+
+  before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Runlevel.any_instance.stubs(:catalog).returns(@catalog)
+
+    described_class.stubs(:command).with(:telinit).returns('/sbin/telinit')
+  end
+
+  context '#level' do
+    it 'should return the runlevel' do
+      Facter.stubs(:value).with(:runlevel).returns('5')
+
+      expect(provider.level).to eq('5')
+    end
+  end
+
+  context '#level=' do
+    context 'with a normal transition' do
+      it 'should succeed' do
+        provider.expects(:execute).with(['/sbin/telinit', resource[:level]])
+
+        provider.level=(resource[:level])
+      end
+    end
+
+    context 'with a timeout' do
+      it 'should raise an exception' do
+        provider.expects(:execute).with(['/sbin/telinit', resource[:level]]).raises(Timeout::Error)
+
+        expect { provider.level=(resource[:level]) }.to raise_error(/Could not transition to runlevel/)
+      end
+    end
+
+    context 'persisting state' do
+      before(:each) do
+        require 'tempfile'
+
+        @tempfile = Tempfile.new("#{described_class}")
+      end
+
+      after(:each) do
+        FileUtils.rm(@tempfile)
+      end
+
+      context '#persist' do
+        it 'returns :true if in sync' do
+          @tempfile.write("id:#{resource[:level]}:initdefault:nil\n")
+          @tempfile.rewind
+
+          File.expects(:open).with('/etc/inittab', 'r').returns(@tempfile)
+
+          expect(provider.persist).to eq(:true)
+        end
+
+        it 'returns :false if not in sync' do
+          @tempfile.write('')
+          @tempfile.rewind
+
+          File.expects(:open).with('/etc/inittab', 'r').returns(@tempfile)
+
+          expect(provider.persist).to eq(:false)
+        end
+      end
+
+      context '#persist=' do
+        it 'sets the system default runlevel' do
+          @tempfile.write("id:#{resource[:level]}:initdefault:nil\n")
+          @tempfile.rewind
+
+          File.expects(:open).with('/etc/inittab', 'r').returns(@tempfile)
+
+          fh = IO.open(IO.sysopen(@tempfile, 'w'), 'w')
+
+          File.expects(:open).with('/etc/inittab', 'w').returns(fh)
+
+          provider.persist=(resource[:level])
+
+          expect(File.read(@tempfile)).to eq("id:#{resource[:level]}:initdefault:nil\n")
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/runlevel_spec.rb
+++ b/spec/unit/puppet/type/runlevel_spec.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+runlevel_type = Puppet::Type.type(:runlevel)
+
+describe runlevel_type do
+  before(:each) do
+    @catalog = Puppet::Resource::Catalog.new
+    Puppet::Type::Runlevel.any_instance.stubs(:catalog).returns(@catalog)
+  end
+
+  context 'when setting parameters' do
+    let(:valid_names){{
+      '1'          => '1',
+      '2'          => '2',
+      '3'          => '3',
+      '4'          => '4',
+      '5'          => '5',
+      'rescue'     => '1',
+      'multi-user' => '3',
+      'graphical'  => '5'
+    }}
+
+    let(:invalid_names){[
+      'foo', '0', 'graphical.target'
+    ]}
+
+    context ':name' do
+      it 'should accept valid values' do
+        valid_names.each_pair do |key, value|
+          resource = runlevel_type.new(:name => key)
+          expect(resource[:name]).to eq(value)
+        end
+      end
+
+      it 'should reject invalid values' do
+        invalid_names.each do |value|
+          expect { runlevel_type.new(:name => value) }.to raise_error(/Invalid value/)
+        end
+      end
+    end
+
+    context ':level' do
+      it 'should accept valid values' do
+        valid_names.each_pair do |key, value|
+          resource = runlevel_type.new(
+            :name  => '5',
+            :level => value
+          )
+
+          expect(resource[:level]).to eq(value)
+        end
+      end
+
+      it 'should reject invalid values' do
+        invalid_names.each do |value|
+          expect {
+            runlevel_type.new(
+              :name  => '5',
+              :level => value
+            )
+          }.to raise_error(/Invalid value/)
+        end
+      end
+    end
+
+    context ':transition_timeout' do
+      let(:valid_values){[
+        '0', '100','1000000'
+      ]}
+
+      let(:invalid_values){[
+        'bob', '-1'
+      ]}
+
+      it 'should accept valid values' do
+        valid_values.each do |value|
+          resource = runlevel_type.new(
+            :name               => '5',
+            :transition_timeout => value
+          )
+
+          expect(resource[:transition_timeout]).to eq(value.to_i)
+        end
+      end
+
+      it 'should reject invalid values' do
+        invalid_values.each do |value|
+          expect {
+            runlevel_type.new(
+              :name               => '5',
+              :transition_timeout => value
+            )
+          }.to raise_error(/Invalid value/)
+        end
+      end
+    end
+
+    context 'persist' do
+      let(:valid_values){[
+        'true', 'false', true, false
+      ]}
+
+      it 'should accept valid values' do
+        valid_values.each do |value|
+          resource = runlevel_type.new(
+            :name    => '5',
+            :persist => value
+          )
+
+          expect(resource[:persist]).to eq("#{value}".to_sym)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
* Added a configurable timeout for changing runlevels based on issues
  discovered in the field with systemctl.
* Fixed bugs in the EL6 runlevel persistence where, in some cases, the
  runlevel line might not get written to /etc/inittab.

SIMP-5096 #close