### PR TITLE
(SIMP-5937) Allow users to disable assert_metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,11 @@
-* Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.0-0
-- Add Simplib::ShadowPass custom data type
-
-* Fri Dec 14 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
+* Wed Jan 16 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
 - Add support for fs.inotify.max_user_watches to
   simplib::validate_sysctl_value()
+- Fix bug in simplib::assert_metadata where it could not be disabled
+  - Thanks to Adam Hagen for filing the proposed patch in JIRA
+
+* Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.0-0
+- Add Simplib::ShadowPass custom data type
 
 * Wed Oct 31 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.11.1-0
 - Fix reboot_notify tests

--- a/functions/assert_metadata.pp
+++ b/functions/assert_metadata.pp
@@ -25,7 +25,8 @@
 function simplib::assert_metadata (
   String[1] $module_name,
   Optional[Struct[{
-    os => Optional[Struct[{
+    enable => Optional[Boolean],
+    os     => Optional[Struct[{
       validate => Optional[Boolean],
       options  => Struct[{
         release_match => Enum['none','full','major']

--- a/spec/functions/assert_metadata_spec.rb
+++ b/spec/functions/assert_metadata_spec.rb
@@ -57,6 +57,12 @@ describe 'simplib::assert_metadata' do
           }.to raise_error(/OS.*is not supported/)
         }
     end
+
+    context 'when disabled' do
+      let(:facts) { facts }
+
+      it { is_expected.to run.with_params('stdlib', { 'enable' => false, 'os' => { 'options' => { 'release_match' => 'full' } } } ) }
+    end
   end
 
   context 'on a supported OS with an unsupported major version' do


### PR DESCRIPTION
Fix a bug in the parameter declaration of simplib::assert_metadata which
prevented users from disabling it as described in the documentation.

Thanks to Adam Hagen for filing the proposed patch in JIRA

SIMP-5937 #close