### PR TITLE
(SIMP-5919) Add Simplib::ShadowPass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.16.0' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - gem install -v '~> 1.16.0' bundler
+  - gem install -v '~> 1.16' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.1-0
+* Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.0-0
 - Add Simplib::ShadowPass custom data type
 
 * Fri Dec 14 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.1-0
+- Add Simplib::ShadowPass custom data type
+
 * Fri Dec 14 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
 - Add support for fs.inotify.max_user_watches to
   simplib::validate_sysctl_value()

--- a/README.md
+++ b/README.md
@@ -2286,6 +2286,11 @@ and validation across the SIMP code base.
         * ``PC1``
         * ``PE``
 
+* ``Simplib::ShadowPass``
+    * Valid options for the password field of /etc/shadow to include
+      locked passwords, unestablished passwords, and hashed passwords
+      using MD5, Blowfish, SHA256, or SHA512 algorithms.
+
 * ``Simplib::Syslog::CFacility``
     * A syslog log facility, in the form expected by ``syslog(3)``.
       Examples:

--- a/functions/assert_metadata.pp
+++ b/functions/assert_metadata.pp
@@ -70,10 +70,6 @@ function simplib::assert_metadata (
         $metadata['operatingsystem_support'].each |Simplib::Puppet::Metadata::OS_support $os_info| {
           if $os_info['operatingsystem'] == $facts['os']['name'] {
             case $_options['os']['options']['release_match'] {
-              'none': {
-                $result = true
-              }
-
               'full': {
                 if !($facts['os']['release']['full'] in $os_info['operatingsystemrelease']) {
                   fail("OS '${facts['os']['name']}' version '${facts['os']['release']['full']}' is not supported by '${module_name}'")
@@ -87,6 +83,9 @@ function simplib::assert_metadata (
                 if !($facts['os']['release']['major'] in $_os_major_releases) {
                   fail("OS '${facts['os']['name']}' version '${facts['os']['release']['major']}' is not supported by '${module_name}'")
                 }
+              }
+              default: {
+                $result = true
               }
             }
           }

--- a/functions/hash_to_opts.pp
+++ b/functions/hash_to_opts.pp
@@ -41,10 +41,12 @@ function simplib::hash_to_opts (
       default: { "${prefix}${key}${connector}${String($val).shellquote}" }
       Undef:   { "${prefix}${key}" }
       Array:   {
+        # lint:ignore:case_without_default
         case $repeat {
           'comma':  { "${prefix}${key}${connector}${val.join($delimiter).shellquote}" }
           'repeat': { $val.prefix("${prefix}${key}${connector}").shellquote }
         }
+        # lint:endignore
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.12.1",
+  "version": "3.12.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/type_aliases/shadowpass_spec.rb
+++ b/spec/type_aliases/shadowpass_spec.rb
@@ -13,7 +13,7 @@ describe 'Simplib::ShadowPass' do
     it { is_expected.to allow_value('$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.') }
   end
 
-  context 'with invalid MAC addresses' do
+  context 'with invalid entries' do
     it { is_expected.not_to allow_value('*$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
     it { is_expected.not_to allow_value('$6$') }
     it { is_expected.not_to allow_value('mycleartextpassword') }

--- a/spec/type_aliases/shadowpass_spec.rb
+++ b/spec/type_aliases/shadowpass_spec.rb
@@ -8,8 +8,6 @@ describe 'Simplib::ShadowPass' do
     it { is_expected.to allow_value('!!i$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
     it { is_expected.to allow_value('$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
     it { is_expected.to allow_value('$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9') }
-    it { is_expected.to allow_value('$sha1$07$6a6d7befbdb6cbdf9fbce9f3a16858fa01ed670f') }
-    it { is_expected.to allow_value('$md5$07$N9D4NHOiICuHB7nzBi0ZX0') }
     it { is_expected.to allow_value('$3$$0480cf9c8755c691c629f6595c2e7238') }
     it { is_expected.to allow_value('$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
     it { is_expected.to allow_value('$2y$10$RT.Z68QWbhbg5.TOba4gGOBEvj6anWfvPBaU3F1HMHTSz5g75Vrme') }

--- a/spec/type_aliases/shadowpass_spec.rb
+++ b/spec/type_aliases/shadowpass_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'Simplib::ShadowPass' do
+  context 'with valid entries' do
+    it { is_expected.to allow_value('*') }
+    it { is_expected.to allow_value('!') }
+    it { is_expected.to allow_value('!!') }
+    it { is_expected.to allow_value('!!i$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
+    it { is_expected.to allow_value('$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
+    it { is_expected.to allow_value('$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9') }
+    it { is_expected.to allow_value('$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
+    it { is_expected.to allow_value('$2y$10$RT.Z68QWbhbg5.TOba4gGOBEvj6anWfvPBaU3F1HMHTSz5g75Vrme') }
+    it { is_expected.to allow_value('$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.') }
+  end
+
+  context 'with invalid MAC addresses' do
+    it { is_expected.not_to allow_value('*$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
+    it { is_expected.not_to allow_value('$6$') }
+    it { is_expected.not_to allow_value('mycleartextpassword') }
+  end
+end

--- a/spec/type_aliases/shadowpass_spec.rb
+++ b/spec/type_aliases/shadowpass_spec.rb
@@ -8,6 +8,9 @@ describe 'Simplib::ShadowPass' do
     it { is_expected.to allow_value('!!i$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
     it { is_expected.to allow_value('$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
     it { is_expected.to allow_value('$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9') }
+    it { is_expected.to allow_value('$sha1$07$6a6d7befbdb6cbdf9fbce9f3a16858fa01ed670f') }
+    it { is_expected.to allow_value('$md5$07$N9D4NHOiICuHB7nzBi0ZX0') }
+    it { is_expected.to allow_value('$3$$0480cf9c8755c691c629f6595c2e7238') }
     it { is_expected.to allow_value('$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
     it { is_expected.to allow_value('$2y$10$RT.Z68QWbhbg5.TOba4gGOBEvj6anWfvPBaU3F1HMHTSz5g75Vrme') }
     it { is_expected.to allow_value('$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.') }

--- a/types/libcrypt/bcrypt.pp
+++ b/types/libcrypt/bcrypt.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::Bcrypt = Pattern['^\$2[abxy]\$[0-9]{2}\$[./A-Za-z0-9]{53}$']

--- a/types/libcrypt/bigcrypt.pp
+++ b/types/libcrypt/bigcrypt.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::Bigcrypt = Pattern['^[./0-9A-Za-z]{13,178}$']

--- a/types/libcrypt/bsdi_extended_des.pp
+++ b/types/libcrypt/bsdi_extended_des.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::BSDIExtendedDES = Pattern['^_[./0-9A-Za-z]{19}$']

--- a/types/libcrypt/des.pp
+++ b/types/libcrypt/des.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::DES = Pattern['^[./0-9A-Za-z]{13}$']

--- a/types/libcrypt/md5_freebsd.pp
+++ b/types/libcrypt/md5_freebsd.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::MD5_FreeBSD = Pattern['^\$1\$[^$]{1,8}\$[./0-9A-Za-z]{22}$']

--- a/types/libcrypt/md5_sun.pp
+++ b/types/libcrypt/md5_sun.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::MD5_Sun = Pattern['^\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}$']

--- a/types/libcrypt/md5_sun.pp
+++ b/types/libcrypt/md5_sun.pp
@@ -1,2 +1,4 @@
 # Regular expression pulled from the crypt(5) man page
+# lint:ignore:single_quote_string_with_variables
 type Simplib::Libcrypt::MD5_Sun = Pattern['^\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}$']
+# lint:endignore

--- a/types/libcrypt/nthash.pp
+++ b/types/libcrypt/nthash.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::NTHASH = Pattern['^\$3\$\$[0-9a-f]{32}$']

--- a/types/libcrypt/scrypt.pp
+++ b/types/libcrypt/scrypt.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::Scrypt = Pattern['^\$7\$[./A-Za-z0-9]{11,97}\$[./A-Za-z0-9]{43}$']

--- a/types/libcrypt/sha1.pp
+++ b/types/libcrypt/sha1.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::SHA1 = Pattern['^\$sha1\$[1-9][0-9]+\$[./0-9A-Za-z]{1,64}\$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}$']

--- a/types/libcrypt/sha2_256.pp
+++ b/types/libcrypt/sha2_256.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::SHA2_256 = Pattern['^\$5\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{43}$']

--- a/types/libcrypt/sha2_512.pp
+++ b/types/libcrypt/sha2_512.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::SHA2_512 = Pattern['^\$6\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{86}$']

--- a/types/libcrypt/yescript.pp
+++ b/types/libcrypt/yescript.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::Yescrypt = Pattern['^\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}$']

--- a/types/shadowpass.pp
+++ b/types/shadowpass.pp
@@ -1,0 +1,2 @@
+# /etc/shadow password allowed values
+type Simplib::ShadowPass = Pattern['(^\*$|^!{1,2}.?|^\$([156]|2[ay]){1}\$.+)']

--- a/types/shadowpass.pp
+++ b/types/shadowpass.pp
@@ -1,2 +1,5 @@
 # /etc/shadow password allowed values
-type Simplib::ShadowPass = Pattern['(^\*$|^!{1,2}.?|^\$([156]|2[ay]){1}\$.+)']
+type Simplib::ShadowPass = Variant[
+  Enum['*','!','!!'],
+  Pattern['^((!.*)|(\$(1|2(a|y)?|3|md5|sha1|5|6)\$.+))$']
+]

--- a/types/shadowpass.pp
+++ b/types/shadowpass.pp
@@ -1,5 +1,24 @@
-# /etc/shadow password allowed values
+# Valid entries for the password field of the 'shadow' file
+#
+# These items are recognized by recent versions of crypt but may not be exhaustive
+#
+# Regular expressions pulled from the crypt(5) man page
+#
+# They are ordered of most to least commonly used for optimization.
+#
+# Just because they are allowed, does not mean that you should use them....
 type Simplib::ShadowPass = Variant[
   Enum['*','!','!!'],
-  Pattern['^((!.*)|(\$(1|2(a|y)?|3|md5|sha1|5|6)\$.+))$']
+  # Disabled Entries
+  Pattern['^!.*'],
+  Simplib::Libcrypt::SHA2_512,
+  Simplib::Libcrypt::SHA2_256,
+  Simplib::Libcrypt::SHA1,
+  Simplib::Libcrypt::MD5_Sun,
+  Simplib::Libcrypt::MD5_FreeBSD,
+  Simplib::Libcrypt::NTHASH,
+  Simplib::Libcrypt::BSDIExtendedDES,
+  Simplib::Libcrypt::Bcrypt,
+  Simplib::Libcrypt::Scrypt,
+  Simplib::Libcrypt::Yescrypt
 ]


### PR DESCRIPTION
This change adds the Simplib::ShadowPass data type which checks against
all valid entries for /etc/shadow for the password field.

SIMP-5919 #comment Create Simplib::ShadowPass type to use