### PR TITLE
(SIMP-6252) Deprecate Puppet 3 slice_array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
   them to namespaced Puppet 4.x functions.
   - array_include() can often be replaced with stdlib member()
   - array_size() can often be replaced with the Puppet builtin length()
+  - slice_array() can often be replace with the Puppet builtin slice()
 - Deprecated Puppet 3 functions that are not used by any SIMP
   modules.  The functions will be removed in a future release,
   unless SIMP receives requests from users to convert them to

--- a/lib/puppet/parser/functions/slice_array.rb
+++ b/lib/puppet/parser/functions/slice_array.rb
@@ -17,6 +17,8 @@ module Puppet::Parser::Functions
     @return [Array[Array[Any]]]]
     EOM
 
+    function_simplib_deprecation(['slice_array', "slice_array is deprecated, please use builtin 'slice()'"])
+
     # Variable Assignment
     to_slice = args[0]
     max_length = args[1]


### PR DESCRIPTION
Deprecated simplib's Puppet 3 slice_array for which a
corresponding, though not identically behaving, Puppet
builtin slice() exists.

NOTE: simplib's slice_array() is only used by pupmod-simp-iptables
and has functionality very specific to that module (i.e., split_char
logic to generate port ranges in iptables rules).  So, in lieu of
creating simplib::slice_array() from slice_array(), we are going
to create iptables::slice_array from slice_array() in
pupmod-simp-iptables.

SIMP-6252 #comment pupmod-simp-simplib