### PR TITLE
(SIMP-MAINT) Fix spec tests on Puppet 5

### DIFF
--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe 'simplib::deprecation' do
   context 'with SIMPLIB_LOG_DEPRECATIONS environment variable = "true" ' do
+    before :each do
+      ENV['SIMPLIB_LOG_DEPRECATIONS'] = nil
+    end
+
     it 'should display a single warning' do
       ENV['SIMPLIB_LOG_DEPRECATIONS'] = 'true'
       Puppet.expects(:warning).with(includes('test_func is deprecated'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,6 +131,7 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
+    Puppet.settings[:autosign] = false
 
     # sanitize hieradata
     if defined?(hieradata)


### PR DESCRIPTION
A new warning has been issued on Puppet 5.5.6, causing the `simplib::deprecation` tests to catch unexpected output.