### PR TITLE
(SIMP-5722) gitlab job specifies nonexistent node set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -289,9 +289,10 @@ pup5.5.7-oel-prelink_fact-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[prelink_fact,oel]'
 
-pup5.5.7-oel-ipa_fact:
-  <<: *acceptance_base
-  <<: *pup_5_5_7
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'bundle exec rake beaker:suites[ipa_fact,oel]'
+# The default node set for the ipa_fact suite includes OEL servers
+#pup5.5.7-oel-ipa_fact:
+#  <<: *acceptance_base
+#  <<: *pup_5_5_7
+#  <<: *only_with_SIMP_FULL_MATRIX
+#  script:
+#    - 'bundle exec rake beaker:suites[ipa_fact,oel]'


### PR DESCRIPTION
OEL servers are included in the default.yml for the ipa_fact suite

SIMP-5722 #close