### PR TITLE
(SIMP-6506) Out Of Memory Error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu May 09 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.1-0
+- Updated simp_version function to use Puppet::Util::Execution.execute
+  instead of backtics.  This avioids a GLIBC error triggered by JRuby 9K when
+  backtics, system or %x are used.
+
 * Fri Apr 12 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 3.15.0-0
 - Added `simplib__sshd_config` fact to check the contents of sshd_config file
 

--- a/lib/puppet/parser/functions/simp_version.rb
+++ b/lib/puppet/parser/functions/simp_version.rb
@@ -24,7 +24,6 @@ module Puppet::Parser::Functions
       retval = version if version
     end
 
-    retval.strip! if strip_whitespace
     retval
   end
 end

--- a/lib/puppet/parser/functions/simp_version.rb
+++ b/lib/puppet/parser/functions/simp_version.rb
@@ -9,13 +9,22 @@ module Puppet::Parser::Functions
 
     retval = "unknown\n"
 
-    begin
-      retval = File.read('/etc/simp/simp.version').gsub('simp-','')
-    rescue
-      tmpval = %x{PATH='/usr/local/bin:/usr/bin:/bin'; rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp}
-      $?.success? and retval = tmpval
+    if File.readable?('/etc/simp/simp.version')
+    # TODO Figure out under what circumstances the version string is prefaced
+    # with 'simp-'. This is not true for SIMP 6.x
+      version = File.read('/etc/simp/simp.version').gsub('simp-','')
+      retval = version unless version.strip.empty?
+    else
+      rpm_query = %q{PATH='/usr/local/bin:/usr/bin:/bin' rpm -q --qf '%{VERSION}-%{RELEASE}\n' simp 2>/dev/null}
+      begin
+        version = Puppet::Util::Execution.execute(rpm_query, :failonfail => true)
+      rescue Puppet::ExecutionFailure
+        version = nil
+      end
+      retval = version if version
     end
 
+    retval.strip! if strip_whitespace
     retval
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/simp_version_spec.rb
+++ b/spec/functions/simplib/simp_version_spec.rb
@@ -5,12 +5,14 @@ describe 'simplib::simp_version' do
   context 'a valid version exists in /etc/simp/simp.version' do
     it 'should return the version with whitespace retained' do
       File.expects(:read).with('/etc/simp/simp.version').returns(" 6.4.0-0\n")
+      File.stubs(:readable?).with('/etc/simp/simp.version').returns(true)
       File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
 
       is_expected.to run.and_return(" 6.4.0-0\n")
     end
 
     it "should return the version with 'simp-' stripped" do
+      File.stubs(:readable?).with('/etc/simp/simp.version').returns(true)
       File.stubs(:read).with('/etc/simp/simp.version').returns("simp-5.4.0-0\n")
       File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
 
@@ -18,6 +20,7 @@ describe 'simplib::simp_version' do
     end
 
     it 'should return the version with whitespace stripped when stripping is enabled' do
+      File.stubs(:readable?).with('/etc/simp/simp.version').returns(true)
       File.stubs(:read).with('/etc/simp/simp.version').returns("6.4.0-0\n")
       File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
 
@@ -28,6 +31,7 @@ describe 'simplib::simp_version' do
   context '/etc/simp/simp.version is empty' do
     it 'should return unknown' do
       File.stubs(:read).with('/etc/simp/simp.version').returns("")
+      File.stubs(:readable?).with('/etc/simp/simp.version').returns(true)
       File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
 
       is_expected.to run.and_return("unknown\n")
@@ -41,19 +45,15 @@ describe 'simplib::simp_version' do
 
     context 'rpm query succeeds' do
       it 'should return the version with whitespace retained' do
-        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
-        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
-        subject.func.stubs(:`).with(rpm_query).returns("6.4.0-0\n")
-        $?.expects(:success?).returns(true)
+        File.stubs(:readable?).with('/etc/simp/simp.version').returns(false)
+        Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).returns("6.4.0-0\n")
 
         is_expected.to run.and_return("6.4.0-0\n")
       end
 
       it 'should return the version with whitespace stripped when stripping is enabled' do
-        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
-        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
-        subject.func.stubs(:`).with(rpm_query).returns("6.4.0-0\n")
-        $?.expects(:success?).returns(true)
+        File.stubs(:readable?).with('/etc/simp/simp.version').returns(false)
+        Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).returns("6.4.0-0\n")
 
         is_expected.to run.with_params(true).and_return('6.4.0-0')
       end
@@ -61,10 +61,12 @@ describe 'simplib::simp_version' do
 
     context 'rpm query fails' do
       it 'should return unknown' do
-        File.stubs(:read).with('/etc/simp/simp.version').raises(Errno::ENOENT)
-        File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
-        subject.func.stubs(:`).with(rpm_query).returns("package simp is not installed\n")
-        $?.expects(:success?).returns(false)
+        File.stubs(:readable?).with('/etc/simp/simp.version').returns(false)
+        Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).raises(Puppet::ExecutionFailure, "Failed")
+#        ({
+#         :exitstatus => 2,
+#         :stdout => "package simp is not installed\n"
+#        })
 
         is_expected.to run.and_return("unknown\n")
       end


### PR DESCRIPTION
- updated simp_version function to use Puppet::Util::Execution.execute
  instead of backtics.  This avoids a GLIBC error triggered by JRuby 9K.

SIMP-6506 #comment Also needs simp module update.