### PR TITLE
(SIMP-6319) Deprecate unused simplib functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,24 @@
-* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.14.2-0
+* Thu Mar 21 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
+- Deprecated Puppet 3 functions that are not used by any SIMP
+  modules.  The functions will be removed in a future release,
+  unless SIMP receives requests from users to convert them to
+  namespaced Puppet 4.x functions.
+  - array_union
+  - generate_reboot_msg
+  - get_ports
+  - h2n
+  - ip_is_me
+  - localuser
+  - mapval
+  - validate_array_of_hashes
+  - validate_float
+
+* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
 - Remove Puppet 3 validate_integer function that conflicts with the
   same-named Puppet 3 function provided by puppetlab-stdlib.  This
   conflict causes compilation failures with Puppet 6.
 
-* Tue Mar 19 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.14.2-0
+* Tue Mar 19 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.15.0-0
 - Removed simplib's `deep_merge()` 3.x function that conflicts with stdlib's
   fully-equivalent `deep_merge()` function.  
   - Has no impact on uses of `deep_merge` (hence a bug fix not a major version

--- a/lib/puppet/parser/functions/array_union.rb
+++ b/lib/puppet/parser/functions/array_union.rb
@@ -15,6 +15,8 @@ module Puppet::Parser::Functions
     @return [Array]
     ENDHEREDOC
 
+    function_simplib_deprecation(['array_union', 'array_union is deprecated and will be removed in a future release'])
+
     unless args.length == 2
       raise Puppet::ParseError, ("array_union(): wrong number of arguments (#{args.length}; must be 2)")
     end

--- a/lib/puppet/parser/functions/generate_reboot_msg.rb
+++ b/lib/puppet/parser/functions/generate_reboot_msg.rb
@@ -23,6 +23,8 @@ module Puppet::Parser::Functions
     @return [String]
     ENDHEREDOC
 
+    function_simplib_deprecation(['generate_reboot_msg', 'generate_reboot_msg is deprecated and will be removed in a future release'])
+
     input_hash = input_hash.shift
 
     raise(Puppet::ParseError,"Error: input to generate_reboot() must be a Hash, got '#{input_hash.class}'") unless input_hash.is_a?(Hash)

--- a/lib/puppet/parser/functions/get_ports.rb
+++ b/lib/puppet/parser/functions/get_ports.rb
@@ -12,6 +12,8 @@ module Puppet::Parser::Functions
     @return [Array[String]]
     EOM
 
+    function_simplib_deprecation(['get_ports', 'get_ports is deprecated and will be removed in a future release'])
+
     raise Puppet::ParseError, "You must pass a list of hosts." if args.empty?
     Puppet::Parser::Functions.autoloader.loadall
 

--- a/lib/puppet/parser/functions/h2n.rb
+++ b/lib/puppet/parser/functions/h2n.rb
@@ -10,6 +10,8 @@ module Puppet::Parser::Functions
 
     require 'resolv'
 
+    function_simplib_deprecation(['h2n', 'h2n is deprecated and will be removed in a future release'])
+
     to_find = args.first.to_s
     retval = to_find
 

--- a/lib/puppet/parser/functions/ip_is_me.rb
+++ b/lib/puppet/parser/functions/ip_is_me.rb
@@ -13,6 +13,8 @@ module Puppet::Parser::Functions
     )
     require 'ipaddr'
 
+    function_simplib_deprecation(['ip_is_me', 'ip_is_me is deprecated and will be removed in a future release'])
+
     if args.class.eql?(Array) then
       f_args = args.dup
     else

--- a/lib/puppet/parser/functions/localuser.rb
+++ b/lib/puppet/parser/functions/localuser.rb
@@ -42,6 +42,9 @@ module Puppet::Parser::Functions
 
     @return [String]
     ENDHEREDOC
+
+    function_simplib_deprecation(['localuser', 'localuser is deprecated and will be removed in a future release'])
+
     filename = args[0]
     hostname = args[1]
     retval = []

--- a/lib/puppet/parser/functions/mapval.rb
+++ b/lib/puppet/parser/functions/mapval.rb
@@ -16,6 +16,8 @@ module Puppet::Parser::Functions
     @return [String]
     EOM
 
+    function_simplib_deprecation(['mapval', 'mapval is deprecated and will be removed in a future release'])
+
     regex = args[0]
     filename = args[1]
     retval = ''

--- a/lib/puppet/parser/functions/validate_array_of_hashes.rb
+++ b/lib/puppet/parser/functions/validate_array_of_hashes.rb
@@ -12,6 +12,8 @@ module Puppet::Parser::Functions
     @return [Boolean]
     ENDHEREDOC
 
+    function_simplib_deprecation(['validate_array_of_hashes', 'validate_array_of_hashes is deprecated and will be removed in a future release'])
+
     unless args.length == 1
       raise Puppet::ParseError, ("validate_array_of_hashes(): expects exactly one argument. Got '#{args.length}'")
     end

--- a/lib/puppet/parser/functions/validate_float.rb
+++ b/lib/puppet/parser/functions/validate_float.rb
@@ -5,6 +5,8 @@ module Puppet::Parser::Functions
     @return [Nil]
     EOS
 
+    function_simplib_deprecation(['validate_float', 'validate_float is deprecated and will be removed in a future release'])
+
     if (args.size != 1)
       raise(Puppet::ParseError, "is_float(): Wrong number of args "+
         "given #{args.size} for 1")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.14.2",
+  "version": "3.15.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
Deprecated Puppet 3 functions that are not used by any SIMP
modules.  The functions will be removed in a future release,
unless SIMP receives requests from users to convert them to
namespaced Puppet 4.x functions.
  - array_union
  - generate_reboot_msg
  - get_ports
  - h2n
  - ip_is_me
  - localuser
  - mapval
  - validate_array_of_hashes
  - validate_float

SIMP-6319 #close