### PR TITLE
(SIMP-6320) Deprecate duplicate Puppet 3 functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
 * Thu Mar 21 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
+- Deprecated simplib Puppet 3 functions for which corresponding,
+  though not identically behaving, Puppet builtins or stdlib
+  functions exist.  The functions will be removed in a future
+  release, unless SIMP receives requests from users to convert
+  them to namespaced Puppet 4.x functions.
+  - array_include() can often be replaced with stdlib member()
+  - array_size() can often be replaced with the Puppet builtin length()
 - Deprecated Puppet 3 functions that are not used by any SIMP
   modules.  The functions will be removed in a future release,
   unless SIMP receives requests from users to convert them to
@@ -16,8 +23,7 @@
   simplib deprecation warning when the Puppet 3 versions are called:
   - simplib::host_is_me() replaces deprecated host_is_me().
 
-
-* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.0-0
+* Wed Mar 20 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.14.2-0
 - Remove Puppet 3 validate_integer function that conflicts with the
   same-named Puppet 3 function provided by puppetlab-stdlib.
   - Has no impact on uses of `validate_integer` (hence a bug fix not a major

--- a/lib/puppet/parser/functions/array_include.rb
+++ b/lib/puppet/parser/functions/array_include.rb
@@ -21,6 +21,8 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
+    function_simplib_deprecation(['array_include', "array_include is deprecated, please use stdlib's member"])
+
     unless args.length == 2
       raise Puppet::ParseError, ("array_include(): wrong number of arguments (#{args.length}; must be 2)")
     end

--- a/lib/puppet/parser/functions/array_include.rb
+++ b/lib/puppet/parser/functions/array_include.rb
@@ -21,7 +21,7 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
-    function_simplib_deprecation(['array_include', "array_include is deprecated, please use stdlib's member"])
+    function_simplib_deprecation(['array_include', "array_include is deprecated, please use puppetlabs-stdlib's 'member()'"])
 
     unless args.length == 2
       raise Puppet::ParseError, ("array_include(): wrong number of arguments (#{args.length}; must be 2)")

--- a/lib/puppet/parser/functions/array_size.rb
+++ b/lib/puppet/parser/functions/array_size.rb
@@ -9,7 +9,7 @@ module Puppet::Parser::Functions
     @return [Integer]
     ENDHEREDOC
 
-    function_simplib_deprecation(['array_size', "array_size is deprecated, please use builtin length"])
+    function_simplib_deprecation(['array_size', "array_size is deprecated, please use builtin 'length()'"])
 
     unless args.length == 1
       raise Puppet::ParseError, ("array_size(): Exactly one argument must be passed.")

--- a/lib/puppet/parser/functions/array_size.rb
+++ b/lib/puppet/parser/functions/array_size.rb
@@ -9,6 +9,8 @@ module Puppet::Parser::Functions
     @return [Integer]
     ENDHEREDOC
 
+    function_simplib_deprecation(['array_size', "array_size is deprecated, please use builtin length"])
+
     unless args.length == 1
       raise Puppet::ParseError, ("array_size(): Exactly one argument must be passed.")
     end


### PR DESCRIPTION
Deprecated simplib Puppet 3 functions for which corresponding,
though not identically behaving, Puppet builtins or stdlib
functions exist.  The functions will be removed in a future
release, unless SIMP receives requests from users to convert
them to namespaced Puppet 4.x functions.
- array_include() can often be replaced with stdlib member()
- array_size() can often be replaced with the Puppet builtin length()

SIMP-6320 #close