### PR TITLE
(SIMP-MAINT) Prep for release - remove Puppet 4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    stdlib: https://github.com/simp/puppetlabs-stdlib
+    stdlib:
+      repo: https://github.com/simp/puppetlabs-stdlib
+      ref: 5.2.0
     # This needs to be in place for the rspec-puppet Hiera 5 hook to work
     # No idea why, it may be because Puppet sees a custom backend and loads all
     # of the global parts.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,8 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
-# SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
+# SIMP 6.3      5.5.10   2.4.5  TBD***
+# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
@@ -65,18 +63,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
-
 .pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
@@ -84,10 +70,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_7: &pup_5_5_7
+.pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.7'
+    PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -151,10 +137,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -170,12 +152,8 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.7-unit:
-  <<: *pup_5_5_7
-  <<: *unit_tests
-
-pup4.10-unit:
-  <<: *pup_4_10
+pup5.5.10-unit:
+  <<: *pup_5_5_10
   <<: *unit_tests
 
 pup6-unit:
@@ -184,100 +162,66 @@ pup6-unit:
 
 # Acceptance tests
 # ==============================================================================
-
-pup4.10:
+pup5.5.10:
   <<: *acceptance_base
-  <<: *pup_4_10
+  <<: *pup_5_5_10
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup4.10-fips:
+pup5.5.10-fips:
   <<: *acceptance_base
-  <<: *pup_4_10
-  <<: *only_with_SIMP_FULL_MATRIX
+  <<: *pup_5_5_10
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
-pup4.10-prelink_fact:
+pup5.5.10-prelink_fact:
   <<: *acceptance_base
-  <<: *pup_4_10
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[prelink_fact]'
-
-pup4.10-prelink_fact-fips:
-  <<: *acceptance_base
-  <<: *pup_4_10
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[prelink_fact]'
-
-pup4.10-ipa_fact:
-  <<: *acceptance_base
-  <<: *pup_4_10
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'bundle exec rake beaker:suites[ipa_fact]'
-
-pup5.5.7:
-  <<: *acceptance_base
-  <<: *pup_5_5_7
-  script:
-    - 'bundle exec rake beaker:suites[default]'
-
-pup5.5.7-fips:
-  <<: *acceptance_base
-  <<: *pup_5_5_7
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
-
-pup5.5.7-prelink_fact:
-  <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   script:
     - 'bundle exec rake beaker:suites[prelink_fact]'
 
-pup5.5.7-prelink_fact-fips:
+pup5.5.10-prelink_fact-fips:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[prelink_fact]'
 
-pup5.5.7-ipa_fact:
+pup5.5.10-ipa_fact:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   script:
     - 'bundle exec rake beaker:suites[ipa_fact]'
 
-pup5.5.7-oel:
+pup5.5.10-oel:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.7-oel-fips:
+pup5.5.10-oel-fips:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.7-oel-prelink_fact:
+pup5.5.10-oel-prelink_fact:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   script:
     - 'bundle exec rake beaker:suites[prelink_fact,oel]'
 
-pup5.5.7-oel-prelink_fact-fips:
+pup5.5.10-oel-prelink_fact-fips:
   <<: *acceptance_base
-  <<: *pup_5_5_7
+  <<: *pup_5_5_10
   <<: *only_with_SIMP_FULL_MATRIX
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[prelink_fact,oel]'
 
 # The default node set for the ipa_fact suite includes OEL servers
-#pup5.5.7-oel-ipa_fact:
+#pup5.5.10-oel-ipa_fact:
 #  <<: *acceptance_base
-#  <<: *pup_5_5_7
+#  <<: *pup_5_5_10
 #  <<: *only_with_SIMP_FULL_MATRIX
 #  script:
 #    - 'bundle exec rake beaker:suites[ipa_fact,oel]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - for x in ${HOME}/.rvm/gems/*; do gem uninstall -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
+  - for x in ${HOME}/.rvm/gems/*; do gem uninstall --force -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall --force -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
   - gem install -v '~> 1.17' bundler
 
 global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.2      4.10     2.1.9  TBD
-# PE 2016.4     4.10     2.1.9  2018-12-31 (LTS)
-# PE 2017.3     5.3      2.4.4  2018-12-31
-# SIMP 6.3      5.5      2.4.4  TBD***
-# PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
+# PE 2017.3     5.3      2.4.5  2018-12-31
+# SIMP 6.3      5.5      2.4.5  TBD***
+# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
@@ -38,7 +36,8 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
-  - gem install -v '~> 1.16' bundler
+  - for x in ${HOME}/.rvm/gems/*; do gem uninstall -I -x -i "${x}" -v '>= 1.17' bundler || true; gem uninstall -I -x -i "${x}@global" -v '>= 1.17' bundler || true; done
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes
@@ -50,7 +49,7 @@ jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -63,21 +62,14 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -85,7 +77,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -98,7 +90,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
+* Fri May 31 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.2-0
+- Remove Puppet 4 support, as Puppet has removed the Puppet 4 RPMs from
+  their yum repos.
+
 * Tue May 21 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.15.2-0
 - Defer to the inbuilt 'fips_enabled' fact if it exists.
 
 * Thu May 09 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.1-0
 - Updated simp_version function to use Puppet::Util::Execution.execute
-  instead of backtics.  This avioids a GLIBC error triggered by JRuby 9K when
+  instead of backtics.  This avoids a GLIBC error triggered by JRuby 9K when
   backtics, system or %x are used.
 
 * Fri Apr 12 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 3.15.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -101,7 +101,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     }
   ],
   "package_release_version": "0"


### PR DESCRIPTION
- Removed Puppet 4 support, as Puppet has removed the Puppet 4 RPMs from
  their yum repos.  This means all the Puppet 4 acceptance tests fail.
- Pinned the version of stdlib to 5.2.0 in the .fixtures.yml, as the
  version on master is beyond the upper bound allowed in this
  component's metadata.json.