### PR TITLE
(SIMP-6304) Simplib::Cron::Weekday does not allow numeric 0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.14.1-0
+- Fixed bug in Simplib::Cron::Weekday type alias in which a numeric
+  value of 0 was not allowed.
+
 * Tue Mar 12 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 3.14.0-0
 - Add `Simplib::Cron::####_entry` set of datatypes for each of: minute, hour, month, 
   monthday, and weekday.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/type_aliases/cron/weekday_entry_spec.rb
+++ b/spec/type_aliases/cron/weekday_entry_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 
 describe 'Simplib::Cron::WeekDay_entry' do
   context 'with valid parameters' do
+    it { is_expected.to allow_value( 0 ) }
     it { is_expected.to allow_value( '0' ) }
     it { is_expected.to allow_value( 2 ) }
     it { is_expected.to allow_value( '2' ) }
     it { is_expected.to allow_value( '7' ) }  #Sunday can be 0 or 7
+    it { is_expected.to allow_value( 7 ) }  #Sunday can be 0 or 7
     it { is_expected.to allow_value( 'SUN' ) }
     it { is_expected.to allow_value( 'sun' ) }
     it { is_expected.to allow_value( '*' ) }

--- a/types/cron/weekday_entry.pp
+++ b/types/cron/weekday_entry.pp
@@ -1,7 +1,7 @@
 # Matches valid cron weekday parameter
 #
 # Tested with Rubular: https://rubular.com/r/uuFFu5ISzdRL7l
-type Simplib::Cron::WeekDay_entry = Variant[Integer[1,7],Pattern['^(?x)(?:\*|
+type Simplib::Cron::WeekDay_entry = Variant[Integer[0,7],Pattern['^(?x)(?:\*|
 (?i)(?:SUN|MON|TUE|WED|THU|FRI|SAT)|
 (?:\*\/(?:[0-7]))|
 (?:(?:[0-7])(?:(?:-[0-7])(?:\/[0-7])?)?)


### PR DESCRIPTION
Fixed bug in Simplib::Cron::Weekday type alias in which a numeric
value of 0 was not allowed.

SIMP-6304 #close