### PR TITLE
Fix errors on non-Linux OS's

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Sep 28 2018 Daniel Henninger <daniel@vorpalcloud.org> - 3.11.1-0
+- Fixed bug where uid_min would throw errors under operating systems
+  without /etc/login.defs.
+- Fixed bug where simplib_sysctl would throw an undefined method error
+  on non-Linux OS's.  (both those with sysctl (MacOS X) and without (Windows))
+- Both patches of which were improved by Trevor Vaughan <tvaughan@onyxpoint.com>.
+
 * Wed Sep 26 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.11.0-0
 - Fixed a bug in the `puppet_settings` fact where settings from all sections
   were interpolated using settings (like `$vardir`) from the `[main]` section.

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -28,13 +28,11 @@ Facter.add("simplib_sysctl") do
       # Facter.*.exec.
       #
       # For now we test around the issue by checking the output if $? is nil:
-      if ($?.nil? && module_value) ||
-          (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?)
+      if !module_value.nil? |&& (($?.nil? && module_value) ||
+          (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?))
       then
-        unless module_value.nil?
-          module_value.strip!
-        end
-
+        module_value.strip!
+        
         # These can be too big for facter to process as Integers
         unless entry.start_with?('kernel.shm')
           if module_value =~ /^\d+$/

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -31,7 +31,9 @@ Facter.add("simplib_sysctl") do
       if ($?.nil? && module_value) ||
           (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?)
       then
-        module_value.strip!
+        unless module_value.nil?
+          module_value.strip!
+        end
 
         # These can be too big for facter to process as Integers
         unless entry.start_with?('kernel.shm')

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -28,7 +28,7 @@ Facter.add("simplib_sysctl") do
       # Facter.*.exec.
       #
       # For now we test around the issue by checking the output if $? is nil:
-      if !module_value.nil? |&& (($?.nil? && module_value) ||
+      if !module_value.nil? && (($?.nil? && module_value) ||
           (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?))
       then
         module_value.strip!

--- a/lib/facter/simplib_sysctl.rb
+++ b/lib/facter/simplib_sysctl.rb
@@ -5,6 +5,8 @@
 # We don't grab the entire output due to the sheer size of it
 #
 Facter.add("simplib_sysctl") do
+  confine { Facter::Core::Execution.which('sysctl') }
+
   setcode do
     relevant_entries = [
       'crypto.fips_enabled',
@@ -28,11 +30,11 @@ Facter.add("simplib_sysctl") do
       # Facter.*.exec.
       #
       # For now we test around the issue by checking the output if $? is nil:
-      if !module_value.nil? && (($?.nil? && module_value) ||
-          (!$?.nil? && $?.exitstatus.zero? && !module_value.strip.empty?))
+      if ($?.nil? && module_value) ||
+          (!$?.nil? && $?.exitstatus.zero? && module_value && !module_value.strip.empty?)
       then
         module_value.strip!
-        
+
         # These can be too big for facter to process as Integers
         unless entry.start_with?('kernel.shm')
           if module_value =~ /^\d+$/

--- a/lib/facter/uid_min.rb
+++ b/lib/facter/uid_min.rb
@@ -4,16 +4,15 @@
 #
 Facter.add('uid_min') do
   setcode do
+    uid_min = ''
     if File.readable?('/etc/login.defs')
       uid_min = File.open('/etc/login.defs').grep(/UID_MIN/)
       unless uid_min.empty?
         uid_min = uid_min.first.to_s.chomp.split.last
-      else
-        uid_min = ''
       end
     end
 
-    unless uid_min || uid_min.empty?
+    unless uid_min.empty?
       if ['RedHat','CentOS','OracleLinux','Scientific'].include?(Facter.value(:operatingsystem)) &&
          Facter.value(:operatingsystemmajrelease) < '7' then
           uid_min = '500'

--- a/lib/facter/uid_min.rb
+++ b/lib/facter/uid_min.rb
@@ -3,18 +3,21 @@
 # Return the minimum uid allowed
 #
 Facter.add('uid_min') do
+  confine { File.exist?('/etc/login.defs') }
+
   setcode do
-    uid_min = ''
-    if File.readable?('/etc/login.defs')
-      uid_min = File.open('/etc/login.defs').grep(/UID_MIN/)
-      unless uid_min.empty?
-        uid_min = uid_min.first.to_s.chomp.split.last
-      end
+    uid_min = File.open('/etc/login.defs').grep(/UID_MIN/)
+
+    # Grep returns an Array
+    uid_min = '' if uid_min.empty?
+
+    unless uid_min.empty?
+      uid_min = uid_min.first.to_s.chomp.split.last
     end
 
     unless uid_min.empty?
       if ['RedHat','CentOS','OracleLinux','Scientific'].include?(Facter.value(:operatingsystem)) &&
-         Facter.value(:operatingsystemmajrelease) < '7' then
+         Facter.value(:operatingsystemmajrelease) < '7'
           uid_min = '500'
       else
         uid_min = '1000'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi folk, this PR takes care of the following two errors that show up on non-Linux OS's:

Under Windows:
```
puppet : [1;31mError: Facter: error while resolving custom fact "simplib_sysctl": undefined method `strip' for nil:NilClass[0m
    + CategoryInfo          : NotSpecified: ([1;31mError: F...il:NilClass[0m:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
```
This was due to it not having sysctl at all.

Under Mac OS X (and Windows if I recall correctly):
```
error while resolving custom fact "uid_min": undefined method `empty?' for nil:NilClass
```
This was due to some slightly confused unless login (at least per my and my coworkers read).  We simplified the section a bit.

Let me know if you have any concerns or questions about the patch!