### PR TITLE
(SIMP-5940) Add simplib::dlookup function

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,9 @@
 fixtures:
   repositories:
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    # This needs to be in place for the rspec-puppet Hiera 5 hook to work
+    # No idea why, it may be because Puppet sees a custom backend and loads all
+    # of the global parts.
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
   symlinks:
     simplib: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
 #-----------------------------------------------------------------------
 
 .pup_4: &pup_4
-  image: 'ruby:2.4'
+  image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.0'
     MATRIX_RUBY_VERSION: '2.1'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
-* Wed Jan 16 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
+* Fri Jan 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.12.0-0
 - Add support for fs.inotify.max_user_watches to
   simplib::validate_sysctl_value()
 - Fix bug in simplib::assert_metadata where it could not be disabled
   - Thanks to Adam Hagen for filing the proposed patch in JIRA
+- Add a 'defined type' lookup capability, `simplib::dlookup` that provides a
+  consistent method for retrieving defined type parameters from Hiera in an
+  opt-in manner.
+- Fixed various YARD documentation issues
 
 * Fri Jan 04 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 3.12.0-0
 - Add Simplib::ShadowPass custom data type

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.6')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
   gem 'danger', :require => false
 end
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -49,6 +49,7 @@
 * [`simplib::assert_metadata`](#simplibassert_metadata): Fails a compile if the client system is not compatible with the module's `metadata.json`
 * [`simplib::assert_optional_dependency`](#simplibassert_optional_dependency): Fails a compile if the system does not contain a correct version of the required module in the current environment.  Provides a message about
 * [`simplib::deprecation`](#simplibdeprecation): Function to print deprecation warnings, logging a warning once for a given key.  Messages can be enabled if the SIMPLIB_LOG_DEPRECATIONS envi
+* [`simplib::dlookup`](#simplibdlookup): 
 * [`simplib::filtered`](#simplibfiltered): Hiera v5 backend that takes a list of allowed hiera key names, and only returns results from the underlying backend function that match those
 * [`simplib::gen_random_password`](#simplibgen_random_password): Generates a random password string.  Terminates catalog compilation if the password cannot be created in the allotted time.
 * [`simplib::hash_to_opts`](#simplibhash_to_opts): Turn a hash into a options string, for use in a shell command
@@ -60,7 +61,7 @@
 * [`simplib::ldap::domain_to_dn`](#simplibldapdomain_to_dn): Generates a LDAP Base DN from a domain
 * [`simplib::lookup`](#simpliblookup): A function for falling back to global scope variable lookups when the Puppet 4 ``lookup()`` function cannot find a value.  While ``lookup()``
 * [`simplib::mock_data`](#simplibmock_data): A mock data function
-* [`simplib::module_exist`](#simplibmodule_exist): Determines if a module exists in the current environment
+* [`simplib::module_exist`](#simplibmodule_exist): Determines if a module exists in the current environment  If passed with an author, such as `simp/simplib` or `simp-simplib`, will return whe
 * [`simplib::nets2cidr`](#simplibnets2cidr): Take an input list of networks and returns an equivalent `Array` in CIDR notation.  * Hostnames are passed through untouched. * Terminates ca
 * [`simplib::nets2ddq`](#simplibnets2ddq): Tranforms a list of networks into an equivalent array in dotted quad notation.  * CIDR networks are converted to dotted quad notation network
 * [`simplib::parse_hosts`](#simplibparse_hosts): Convert an `Array` of items that may contain port numbers or protocols into a structured `Hash` of host information.  * Works with Hostnames 
@@ -1341,6 +1342,76 @@ Data type: `String`
 Message to be printed, to which file and line
 information will be appended, if available.
 
+### simplib::dlookup
+
+Type: Ruby 4.x API
+
+The simplib::dlookup function.
+
+#### `simplib::dlookup(String[1] $define_id, String[1] $param, Optional[Any] $options)`
+
+The literal unique identifier of the defined type resource ('mydef::global'
+in the examples)
+
+Returns: `Any` The discovered data from Hiera
+
+##### `define_id`
+
+Data type: `String[1]`
+
+
+
+##### `param`
+
+Data type: `String[1]`
+
+The parameter that you wish to look up
+
+##### `options`
+
+Data type: `Optional[Any]`
+
+Hash of options for regular ``lookup()``
+
+* This **must** follow the syntax rules for the
+Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+* No other formats are supported!
+
+#### `simplib::dlookup(String[1] $define_id, String[1] $param, String[1] $resource_title, Optional[Any] $options)`
+
+The literal unique identifier of the defined type resource ('mydef::global'
+in the examples)
+
+Returns: `Any` The discovered data from Hiera
+
+##### `define_id`
+
+Data type: `String[1]`
+
+
+
+##### `param`
+
+Data type: `String[1]`
+
+The parameter that you wish to look up
+
+##### `resource_title`
+
+Data type: `String[1]`
+
+The $title of the resource
+
+##### `options`
+
+Data type: `Optional[Any]`
+
+Hash of options for regular ``lookup()``
+
+* This **must** follow the syntax rules for the
+Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+* No other formats are supported!
+
 ### simplib::filtered
 
 Type: Ruby 4.x API
@@ -1413,7 +1484,7 @@ in the allotted time.
 Returns: `String` Generated password
 
 Raises:
-* `RuntimeError` if password cannot be created within allotted time
+* `if` password cannot be created within allotted time
 
 ##### `length`
 
@@ -1783,9 +1854,15 @@ Type: Ruby 4.x API
 
 Determines if a module exists in the current environment
 
+If passed with an author, such as `simp/simplib` or `simp-simplib`, will
+return whether or not that *specific* module exists.
+
 #### `simplib::module_exist(String[1] $module_name)`
 
 Determines if a module exists in the current environment
+
+If passed with an author, such as `simp/simplib` or `simp-simplib`, will
+return whether or not that *specific* module exists.
 
 Returns: `Boolean` Whether or not the module exists in the current environment
 
@@ -1899,8 +1976,8 @@ into a structured `Hash` of host information.
 Returns: `Hash` Structured Hash of the host information
 
 Raises:
-* `RuntimeError` if a valid network or hostname cannot be extracted from all input items
-* `RuntimeError` if any input item that contains a port specifies an invalid port
+* `if` a valid network or hostname cannot be extracted from all input items
+* `if` any input item that contains a port specifies an invalid port
 
 ##### `hosts`
 
@@ -2059,7 +2136,7 @@ Terminates catalog compilation if
 Returns: `Array[String]` Non-port portion of hostnames
 
 Raises:
-* `RuntimeError` if any input item that contains a port specifies an invalid port
+* `if` any input item that contains a port specifies an invalid port
 
 ##### `hosts`
 
@@ -2084,6 +2161,9 @@ Terminates catalog compilation if the argument's class
 does not respond to the `to_i()` Ruby method.
 
 Returns: `Integer` Converted input
+
+Raises:
+* `if` ``input`` does not implement a ``to_i()`` method
 
 ##### `input`
 
@@ -2130,7 +2210,7 @@ Validate that an single input is a member of another `Array` or an
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` if validation fails
+* `if` validation fails
 
 ##### `input`
 
@@ -2171,7 +2251,7 @@ Terminates catalog compilation if validation fails.
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` if validation fails
+* `if` validation fails
 
 ##### `value`
 
@@ -2210,7 +2290,7 @@ Terminates catalog compilation if validation fails.
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` if validation fails
+* `if` validation fails
 
 ##### `*values_to_validate`
 
@@ -2251,7 +2331,7 @@ Perform a deep validation on two passed `Hashes`.
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` if validation fails
+* `if` validation fails
 
 ##### `reference`
 
@@ -2357,7 +2437,7 @@ Validates whether each passed argument contains valid port(s).
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` if validation fails
+* `if` validation fails
 
 ##### `*port_args`
 
@@ -2485,7 +2565,7 @@ Validate that the passed value is correct for the passed `sysctl` key.
 * If a key is not known, assumes the value is valid.
 * Terminates catalog compilation if validation fails.
 
-#### `simplib::validate_sysctl_value(String $key, String $value)`
+#### `simplib::validate_sysctl_value(String $key, NotUndef $value)`
 
 Validate that the passed value is correct for the passed `sysctl` key.
 
@@ -2495,7 +2575,7 @@ Validate that the passed value is correct for the passed `sysctl` key.
 Returns: `Nil`
 
 Raises:
-* `RuntimeError` upon validation failure
+* `upon` validation failure
 
 ##### `key`
 
@@ -2505,7 +2585,7 @@ sysctl setting whose value is to be validated
 
 ##### `value`
 
-Data type: `String`
+Data type: `NotUndef`
 
 Value to be validated
 

--- a/lib/puppet/functions/simplib/dlookup.rb
+++ b/lib/puppet/functions/simplib/dlookup.rb
@@ -12,10 +12,7 @@
 # appropriately but was split out in case the underlying syntax needs to
 # change in the future.
 #
-# There are two ways to call this method and, in both cases, to prevent
-# conflicts with class parameters, the keys in Hiera have been modified to
-# completely avoid items that are allowed Puppet Class names but to also mirror
-# common Puppet nomenclature for working with existing resources.
+# There are two ways to call this method as shown in the following examples.
 #
 # @example Global Options
 #

--- a/lib/puppet/functions/simplib/dlookup.rb
+++ b/lib/puppet/functions/simplib/dlookup.rb
@@ -131,7 +131,7 @@ Puppet::Functions.create_function(:'simplib::dlookup') do
     retval = call_function('simplib::lookup', target_param, options)
 
     # Fall back to the global lookup for this option
-    if options['default_value'] && retval == options['default_value']
+    if retval == options['default_value']
       retval = dlookup(define_id, param, options)
     end
 

--- a/lib/puppet/functions/simplib/dlookup.rb
+++ b/lib/puppet/functions/simplib/dlookup.rb
@@ -23,6 +23,9 @@
 #   defined type that is ever called. For example, this may be useful for
 #   setting cipher suites to a modified global default to meet company policy.
 #
+#   This follows the general Puppet nomenclature for class lookups since you
+#   cannot have a class and defined type of the same name.
+#
 #   Function Call:
 #
 #   ```ruby
@@ -37,7 +40,7 @@
 #
 #   ```yaml
 #   ---
-#   Define[mydef::global]::ssl_version: 'TLS1.2'
+#   mydef::global::ssl_version: 'TLS1.2'
 #   ```
 #
 # @example Specific Instance Options
@@ -68,7 +71,7 @@
 #   resource will have its `ssl_version` set to `TLS1.2`. All others will have
 #   their version set to `SSLv3`.
 #
-
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 Puppet::Functions.create_function(:'simplib::dlookup') do
   # @param define_id
@@ -93,7 +96,7 @@ Puppet::Functions.create_function(:'simplib::dlookup') do
   end
 
   # @param define_id
-  # The literal unique identifier of the defined type resource ('mydef::global'
+  # The literal unique identifier of the defined type resource ('mydef::specific'
   # in the examples)
   #
   # @param param The parameter that you wish to look up
@@ -117,7 +120,7 @@ Puppet::Functions.create_function(:'simplib::dlookup') do
   end
 
   def dlookup(define_id, param, options)
-    target_param = "Define[#{define_id}]::#{param}"
+    target_param = "#{define_id}::#{param}"
 
     return call_function('simplib::lookup', target_param, options )
   end

--- a/lib/puppet/functions/simplib/dlookup.rb
+++ b/lib/puppet/functions/simplib/dlookup.rb
@@ -1,0 +1,137 @@
+# A function for performing lookups targeted at ease of use with defined types.
+#
+# Quite often you need to override something in an existing defined type and,
+# presently, you have to do this by creating a resource collector and
+# potentially ending up with unintended side-effects.
+#
+# This function introduces the capability to consistently opt-in to a lookup
+# syntax for overriding all parameters of a given defined type or parameters on
+# a specific instance of a defined type.
+#
+# This calls `simplib::lookup` under the hood after formatting the parameters
+# appropriately but was split out in case the underlying syntax needs to
+# change in the future.
+#
+# There are two ways to call this method and, in both cases, to prevent
+# conflicts with class parameters, the keys in Hiera have been modified to
+# completely avoid items that are allowed Puppet Class names but to also mirror
+# common Puppet nomenclature for working with existing resources.
+#
+# @example Global Options
+#
+#   In this case, you want to set a parameter on *every* instance of your
+#   defined type that is ever called. For example, this may be useful for
+#   setting cipher suites to a modified global default to meet company policy.
+#
+#   Function Call:
+#
+#   ```ruby
+#   define mydef::global (
+#     $ssl_version = simplib::dlookup('mydef::global', 'ssl_version', { 'default_value' => 'SSLv3' })
+#   ) { ... }
+#
+#   mydef::global { 'test': }
+#   ```
+#
+#   Example Hieradata:
+#
+#   ```yaml
+#   ---
+#   Define[mydef::global]::ssl_version: 'TLS1.2'
+#   ```
+#
+# @example Specific Instance Options
+#
+#   In this case, you want to focus on a specific named instance of a defined
+#   type resource and change only that parameter. If the specific instance
+#   cannot be found, it will fall back to a global lookup for the parameter
+#   as in the first example.
+#
+#   Function Call:
+#
+#   ```ruby
+#   define mydef::specific (
+#     $ssl_version = simplib::dlookup('mydef::specific', 'ssl_version', $title, { 'default_value' => 'SSLv3' })
+#   ) { ... }
+#
+#   mydef::specific{ 'test': }
+#   ```
+#
+#   Example Hieradata:
+#
+#   ```yaml
+#   ---
+#   "Mydef::Specific[test]::ssl_version": 'TLS1.2'
+#   ```
+#
+#   Note that, in this case, only the `test` instance of the `mydef::specific`
+#   resource will have its `ssl_version` set to `TLS1.2`. All others will have
+#   their version set to `SSLv3`.
+#
+
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+Puppet::Functions.create_function(:'simplib::dlookup') do
+  # @param define_id
+  # The literal unique identifier of the defined type resource ('mydef::global'
+  # in the examples)
+  #
+  # @param param The parameter that you wish to look up
+  #
+  # @param options Hash of options for regular ``lookup()``
+  #
+  #   * This **must** follow the syntax rules for the
+  #   Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+  #   * No other formats are supported!
+  #
+  # @see https://docs.puppet.com/puppet/latest/function.html#lookup - Lookup Function
+  #
+  # @return [Any] The discovered data from Hiera
+  dispatch :dlookup do
+    param          'String[1]', :define_id
+    param          'String[1]', :param
+    optional_param 'Any',       :options
+  end
+
+  # @param define_id
+  # The literal unique identifier of the defined type resource ('mydef::global'
+  # in the examples)
+  #
+  # @param param The parameter that you wish to look up
+  #
+  # @param resource_title The $title of the resource
+  #
+  # @param options Hash of options for regular ``lookup()``
+  #
+  #   * This **must** follow the syntax rules for the
+  #   Puppet ``lookup( [<NAME>], <OPTIONS HASH> )`` version of ``lookup()``
+  #   * No other formats are supported!
+  #
+  # @see https://docs.puppet.com/puppet/latest/function.html#lookup - Lookup Function
+  #
+  # @return [Any] The discovered data from Hiera
+  dispatch :dlookup_specific do
+    param          'String[1]', :define_id
+    param          'String[1]', :param
+    param          'String[1]', :resource_title
+    optional_param 'Any',       :options
+  end
+
+  def dlookup(define_id, param, options)
+    target_param = "Define[#{define_id}]::#{param}"
+
+    return call_function('simplib::lookup', target_param, options )
+  end
+
+  def dlookup_specific(define_id, param, resource_title, options)
+    target_param = "#{define_id.split('::').map(&:capitalize).join('::')}[#{resource_title}]::#{param}"
+
+    retval = call_function('simplib::lookup', target_param, options)
+
+    # Fall back to the global lookup for this option
+    if options['default_value'] && retval == options['default_value']
+      retval = dlookup(define_id, param, options)
+    end
+
+    return retval
+  end
+end

--- a/lib/puppet/functions/simplib/gen_random_password.rb
+++ b/lib/puppet/functions/simplib/gen_random_password.rb
@@ -19,7 +19,7 @@ Puppet::Functions.create_function(:'simplib::gen_random_password') do
   #
   # @return [String] Generated password
   #
-  # @raise RuntimeError if password cannot be created within allotted time
+  # @raise [RuntimeError] if password cannot be created within allotted time
   dispatch :gen_random_password do
     required_param 'Integer[8]',                   :length
     optional_param 'Integer[0,2]',                 :complexity

--- a/lib/puppet/functions/simplib/nets2cidr.rb
+++ b/lib/puppet/functions/simplib/nets2cidr.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'simplib::nets2cidr') do
   # @param network_list List of 1 or more networks separated by spaces,
   #   commas, or semicolons
   # @return [Array[String]] Array of networks in CIDR notation
-  # @raise RuntimeError if any input item is not a valid network
+  # @raise [RuntimeError] if any input item is not a valid network
   #   or hostname
   #
   # @example Convert space-separated network string
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:'simplib::nets2cidr') do
 
   # @param networks Array of networks
   # @return [Array[String]] Array of networks in CIDR notation
-  # @raise RuntimeError if any input item is not a valid network
+  # @raise [RuntimeError] if any input item is not a valid network
   #   or hostname
   #
   # @example Convert array of networks

--- a/lib/puppet/functions/simplib/nets2ddq.rb
+++ b/lib/puppet/functions/simplib/nets2ddq.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'simplib::nets2ddq') do
 
   # @param networks The networks to convert
   # @return [Array[String]] Converted input
-  # @raise RuntimeError if any input item is not a valid network
+  # @raise [RuntimeError] if any input item is not a valid network
   #   or hostname
   #
   # @example Convert Array input
@@ -34,7 +34,7 @@ Puppet::Functions.create_function(:'simplib::nets2ddq') do
   # @param networks_string String containing the list of networks to
   #   convert; list elements are separated by spaces, commas or semicolons.
   # @return [Array[String]] Converted input
-  # @raise RuntimeError if any input item is not a valid network
+  # @raise [RuntimeError] if any input item is not a valid network
   #   or hostname
   #
   # @example Convert String input

--- a/lib/puppet/functions/simplib/parse_hosts.rb
+++ b/lib/puppet/functions/simplib/parse_hosts.rb
@@ -14,9 +14,9 @@ Puppet::Functions.create_function(:'simplib::parse_hosts') do
   # @param hosts Array of host entries, where each entry may contain
   #   a protocol or both a protocol and port
   # @return [Hash] Structured Hash of the host information
-  # @raise RuntimeError if a valid network or hostname cannot be
+  # @raise [RuntimeError] if a valid network or hostname cannot be
   #   extracted from all input items
-  # @raise RuntimeError if any input item that contains a port
+  # @raise [RuntimeError] if any input item that contains a port
   #   specifies an invalid port
   # @example Input with multiple host formats:
   #

--- a/lib/puppet/functions/simplib/strip_ports.rb
+++ b/lib/puppet/functions/simplib/strip_ports.rb
@@ -11,7 +11,7 @@ Puppet::Functions.create_function(:'simplib::strip_ports') do
   # @param hosts List of hosts which may contain protocols and port numbers.
   #
   # @return [Array[String]] Non-port portion of hostnames
-  # @raise RuntimeError if any input item that contains a port
+  # @raise [RuntimeError] if any input item that contains a port
   #   specifies an invalid port
   #
   # @example

--- a/lib/puppet/functions/simplib/to_integer.rb
+++ b/lib/puppet/functions/simplib/to_integer.rb
@@ -7,7 +7,7 @@ Puppet::Functions.create_function(:'simplib::to_integer') do
 
   # @param input The argument to convert into an `Integer`
   # @return [Integer] Converted input
-  # @raise 'RuntimeError' if ``input`` does not implement a ``to_i()``
+  # @raise [RuntimeError] if ``input`` does not implement a ``to_i()``
   #   method
   dispatch :to_integer do
     required_param 'Any', :input

--- a/lib/puppet/functions/simplib/validate_array_member.rb
+++ b/lib/puppet/functions/simplib/validate_array_member.rb
@@ -16,7 +16,7 @@ Puppet::Functions.create_function(:'simplib::validate_array_member') do
   #   operation.  Currently, 'i', string case invariance is the only
   #   supported modifier.
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Validating single input
   #

--- a/lib/puppet/functions/simplib/validate_between.rb
+++ b/lib/puppet/functions/simplib/validate_between.rb
@@ -9,7 +9,7 @@ Puppet::Functions.create_function(:'simplib::validate_between') do
   # @param min_value Minimum value that is valid
   # @param max_value Maximum value that is valid
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   simplib::validate_between('-1', -3, 0)

--- a/lib/puppet/functions/simplib/validate_bool.rb
+++ b/lib/puppet/functions/simplib/validate_bool.rb
@@ -7,7 +7,7 @@ Puppet::Functions.create_function(:'simplib::validate_bool') do
 
   # @param values_to_validate One or more values to validate
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   # @example Passing validation
   #
   #     $iamtrue = true

--- a/lib/puppet/functions/simplib/validate_deep_hash.rb
+++ b/lib/puppet/functions/simplib/validate_deep_hash.rb
@@ -36,7 +36,7 @@ Puppet::Functions.create_function(:'simplib::validate_deep_hash') do
   #
   # @param to_check Hash to be validated against the reference
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing Examples
   #   reference = {

--- a/lib/puppet/functions/simplib/validate_net_list.rb
+++ b/lib/puppet/functions/simplib/validate_net_list.rb
@@ -13,7 +13,7 @@ Puppet::Functions.create_function(:'simplib::validate_net_list') do
   # @param str_match Stringified regular expression (regex without
   #   the `//` delimiters)
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #
@@ -43,7 +43,7 @@ Puppet::Functions.create_function(:'simplib::validate_net_list') do
   # @param str_match Stringified regular expression (regex without
   #   the `//` delimiters)
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #

--- a/lib/puppet/functions/simplib/validate_port.rb
+++ b/lib/puppet/functions/simplib/validate_port.rb
@@ -13,7 +13,7 @@ Puppet::Functions.create_function(:'simplib::validate_port') do
   # @param port_args Arguments each of which contain either an
   #   individual port or an array of ports.
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   $port = '10541'

--- a/lib/puppet/functions/simplib/validate_re_array.rb
+++ b/lib/puppet/functions/simplib/validate_re_array.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:'simplib::validate_re_array') do
   #
   # @param err_msg Optional error message to emit upon failure
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   simplib::validate_re_array('one', '^one$')
@@ -35,7 +35,7 @@ Puppet::Functions.create_function(:'simplib::validate_re_array') do
   #
   # @param err_msg Optional error message to emit upon failure
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   simplib::validate_re_array('one', [ '^one', '^two' ])
@@ -59,7 +59,7 @@ Puppet::Functions.create_function(:'simplib::validate_re_array') do
   #
   # @param err_msg Optional error message to emit upon failure
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   simplib::validate_re_array(['one-a', 'one-b'], [ '^one', '^two' ])
@@ -82,7 +82,7 @@ Puppet::Functions.create_function(:'simplib::validate_re_array') do
   #    regexes without the `//` delimiters)
   # @param err_msg Optional error message to emit upon failure
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   #
   # @example Passing
   #   simplib::validate_re_array(['one-a', 'one-b'], [ '^one', '^two' ])

--- a/lib/puppet/functions/simplib/validate_sysctl_value.rb
+++ b/lib/puppet/functions/simplib/validate_sysctl_value.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:'simplib::validate_sysctl_value') do
   # @param key sysctl setting whose value is to be validated
   # @param value Value to be validated
   # @return [Nil]
-  # @raise RuntimeError upon validation failure
+  # @raise [RuntimeError] upon validation failure
   # @example Passing validation
   #   validate_sysctl_value('kernel.core_pattern','/var/core/%u_%g_%p_%t_%h_%e.core')
 

--- a/lib/puppet/functions/simplib/validate_uri_list.rb
+++ b/lib/puppet/functions/simplib/validate_uri_list.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'simplib::validate_uri_list') do
   # @param uri URI to be validated.
   # @param scheme_list List of schemes (protocol types) allowed for the URI.
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   # @example Passing
   #   $uri = 'http://foo.bar.baz:1234'
   #   simplib::validate_uri_list($uri)
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:'simplib::validate_uri_list') do
   # @param uri_list 1 or more URIs to be validated.
   # @param scheme_list List of schemes (protocol types) allowed for the URI.
   # @return [Nil]
-  # @raise RuntimeError if validation fails
+  # @raise [RuntimeError] if validation fails
   # @example Passing
   #   $uris = ['http://foo.bar.baz:1234','ldap://my.ldap.server']
   #   simplib::validate_uri_list($uris)

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,4 +1,4 @@
 ---
-rsync::server : 'rsync.bar.baz'
-rsync::timeout : '1'
-yum::server : 'yum.bar.baz'
+rsync::server: 'rsync.bar.baz'
+rsync::timeout: '1'
+yum::server: 'yum.bar.baz'

--- a/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
+++ b/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
@@ -1,0 +1,3 @@
+---
+Define[mydef::test]::attribute: illusions
+Mydef::Test[tobias]::attribute: blueman

--- a/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
+++ b/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
@@ -1,3 +1,3 @@
 ---
-Define[mydef::test]::attribute: illusions
+mydef::test::attribute: illusions
 Mydef::Test[tobias]::attribute: blueman

--- a/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
+++ b/spec/fixtures/hieradata/simplib_dlookup_overrides.yaml
@@ -1,3 +1,8 @@
 ---
 mydef::test::attribute: illusions
 Mydef::Test[tobias]::attribute: blueman
+
+mydef::othertest::attribute: illusions
+# this will not be used because mydef::othertest does not use the form
+# of dlookup that supports this
+Mydef::Othertest[tobias]::attribute: blueman

--- a/spec/functions/simplib/dlookup_spec.rb
+++ b/spec/functions/simplib/dlookup_spec.rb
@@ -34,10 +34,6 @@ describe 'simplib::stages', type: :class do
     }}
 
     let(:hieradata){ 'simplib_dlookup_overrides' }
-    let(:hiera_data){{
-      'Define[mydef::test]::attribute' => 'illusions',
-      'foo::bar' => 'baz'
-    }}
 
     context 'with global overrides' do
       it { expect(gob[:attribute]).to eq('illusions') }

--- a/spec/functions/simplib/dlookup_spec.rb
+++ b/spec/functions/simplib/dlookup_spec.rb
@@ -10,14 +10,28 @@ describe 'simplib::stages', type: :class do
       notify { "$title says": message => $attribute }
     }
 
+    define mydef::othertest (
+      $attribute = simplib::dlookup('mydef::test', 'attribute', { 'default_value' => 'lucille2' })
+    ){
+      notify { "other $title says": message => $attribute }
+    }
+
     mydef::test { 'gob': }
     mydef::test { 'tobias': }
     mydef::test { 'michael': attribute => 'bananastand' }
+
+    mydef::othertest { 'gob': }
+    mydef::othertest { 'tobias': }
+    mydef::othertest { 'michael': attribute => 'bananastand' }
   )}
 
   let(:gob){catalogue.resource('Mydef::Test[gob]')}
   let(:tobias){catalogue.resource('Mydef::Test[tobias]')}
   let(:michael){catalogue.resource('Mydef::Test[michael]')}
+
+  let(:gob_other){catalogue.resource('Mydef::Othertest[gob]')}
+  let(:tobias_other){catalogue.resource('Mydef::Othertest[tobias]')}
+  let(:michael_other){catalogue.resource('Mydef::Othertest[michael]')}
 
   it { is_expected.to compile.with_all_deps }
 
@@ -25,6 +39,9 @@ describe 'simplib::stages', type: :class do
     it { expect(gob[:attribute]).to eq('lucille2') }
     it { expect(tobias[:attribute]).to eq('lucille2') }
     it { expect(michael[:attribute]).to eq('bananastand') }
+    it { expect(gob_other[:attribute]).to eq('lucille2') }
+    it { expect(tobias_other[:attribute]).to eq('lucille2') }
+    it { expect(michael_other[:attribute]).to eq('bananastand') }
   end
 
   context 'overrides' do
@@ -37,12 +54,15 @@ describe 'simplib::stages', type: :class do
 
     context 'with global overrides' do
       it { expect(gob[:attribute]).to eq('illusions') }
+      it { expect(gob_other[:attribute]).to eq('illusions') }
+      it { expect(tobias_other[:attribute]).to eq('illusions') }
     end
     context 'with specific overrides' do
       it { expect(tobias[:attribute]).to eq('blueman') }
     end
     context 'with a static value' do
       it { expect(michael[:attribute]).to eq('bananastand') }
+      it { expect(michael_other[:attribute]).to eq('bananastand') }
     end
   end
 end

--- a/spec/functions/simplib/dlookup_spec.rb
+++ b/spec/functions/simplib/dlookup_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+# This just gives us a hook so that we can call the function later on
+describe 'simplib::stages', type: :class do
+
+  let(:pre_condition) {%(
+    define mydef::test (
+      $attribute = simplib::dlookup('mydef::test', 'attribute', $title, { 'default_value' => 'lucille2' })
+    ){
+      notify { "$title says": message => $attribute }
+    }
+
+    mydef::test { 'gob': }
+    mydef::test { 'tobias': }
+    mydef::test { 'michael': attribute => 'bananastand' }
+  )}
+
+  let(:gob){catalogue.resource('Mydef::Test[gob]')}
+  let(:tobias){catalogue.resource('Mydef::Test[tobias]')}
+  let(:michael){catalogue.resource('Mydef::Test[michael]')}
+
+  it { is_expected.to compile.with_all_deps }
+
+  context 'no overrides' do
+    it { expect(gob[:attribute]).to eq('lucille2') }
+    it { expect(tobias[:attribute]).to eq('lucille2') }
+    it { expect(michael[:attribute]).to eq('bananastand') }
+  end
+
+  context 'overrides' do
+    let(:facts){{
+      :cache_bust => Time.now.to_s,
+      :hieradata => 'simplib_dlookup_overrides'
+    }}
+
+    let(:hieradata){ 'simplib_dlookup_overrides' }
+    let(:hiera_data){{
+      'Define[mydef::test]::attribute' => 'illusions',
+      'foo::bar' => 'baz'
+    }}
+
+    context 'with global overrides' do
+      it { expect(gob[:attribute]).to eq('illusions') }
+    end
+    context 'with specific overrides' do
+      it { expect(tobias[:attribute]).to eq('blueman') }
+    end
+    context 'with a static value' do
+      it { expect(michael[:attribute]).to eq('bananastand') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -186,7 +186,7 @@ RSpec.configure do |c|
 
   c.after(:each) do
     # clean up the mocked environmentpath
-    FileUtils.rm_rf(@spec_global_env_temp) if File.exist?(@spec_global_env_temp)
+    FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
 end


### PR DESCRIPTION
- Add a 'defined type' lookup capability, `simplib::dlookup` that provides a
  consistent method for retrieving defined type parameters from Hiera in an
  opt-in manner.
- Fixed various YARD documentation issues

SIMP-5940 #comment Add function to support defined type global lookups