### PR TITLE
(SIMP-5383) Fix bug in `puppet_settings` fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Sep 26 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.11.1-0
+- Fixed a bug in the `puppet_settings` fact where settings from all sections
+  were interpolated using settings (like `$vardir`) from the `[main]` section.
+
 * Wed Aug 01 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.11.0-0
 - Added a function `assert_optional_dependency` that allows users to fail if
   expected functionality is not present in the current environment's module

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Sep 26 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.11.1-0
+* Wed Sep 26 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.11.0-0
 - Fixed a bug in the `puppet_settings` fact where settings from all sections
   were interpolated using settings (like `$vardir`) from the `[main]` section.
 

--- a/lib/facter/simp_puppet_settings.rb
+++ b/lib/facter/simp_puppet_settings.rb
@@ -3,24 +3,49 @@
 # automatically be able to use the various aspects of the puppet system
 # regardless of the node's platform.
 #
-# Each entry is under a hash entry of its associated section
+# Each entry is under a hash entry of its associated section.
 
 Facter.add(:puppet_settings) do
-  setcode do
-    retval = {}
+   if Object.const_defined?('Puppet') && Puppet.respond_to?(:settings)
+    setcode do
+      retval = {}
+      puppet_settings = Hash[Puppet.settings.map { |k, v| [k, v] }]
 
-    if Object.const_defined?('Puppet') && Puppet.respond_to?(:settings)
-      puppet_settings = Hash[Puppet.settings.map{|k,v| [k,v]}]
+      Puppet.settings.eachsection do |section|
+        retval[section.to_s] ||= {}
+        section_values  = Puppet.settings.values(nil, section)
+        loader_settings = {
+          :environmentpath => section_values.interpolate(:environmentpath),
+          :basemodulepath  => section_values.interpolate(:basemodulepath)
+        }
 
-      puppet_settings.each_pair do |name, obj|
-        next if obj.deprecated?
+        # Temporarily override Puppet's run_mode to evaluate this session:
+        #
+        # In order to correctly interpolate values from each section, we need
+        # to set up a Puppet.override block for each section.  Otherwise,
+        # Facter will always interpolate variables from the `[main]` section
+        # (in particular, $vardir), and won't agree with `puppet config --section`
+        Puppet.override(
+          Puppet.base_context(loader_settings),
+          "New loader for facter to inspect section '#{section}' ."
+        ) do
+          # NOW we can lookup values as configured from the section:
+          values = Puppet.settings.values(Puppet[:environment].to_sym, section)
 
-        # For older versions of Facter, no hash keys/values can be symbols
-        retval[obj.section.to_s] ||= {}
-        retval[obj.section.to_s][name.to_s] = obj.value.to_s
+          # Get the names of the settings that were set specifically for this section
+          settings = puppet_settings.select { |_k, v| v.section == section }
+          settings.each do |setting_name, setting|
+            value = values.interpolate(setting_name)
+            Facter.debug "#{section.to_s.ljust(12, '.')}" \
+                         "#{setting_name.to_s.ljust(32)} = #{value.to_s.ljust(20)}" \
+                         "#{setting.deprecated? ? ' *** DEPRECATED ***' : ''}"
+            next if setting.deprecated?
+            retval[section.to_s][setting_name.to_s] = value.to_s
+          end
+        end
       end
-    end
 
-    retval
+      retval
+    end
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.11.1",
+  "version": "3.11.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/validate_simp_puppet_settings_spec.rb
+++ b/spec/acceptance/suites/default/validate_simp_puppet_settings_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+test_name 'validate simp puppet_settings fact'
+
+describe 'validate simp puppet_settings fact' do
+  let(:puppet_conf) do
+    <<-PUPPET_CONF.gsub(%r{^ {6}}, '')
+      [main]
+        vardir = /opt/puppetlabs/puppet/cache
+      [master]
+        vardir = /opt/puppetlabs/server/data/puppetserver
+    PUPPET_CONF
+  end
+
+  hosts.each do |host|
+    context "when [main] and [master] have different vardirs in puppet.conf" do
+      it 'master.server_datadir should start with the [master] vardir' do
+        tmp_dir = create_tmpdir_on(host, 'validate_simp_puppet_settings_spec')
+        tmp_puppet_conf_path = "#{tmp_dir}/validate_simp_puppet_settings_spec--puppet.conf"
+        tmp_puppet_manifest_path = "#{tmp_dir}/validate_simp_puppet_settings_spec--manifest.pp"
+        manifest = <<-MANIFEST.gsub(%r{^ {10}}, '')
+          file{ '#{tmp_dir}/master-server_datadir.fact':
+            content => fact('puppet_settings.master.server_datadir')
+          }
+        MANIFEST
+        create_remote_file(host, tmp_puppet_conf_path, puppet_conf)
+        create_remote_file(host, tmp_puppet_manifest_path, manifest)
+
+        on host, "puppet apply '#{tmp_puppet_manifest_path}' --config '#{tmp_puppet_conf_path}'"
+        master_server_datadir = on(host, "cat #{tmp_dir}/master-server_datadir.fact").stdout
+        expect(master_server_datadir).to start_with('/opt/puppetlabs/server/data/puppetserver')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this patch, the `puppet_settings` fact incorrectly interpolated
variables using the `[main]` section's settings instead of `[master]`.

A significant consequence of this has been that the fact supplies
 incorrect paths for `[master]` settings, notably `server_datadir`:

```sh
[root@puppet ~]# puppet config print --section master server_datadir
  /opt/puppetlabs/server/data/puppetserver/server_data

[root@puppet ~]# facter -p puppet_settings.master.server_datadir
  /opt/puppetlabs/puppet/cache/server_data
```

As a consequence, `pupmod::master::sysconfig` ends up using the puppet
agent's vardir instead of puppetserver's (SIMP-5021), causing the
puppetserver service to fail when upgrading to new versions of
puppet-agent (SIMP-5383)―particularly when upgrading from SIMP 6.1 to
SIMP 6.2.

This patch fixes the issue by using `Puppet.override` to temporarily set
Puppet's run_mode to each section while interpolating their settings.

SIMP-5021 #close #comment Fixed bug in `puppet_settings` fact
SIMP-5383 #close #comment Fixed bug in `puppet_settings` fact