### PR TITLE
(SIMP-6745) SIMP Deprecation warnings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri June 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.3-0
+* Fri Jun 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.3-0
 - Allow users to disable deprecation warnings using SIMPLIB_NOLOG_DEPRECATIONS
   environment variable
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri June 28 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 3.15.3-0
+- Allow users to disable deprecation warnings using SIMPLIB_NOLOG_DEPRECATIONS
+  environment variable
+
 * Fri May 31 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 3.15.2-0
 - Remove Puppet 4 support, as Puppet has removed the Puppet 4 RPMs from
   their yum repos.

--- a/lib/puppet/functions/simplib/deprecation.rb
+++ b/lib/puppet/functions/simplib/deprecation.rb
@@ -29,6 +29,6 @@ Puppet::Functions.create_function(:'simplib::deprecation') do
       message = "#{message} at #{file}:#{line}"
     end
 
-    Puppet.deprecation_warning(message, key)
+    Puppet.deprecation_warning(message, key) unless ENV['SIMPLIB_NOLOG_DEPRECATIONS'] 
   end
 end

--- a/lib/puppet/parser/functions/simplib_deprecation.rb
+++ b/lib/puppet/parser/functions/simplib_deprecation.rb
@@ -16,6 +16,6 @@ module Puppet::Parser::Functions
     key = arguments[0]
     message = arguments[1]
 
-    Puppet.deprecation_warning(message, key)
+    Puppet.deprecation_warning(message, key) unless ENV['SIMPLIB_NOLOG_DEPRECATIONS']
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -16,16 +16,14 @@ describe 'simplib::deprecation' do
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
-  end
 
-#  context 'with no SIMPLIB_LOG_DEPRECATIONS environment variable set' do
-#    it 'should not display a warning' do
-#      ENV['SIMPLIB_LOG_DEPRECATIONS'] = nil
-#      # This is working around deprecation warnings that get added by Puppet core
-#      Puppet.expects(:warning).with(includes('test_func is deprecated')).never
-#      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
-#
-#      is_expected.to run.with_params('test_key', 'test_func is deprecated')
-#    end
-#  end
+    it  'should not display a warning' do
+      ENV['SIMPLIB_NOLOG_DEPRECATIONS'] = 'true'
+      # This is working around deprecation warnings that get added by Puppet core
+      Puppet.expects(:warning).with(includes('test_func is deprecated')).never
+      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+
+      is_expected.to run.with_params('test_key', 'test_func is deprecated')
+    end
+  end
 end


### PR DESCRIPTION
- added check for environment variable,
  SIMPLIB_NOLOG_DEPRECATIONS, to disable SIMP function
  deprecation warnings.  (This has no impact on
  puppet deprecation warnings)