### PR TITLE
(SIMP-MAINT) Fix syntax on simplib::ipaddresses signature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Feb 11 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.12.1-0
+- Fix simplib::ipaddresses signature
+
 * Wed Jan 30 2019 Jason Hane <hanej@users.noreply.github.com> - 3.12.0-0
 - Add a timeout to the `ipa` fact to prevent hangs during fact collection
 

--- a/lib/puppet/functions/simplib/ipaddresses.rb
+++ b/lib/puppet/functions/simplib/ipaddresses.rb
@@ -1,7 +1,7 @@
 # Return an `Array` of all IP addresses known to be associated with the
 # client, optionally excluding local addresses.
 #
-Puppet::Functions.create_function('simplib::ipaddresses') do
+Puppet::Functions.create_function(:'simplib::ipaddresses') do
 
   # @param only_remote Whether to exclude local addresses
   #   from the return value (e.g., '127.0.0.1').

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
Add missing ':' in the function declaration.