### PR TITLE
(SIMP-6251) Convert simp_version to Puppet 4 function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,16 @@
-* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.14.2-0
+* Thu Mar 21 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
+- Convert a subset of Puppet 3 functions to Puppet 4 and emit a
+  simplib deprecation warning when the Puppet 3 versions are called:
+  - simplib::simp_version() replaces deprecated simp_version().
+
+* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
 - Remove Puppet 3 validate_integer function that conflicts with the
   same-named Puppet 3 function provided by puppetlab-stdlib.  This
   conflict causes compilation failures with Puppet 6.
 
-* Tue Mar 19 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.14.2-0
+* Tue Mar 19 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.15.0-0
 - Removed simplib's `deep_merge()` 3.x function that conflicts with stdlib's
-  fully-equivalent `deep_merge()` function.  
+  fully-equivalent `deep_merge()` function.
   - Has no impact on uses of `deep_merge` (hence a bug fix not a major version
     change).
   - Eliminates 'Illegal method definition' errors caused by the conflict,

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,7 @@
 * [`simplib::parse_hosts`](#simplibparse_hosts): Convert an `Array` of items that may contain port numbers or protocols into a structured `Hash` of host information.  * Works with Hostnames 
 * [`simplib::passgen`](#simplibpassgen): Generates/retrieves a random password string or its hash for a passed identifier.  * Uses `Puppet.settings[:vardir]/simp/environments/$enviro
 * [`simplib::rand_cron`](#simplibrand_cron): Transforms an input string to one or more interval values for `cron`.  This can be used to avoid starting a certain cron job at the same  tim
+* [`simplib::simp_version`](#simplibsimp_version): Return the version of SIMP that this server is running or "unknown\n"
 * [`simplib::strip_ports`](#simplibstrip_ports): Extract list of unique hostnames and/or IP addresses from an `Array` of hosts, each of which may may contain protocols and/or port numbers  T
 * [`simplib::to_integer`](#simplibto_integer): Converts the argument into an `Integer`.  Terminates catalog compilation if the argument's class does not respond to the `to_i()` Ruby method
 * [`simplib::to_string`](#simplibto_string): Converts the argument into a `String`.
@@ -2125,6 +2126,27 @@ Data type: `Optional[Integer[1]]`
 The maximum value for the interval.  The values generated will
 be in the inclusive range [0, max_value]. Defaults to `60` for
 use in the `minute` cron field.
+
+### simplib::simp_version
+
+Type: Ruby 4.x API
+
+Return the version of SIMP that this server is running or "unknown\n"
+
+#### `simplib::simp_version(Optional[Boolean] $strip_whitespace)`
+
+Return the version of SIMP that this server is running or "unknown\n"
+
+Returns: `String` Version string if the version can be detected;
+"unknown\n" otherwise
+
+##### `strip_whitespace`
+
+Data type: `Optional[Boolean]`
+
+Whether to strip whitespace from the
+version string.  Without stripping, the string may end with
+a "\n"
 
 ### simplib::strip_ports
 

--- a/lib/puppet/functions/simplib/simp_version.rb
+++ b/lib/puppet/functions/simplib/simp_version.rb
@@ -1,0 +1,30 @@
+# Return the version of SIMP that this server is running or "unknown\n"
+Puppet::Functions.create_function(:'simplib::simp_version') do
+
+  # @param strip_whitespace Whether to strip whitespace from the
+  #   version string.  Without stripping, the string may end with
+  #   a "\n"
+  # @return [String] Version string if the version can be detected;
+  #   "unknown\n" otherwise
+  dispatch :simp_version do
+    optional_param 'Boolean', :strip_whitespace
+  end
+
+  def simp_version(strip_whitespace = false)
+    retval = "unknown\n"
+
+    begin
+      # TODO Figure out under what circumstances the version string is prefaced
+      # with 'simp-'. This is not true for SIMP 6.x
+      version = File.read('/etc/simp/simp.version').gsub('simp-','')
+      retval = version unless version.strip.empty?
+    rescue
+      rpm_query = %q{PATH='/usr/local/bin:/usr/bin:/bin' rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp 2>/dev/null}
+      version = `#{rpm_query}`
+      retval = version if $?.success?
+    end
+
+    retval.strip! if strip_whitespace
+    retval
+  end
+end

--- a/lib/puppet/parser/functions/simp_version.rb
+++ b/lib/puppet/parser/functions/simp_version.rb
@@ -5,6 +5,8 @@ module Puppet::Parser::Functions
     @return [String]
     EOM
 
+    function_simplib_deprecation(['simp_version', 'simp_version is deprecated, please use simplib::simp_version'])
+
     retval = "unknown\n"
 
     begin

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.14.2",
+  "version": "3.15.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/simp_version_spec.rb
+++ b/spec/functions/simplib/simp_version_spec.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::simp_version' do
+  context 'a valid version exists in /etc/simp/simp.version' do
+    it 'should return the version with whitespace retained' do
+      File.expects(:read).with('/etc/simp/simp.version').returns(" 6.4.0-0\n")
+      File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+
+      is_expected.to run.and_return(" 6.4.0-0\n")
+    end
+
+    it "should return the version with 'simp-' stripped" do
+      File.stubs(:read).with('/etc/simp/simp.version').returns("simp-5.4.0-0\n")
+      File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+
+      is_expected.to run.and_return("5.4.0-0\n")
+    end
+
+    it 'should return the version with whitespace stripped when stripping is enabled' do
+      File.stubs(:read).with('/etc/simp/simp.version').returns("6.4.0-0\n")
+      File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+
+      is_expected.to run.with_params(true).and_return('6.4.0-0')
+    end
+  end
+
+  context '/etc/simp/simp.version is empty' do
+    it 'should return unknown' do
+      File.stubs(:read).with('/etc/simp/simp.version').returns("")
+      File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+
+      is_expected.to run.and_return("unknown\n")
+    end
+  end
+
+  context '/etc/simp/simp.version does not exist' do
+    let(:rpm_query) do
+      %q{PATH='/usr/local/bin:/usr/bin:/bin' rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp 2>/dev/null}
+    end
+
+    context 'rpm query succeeds' do
+      it 'should return the version with whitespace retained' do
+        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
+        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+        subject.func.stubs(:`).with(rpm_query).returns("6.4.0-0\n")
+        $?.expects(:success?).returns(true)
+
+        is_expected.to run.and_return("6.4.0-0\n")
+      end
+
+      it 'should return the version with whitespace stripped when stripping is enabled' do
+        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
+        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+        subject.func.stubs(:`).with(rpm_query).returns("6.4.0-0\n")
+        $?.expects(:success?).returns(true)
+
+        is_expected.to run.with_params(true).and_return('6.4.0-0')
+      end
+    end
+
+    context 'rpm query fails' do
+      it 'should return unknown' do
+        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
+        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+        subject.func.stubs(:`).with(rpm_query).returns("package simp is not installed\n")
+        $?.expects(:success?).returns(false)
+
+        is_expected.to run.and_return("unknown\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Converted simp_version Puppet 3 function to a Puppet 4
  version, simplib::simp_version
- Added a unit test for simplib::simp_version
- Added deprecation warning to simp_version

SIMP-6251 #close