### PR TITLE
(SIMP-5855) Validate fs.inotify.max_user_watches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Dec 14 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
+- Add support for fs.inotify.max_user_watches to
+  simplib::validate_sysctl_value()
+
 * Wed Oct 31 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.11.1-0
 - Fix reboot_notify tests
 - Ensure that reboot_notify updates resources based on a modified 'reason'

--- a/lib/puppet/functions/simplib/validate_sysctl_value.rb
+++ b/lib/puppet/functions/simplib/validate_sysctl_value.rb
@@ -14,30 +14,57 @@ Puppet::Functions.create_function(:'simplib::validate_sysctl_value') do
 
   dispatch :validate_sysctl_value do
     required_param 'String',:key
-    required_param 'String',:value
+    required_param 'NotUndef',:value
   end
 
   def validate_sysctl_value(key, value)
 
     key_method_name = key.to_s.gsub('.','__')
 
-    self.send(key_method_name,value) if self.respond_to?(key_method_name)
+    self.send(key_method_name, key, value) if self.respond_to?(key_method_name)
   end
 
   # Below are the recognized validation methods
 
-  def kernel__core_pattern(value)
-    method = 'kernel.core_pattern'
+  def kernel__core_pattern(key, value)
+    unless value.is_a?(String)
+      validate_sysctl_err("Values for #{key} must be Strings")
+    end
 
     if value.length > 128
-      fail("simplib::validate_sysctl_value(): Values for #{method} must be less than 129 characters")
+      validate_sysctl_err("Values for #{key} must be less than 129 characters")
     end
 
     if value =~ /\|\s*(\S*)/
       require 'puppet/util'
       unless  Puppet::Util.absolute_path?($1, :posix)
-        fail("simplib::validate_sysctl_value(): Piped commands for #{method} must have an absolute path")
+        validate_sysctl_err("Piped commands for #{key} must have an absolute path")
       end
     end
+  end
+
+  def fs__inotify__max_user_watches(key, value)
+    if !value.respond_to?('to_i') || value.to_i == 0
+      validate_sysctl_err("#{key} cannot be #{value}")
+    end
+
+    system_ram_mb = closure_scope['facts']['memorysize_mb']
+
+    if system_ram_mb
+      system_ram_mb = system_ram_mb.to_i
+
+      size_multiplier = 512
+      size_multiplier = 1024 if (closure_scope['facts']['architecture'] == 'x86_64')
+
+      inode_ram_mb = (value.to_i * size_multiplier)/1024/1024
+
+      if inode_ram_mb >= system_ram_mb
+        validate_sysctl_err("#{key} set to #{value} would exceed system RAM")
+      end
+    end
+  end
+
+  def validate_sysctl_err(msg)
+    fail("simplib::validate_sysctl_value(): #{msg}")
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/validate_sysctl_value_spec.rb
+++ b/spec/functions/simplib/validate_sysctl_value_spec.rb
@@ -2,31 +2,80 @@ require 'spec_helper'
 
 describe 'simplib::validate_sysctl_value' do
 
-  context 'with valid config' do
-    it 'validates a kernel.core_pattern setting that is a filename' do
-      is_expected.to run.with_params('kernel.core_pattern','/var/core/%u_%g_%p_%t_%h_%e.core')
+  context 'kernel.core_pattern' do
+    context 'valid config' do
+      it 'validates a setting that is a filename' do
+        is_expected.to run.with_params('kernel.core_pattern','/var/core/%u_%g_%p_%t_%h_%e.core')
+      end
+
+      it 'validates a setting to pipe core to an fully qualified path' do
+        is_expected.to run.with_params('kernel.core_pattern','| /usr/sbin/my_core_dump_program %p')
+      end
+
+      it 'accepts setting for which it does not have a validation routine' do
+        is_expected.to run.with_params('net.ipv4.tcp_available_congestion_control','oops')
+      end
+
     end
 
-    it 'validates a kernel.core_pattern setting to pipe core to an fully qualified path' do
-      is_expected.to run.with_params('kernel.core_pattern','| /usr/sbin/my_core_dump_program %p')
-    end
+    context 'invalid config' do
+      it 'rejects a setting that is too long' do
+        is_expected.to run.with_params('kernel.core_pattern', '/var/core/'+ "x"*120).and_raise_error(
+         /Values for kernel.core_pattern must be less than 129 characters/ )
+      end
 
-    it 'accepts sysctl setting for which it does not have a validation routine' do
-      is_expected.to run.with_params('net.ipv4.tcp_available_congestion_control','oops')
+      it 'rejects a setting that is pipe to an executable that does not have a fully-qualified path' do
+        is_expected.to run.with_params('kernel.core_pattern', '| my_core_dump_program %p').and_raise_error(
+         /Piped commands for kernel.core_pattern must have an absolute path/ )
+      end
     end
-
   end
 
-  context 'with invalid config' do
-    it 'rejects a kernel.core_pattern setting that is too long' do
-      is_expected.to run.with_params('kernel.core_pattern', '/var/core/'+ "x"*120).and_raise_error(
-       /Values for kernel.core_pattern must be less than 129 characters/ )
+  context 'fs.inotify.max_user_watches' do
+    let(:facts){{
+      :architecture  => 'x86_64',
+      :memorysize_mb => 20
+    }}
+
+    context 'valid config' do
+      it 'validates a setting that is a positive integer that does not exceed the memory limit' do
+        is_expected.to run.with_params('fs.inotify.max_user_watches', 20)
+      end
     end
 
-    it 'rejects an kernel.core_pattern setting that is pipe to an executable that does not have a fully-qualified path' do
-      is_expected.to run.with_params('kernel.core_pattern', '| my_core_dump_program %p').and_raise_error(
-       /Piped commands for kernel.core_pattern must have an absolute path/ )
+    context 'invalid config' do
+      invalid_values = [
+        0,
+        'Invalid',
+        { :bad => 'stuff' },
+        [ 'Also', 'Bad' ]
+      ]
+
+      invalid_values.each do |value|
+        it "rejects #{value}" do
+          is_expected.to run.with_params('fs.inotify.max_user_watches', value).and_raise_error(
+            /fs.inotify.max_user_watches cannot be #{Regexp.escape(value.to_s)}/ )
+        end
+      end
+
+      context 'x86_64' do
+        it 'rejects items that exceed the memory limit' do
+          is_expected.to run.with_params('fs.inotify.max_user_watches', 20480).and_raise_error(
+            /fs.inotify.max_user_watches set to 20480 would exceed system RAM/ )
+        end
+      end
+
+      context 'i686' do
+        let(:facts){{
+          :architecture  => 'i686',
+          :memorysize_mb => 20
+        }}
+
+        it 'rejects items that exceed the memory limit' do
+          is_expected.to run.with_params('fs.inotify.max_user_watches', 40960).and_raise_error(
+            /fs.inotify.max_user_watches set to 40960 would exceed system RAM/ )
+        end
+      end
     end
   end
-
 end


### PR DESCRIPTION
simp::sysctl added support for setting fs.inotify.max_user_watches
inline with many vendor recommendations.

The simplib::validate_sysctl_value function was updated to ensure that
users do not try to set fs.inotify.max_user_watches to a value that
exceeds system RAM.

SIMP-5855 #comment validate fs.inotify.max_user_watches