### PR TITLE
(SIMP-6515) Defer to inbuilt fips_enable fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue May 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.15.1-0
+- Defer to the inbuilt 'fips_enabled' fact if it exists.
+
 * Thu May 09 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.1-0
 - Updated simp_version function to use Puppet::Util::Execution.execute
   instead of backtics.  This avioids a GLIBC error triggered by JRuby 9K when

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue May 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.15.1-0
+* Tue May 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.15.2-0
 - Defer to the inbuilt 'fips_enabled' fact if it exists.
 
 * Thu May 09 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.1-0

--- a/lib/facter/fips_enabled.rb
+++ b/lib/facter/fips_enabled.rb
@@ -1,15 +1,20 @@
 # Determine whether or not FIPS is enabled on this system
 # Returns: Boolean
-Facter.add('fips_enabled') do
-  confine :kernel => 'Linux'
 
-  setcode do
-    status_file = '/proc/sys/crypto/fips_enabled'
+# This is a native fact in some versions of Puppet but we don't want to lose it
+# if it's not present.
+if Facter.value('fips_enabled').nil?
+  Facter.add('fips_enabled') do
+    confine :kernel => 'Linux'
 
-    if File.exist?(status_file) && File.open(status_file, &:readline)[0].chr == '1'
-      true
-    else
-      false
+    setcode do
+      status_file = '/proc/sys/crypto/fips_enabled'
+
+      if File.exist?(status_file) && File.open(status_file, &:readline)[0].chr == '1'
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/fips_enabled_fact_spec.rb
+++ b/spec/acceptance/suites/default/fips_enabled_fact_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper_acceptance'
+
+test_name 'fips_enabled fact'
+if ENV['BEAKER_fips'] == 'yes'
+  fips_state = 'enabled'
+  expected_fips_enabled = true
+else
+  fips_state = 'disabled'
+  expected_fips_enabled = false
+end
+
+describe 'fips_enabled fact' do
+
+  hosts.each do |host|
+    context "when FIPS is #{fips_state}" do
+      it "fips_enabled fact should be #{expected_fips_enabled}" do
+        results = on(host, 'puppet facts')
+        expect(results.output).to match(/"fips_enabled": #{expected_fips_enabled}/)
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/inspect_spec.rb
+++ b/spec/acceptance/suites/default/inspect_spec.rb
@@ -28,8 +28,7 @@ end
 
 describe 'inspect function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "logs variables with deprecated inspect" do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/inspect_spec.rb
+++ b/spec/acceptance/suites/default/inspect_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 test_name 'inspect function'
 
-def normalize(puppet_log)
+def normalize(puppet_log, keep_warning_lines_only = false)
   # remove normal puppet log lines and inspect/simplib::inspect
   # 'puts' lines, as their ordering relative to the Puppet warning
   # lines is non-deterministic
@@ -14,6 +14,9 @@ def normalize(puppet_log)
     line.match(/^Inspect:/)
   end
 
+  if keep_warning_lines_only
+    normalized_lines.delete_if { |line| !line.include?('Warning: ') }
+  end
 
   normalized_log = normalized_lines.join("\n")
   # remove color formatting
@@ -48,13 +51,12 @@ describe 'inspect function' do
         results = apply_manifest_on(server, manifest)
 
         expected = %r|Warning: inspect is deprecated, please use simplib::inspect
-\s+\(at /etc/puppetlabs/code/environments/production/modules/simplib/lib/puppet/parser/functions/simplib_deprecation\.rb:\d+:in `block in <module:Functions>'\)
 Warning: Inspect: Type => 'String' Content => '"var1 value"'
 Warning: Inspect: Type => 'TrueClass' Content => 'true'
 Warning: Inspect: Type => 'Hash' Content => '\{"a":"b"\}'
 Warning: Inspect: Type => 'String' Content => '""'|
 
-        expect(normalize(results.output)).to match(expected)
+        expect(normalize(results.output, true)).to match(expected)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('inspect is deprecated, please use simplib::inspect')
@@ -95,10 +97,6 @@ Notice: /Stage[main]/Main/Notify[DEBUG_INSPECT_var3]/message: defined 'message' 
 Notice: Type => NilClass Content => null
 Notice: /Stage[main]/Main/Notify[DEBUG_INSPECT_var4]/message: defined 'message' as 'Type => NilClass Content => null'
 EOM
-
-puts '<'*80
-puts normalize(results.output).inspect
-puts '>'*80
 
         expect(normalize(results.output)).to eq(expected)
 

--- a/spec/acceptance/suites/default/ipaddresses_spec.rb
+++ b/spec/acceptance/suites/default/ipaddresses_spec.rb
@@ -4,8 +4,7 @@ test_name 'ipaddresses function'
 
 describe 'ipaddresses function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     let(:all_ips) do
       ifaces = fact_on(server, 'interfaces').split(',').map(&:strip)
 

--- a/spec/acceptance/suites/default/nets2ddq_spec.rb
+++ b/spec/acceptance/suites/default/nets2ddq_spec.rb
@@ -4,8 +4,7 @@ test_name 'nets2ddq function'
 
 describe 'nets2ddq function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'when nets2ddq' do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/parse_hosts_spec.rb
+++ b/spec/acceptance/suites/default/parse_hosts_spec.rb
@@ -4,8 +4,7 @@ test_name 'parse_hosts function'
 
 describe 'parse_hosts function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when parse_hosts called" do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/passgen_spec.rb
+++ b/spec/acceptance/suites/default/passgen_spec.rb
@@ -9,8 +9,7 @@ end
 
 describe 'passgen function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     hash_algorithms.each do |hash|
       (1..10).each do |round|
       context "when set user 'testuser#{round}' to password 'test' and hash type == #{hash}" do

--- a/spec/acceptance/suites/default/strip_ports_spec.rb
+++ b/spec/acceptance/suites/default/strip_ports_spec.rb
@@ -4,8 +4,7 @@ test_name 'strip_ports function'
 
 describe 'strip_ports function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when strip_ports called" do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/to_integer_spec.rb
+++ b/spec/acceptance/suites/default/to_integer_spec.rb
@@ -4,8 +4,7 @@ test_name 'to_integer function'
 
 describe 'to_integer function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when to_integer called" do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/to_integer_spec.rb
+++ b/spec/acceptance/suites/default/to_integer_spec.rb
@@ -19,8 +19,8 @@ describe 'to_integer function' do
       it 'should return an integer and log a single deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
-        expect(results.output).to match(/Notice: Type => Fixnum Content => 10/)
-        expect(results.output).to match(/Notice: Type => Fixnum Content => 2345/)
+        expect(results.output).to match(/Notice: Type => (Fixnum|Integer) Content => 10/)
+        expect(results.output).to match(/Notice: Type => (Fixnum|Integer) Content => 2345/)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('to_integer is deprecated, please use simplib::to_integer')
@@ -44,8 +44,8 @@ describe 'to_integer function' do
       it 'should return an integer without logging a deprecation warning' do
         results = apply_manifest_on(server, manifest)
 
-        expect(results.output).to match(/Notice: Type => Fixnum Content => -1/)
-        expect(results.output).to match(/Notice: Type => Fixnum Content => 24/)
+        expect(results.output).to match(/Notice: Type => (Fixnum|Integer) Content => -1/)
+        expect(results.output).to match(/Notice: Type => (Fixnum|Integer) Content => 24/)
 
         deprecation_lines = results.output.split("\n").delete_if do |line|
           !line.include?('to_integer is deprecated, please use simplib::to_integer')

--- a/spec/acceptance/suites/default/to_string_spec.rb
+++ b/spec/acceptance/suites/default/to_string_spec.rb
@@ -4,8 +4,7 @@ test_name 'to_string function'
 
 describe 'to_string function' do
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when to_string called" do
       let (:manifest) {
         <<-EOS

--- a/spec/acceptance/suites/default/validate_array_member_spec.rb
+++ b/spec/acceptance/suites/default/validate_array_member_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_array_member function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'when validate_array_member called' do
 
       it 'should accept element that is in array' do

--- a/spec/acceptance/suites/default/validate_between_spec.rb
+++ b/spec/acceptance/suites/default/validate_between_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_between function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'when validate_between called' do
 
       it 'should accept element within range' do

--- a/spec/acceptance/suites/default/validate_bool_simp_spec.rb
+++ b/spec/acceptance/suites/default/validate_bool_simp_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_bool_simp function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'when validate_bool_simp called' do
 
       it 'should accept valid bool equivalent' do

--- a/spec/acceptance/suites/default/validate_deep_hash_spec.rb
+++ b/spec/acceptance/suites/default/validate_deep_hash_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_deep_hash function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'when validate_deep_hash called' do
 
       it 'should accept valid hash' do

--- a/spec/acceptance/suites/default/validate_net_list_spec.rb
+++ b/spec/acceptance/suites/default/validate_net_list_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_net_list function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when validate_net_list called" do
 
       it 'should accept valid netlist' do

--- a/spec/acceptance/suites/default/validate_port_spec.rb
+++ b/spec/acceptance/suites/default/validate_port_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_port function' do
     }
   end
 
- servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when validate_port called" do
 
       it 'should accept valid ports' do

--- a/spec/acceptance/suites/default/validate_uri_list_spec.rb
+++ b/spec/acceptance/suites/default/validate_uri_list_spec.rb
@@ -9,8 +9,7 @@ describe 'validate_uri_list function' do
     }
   end
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context "when validate_uri_list called" do
 
       it 'should accept valid URIs' do

--- a/spec/acceptance/suites/prelink_fact/prelink_fact_spec.rb
+++ b/spec/acceptance/suites/prelink_fact/prelink_fact_spec.rb
@@ -10,8 +10,7 @@ describe 'prelink fact' do
     EOS
   }
 
-  servers = hosts_with_role(hosts, 'server')
-  servers.each do |server|
+  hosts.each do |server|
     context 'prepare clean environment' do
       it 'removes prelink when installed' do
         installed =  check_for_package(server, 'prelink')


### PR DESCRIPTION
Some version of facter have a built-in 'fips_enabled' fact. We now defer
to that one prior to adding our own fact.

Note: I was unable to determine how to properly unit test this but,
since the entire change is just checking for one item in Facter prior to
creating the fact, this isn't vastly different from the previous code
version (which also didn't have a unit test)

SIMP-6591 #close