### PR TITLE
(SIMP-7096) Add simplib::ip::family_hash function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Nov 05 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.0-0
+- Add `simplib::ip::family_hash` function that takes an IP address or Array of
+  IP addresses and returns a Hash with the addresses broken down by family with
+  additional helpful metadata
+
 * Fri Oct 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.0-0
 - Updated `simplib::passgen` to run in legacy mode or in a libkv mode.
   - libkv mode is **EXPERIMENTAL**.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -39,6 +39,7 @@
 * [`simplib::host_is_me`](#simplibhost_is_me): Detect if a local system identifier hostname/IPv4 address matches a specified hostname/IPv4 address or an entry in a list of  hostnames and/o
 * [`simplib::in_bolt`](#simplibin_bolt): Returns ``true`` if the run is active inside of Bolt and ``false`` otherwise.  Presently, this function is extremely basic. However, this che
 * [`simplib::inspect`](#simplibinspect): Prints the passed variable's Ruby type and value for debugging purposes  This uses a ``Notify`` resource to print the information during the 
+* [`simplib::ip::family_hash`](#simplibipfamily_hash): Process an array of IP addresses and return them split by IP family and include metadata and/or processed versions.
 * [`simplib::ip_to_cron`](#simplibip_to_cron): Transforms an IP address to one or more interval values for `cron`.  This can be used to avoid starting a certain cron job at the same  time 
 * [`simplib::ipaddresses`](#simplibipaddresses): Return an `Array` of all IPv4 addresses known to be associated with the client, optionally excluding local addresses.
 * [`simplib::join_mount_opts`](#simplibjoin_mount_opts): Merge two sets of `mount` options in a reasonable fashion, giving precedence to the second set.
@@ -1566,6 +1567,66 @@ Data type: `Enum['json','yaml', 'oneline_json']`
 The format that you wish to use to display the output during the
 run. 'json' and 'yaml' result in multi-line message content.
 'oneline_json' results in single-line message content.
+
+### simplib::ip::family_hash
+
+Type: Ruby 4.x API
+
+Process an array of IP addresses and return them split by IP family and
+include metadata and/or processed versions.
+
+#### `simplib::ip::family_hash(Variant[
+      Simplib::IP,
+      Simplib::IP::V4::DDQ,
+      Simplib::IP::V4::CIDR,
+      Simplib::IP::V6::CIDR,
+      Array[Variant[
+        Simplib::IP,
+        Simplib::IP::V4::DDQ,
+        Simplib::IP::V4::CIDR,
+        Simplib::IP::V6::CIDR
+      ]]
+    ] $ip_addresses)`
+
+Process an array of IP addresses and return them split by IP family and
+include metadata and/or processed versions.
+
+Returns: `Hash` Converted Hash with the following format (YAML representation):
+
+```
+# IPv4 Addresses
+ipv4:
+  <Passed Address>:
+    address: <normalized address>
+    netmask:
+      ddq: <dotted quad notation netmask>
+      cidr: <CIDR netmask>
+# IPv6 Addresses
+ipv6:
+  <Passed Address>:
+    address: <normalized address>
+    netmask:
+      # DDQ is not valid for IPv6
+      ddq: nil
+      cidr: <CIDR netmask>
+```
+
+##### `ip_addresses`
+
+Data type: `Variant[
+      Simplib::IP,
+      Simplib::IP::V4::DDQ,
+      Simplib::IP::V4::CIDR,
+      Simplib::IP::V6::CIDR,
+      Array[Variant[
+        Simplib::IP,
+        Simplib::IP::V4::DDQ,
+        Simplib::IP::V4::CIDR,
+        Simplib::IP::V6::CIDR
+      ]]
+    ]`
+
+The addresses to convert
 
 ### simplib::ip_to_cron
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1575,6 +1575,40 @@ Type: Ruby 4.x API
 Process an array of IP addresses and return them split by IP family and
 include metadata and/or processed versions.
 
+#### Examples
+
+##### 
+
+```puppet
+
+simplib::ip::family_hash([
+  '1.2.3.4',
+  '2.3.4.5/8',
+  '::1'
+])
+
+Returns (YAML Formatted for clarity)
+
+---
+ipv4:
+  '1.2.3.4':
+    address: '1.2.3.4'
+    netmask:
+      ddq: '255.255.255.255'
+      cidr: 32
+  '2.3.4.5/8':
+    address: '2.0.0.0'
+    netmask:
+      ddq: '255.0.0.0'
+      cidr: 8
+ipv6:
+  '::1':
+    address: '[::1]'
+    netmask:
+      ddq: nil
+      cidr: 128
+```
+
 #### `simplib::ip::family_hash(Variant[
       Simplib::IP,
       Simplib::IP::V4::DDQ,
@@ -1609,6 +1643,40 @@ ipv6:
       # DDQ is not valid for IPv6
       ddq: nil
       cidr: <CIDR netmask>
+```
+
+##### Examples
+
+###### 
+
+```puppet
+
+simplib::ip::family_hash([
+  '1.2.3.4',
+  '2.3.4.5/8',
+  '::1'
+])
+
+Returns (YAML Formatted for clarity)
+
+---
+ipv4:
+  '1.2.3.4':
+    address: '1.2.3.4'
+    netmask:
+      ddq: '255.255.255.255'
+      cidr: 32
+  '2.3.4.5/8':
+    address: '2.0.0.0'
+    netmask:
+      ddq: '255.0.0.0'
+      cidr: 8
+ipv6:
+  '::1':
+    address: '[::1]'
+    netmask:
+      ddq: nil
+      cidr: 128
 ```
 
 ##### `ip_addresses`

--- a/lib/puppet/functions/simplib/ip/family_hash.rb
+++ b/lib/puppet/functions/simplib/ip/family_hash.rb
@@ -26,6 +26,35 @@ Puppet::Functions.create_function(:'simplib::ip::family_hash') do
   #         cidr: <CIDR netmask>
   #   ```
   #
+  # @example
+  #
+  #   simplib::ip::family_hash([
+  #     '1.2.3.4',
+  #     '2.3.4.5/8',
+  #     '::1'
+  #   ])
+  #
+  #   Returns (YAML Formatted for clarity)
+  #
+  #   ---
+  #   ipv4:
+  #     '1.2.3.4':
+  #       address: '1.2.3.4'
+  #       netmask:
+  #         ddq: '255.255.255.255'
+  #         cidr: 32
+  #     '2.3.4.5/8':
+  #       address: '2.0.0.0'
+  #       netmask:
+  #         ddq: '255.0.0.0'
+  #         cidr: 8
+  #   ipv6:
+  #     '::1':
+  #       address: '[::1]'
+  #       netmask:
+  #         ddq: nil
+  #         cidr: 128
+  #
   dispatch :family_hash do
     required_param 'Variant[
       Simplib::IP,

--- a/lib/puppet/functions/simplib/ip/family_hash.rb
+++ b/lib/puppet/functions/simplib/ip/family_hash.rb
@@ -1,0 +1,82 @@
+# Process an array of IP addresses and return them split by IP family and
+# include metadata and/or processed versions.
+#
+Puppet::Functions.create_function(:'simplib::ip::family_hash') do
+  # @param ip_addresses
+  #   The addresses to convert
+  #
+  # @return [Hash]
+  #   Converted Hash with the following format (YAML representation):
+  #
+  #   ```
+  #   # IPv4 Addresses
+  #   ipv4:
+  #     <Passed Address>:
+  #       address: <normalized address>
+  #       netmask:
+  #         ddq: <dotted quad notation netmask>
+  #         cidr: <CIDR netmask>
+  #   # IPv6 Addresses
+  #   ipv6:
+  #     <Passed Address>:
+  #       address: <normalized address>
+  #       netmask:
+  #         # DDQ is not valid for IPv6
+  #         ddq: nil
+  #         cidr: <CIDR netmask>
+  #   ```
+  #
+  dispatch :family_hash do
+    required_param 'Variant[
+      Simplib::IP,
+      Simplib::IP::V4::DDQ,
+      Simplib::IP::V4::CIDR,
+      Simplib::IP::V6::CIDR,
+      Array[Variant[
+        Simplib::IP,
+        Simplib::IP::V4::DDQ,
+        Simplib::IP::V4::CIDR,
+        Simplib::IP::V6::CIDR
+      ]]
+    ]', :ip_addresses
+  end
+
+  def family_hash(addresses)
+    results = {}
+
+    Array(addresses).uniq.each do |addr|
+      ip = IPAddr.new(addr)
+
+      addr_normalized, cidr_netmask = call_function('simplib::nets2cidr', addr).
+        first.split('/')
+
+      ip_breakdown = {
+        'address' => call_function('simplib::bracketize', Array(addr_normalized)),
+        'netmask' => {
+          'ddq'  => nil,
+          'cidr' => cidr_netmask && cidr_netmask.to_i
+        }
+      }
+
+      if ip.ipv4?
+        ip_family = 'ipv4'
+
+        ip_breakdown['netmask']['ddq'] = call_function('simplib::nets2ddq', addr).
+          first.split('/')[1] || '255.255.255.255'
+
+        ip_breakdown['netmask']['cidr'] = 32 unless ip_breakdown['netmask']['cidr']
+      elsif ip.ipv6?
+        ip_family = 'ipv6'
+
+        ip_breakdown['netmask']['cidr'] = 128 unless ip_breakdown['netmask']['cidr']
+      else
+        ip_family = 'unknown'
+      end
+
+      results[ip_family] ||= {}
+      results[ip_family][addr] = ip_breakdown
+    end
+
+    results
+  end
+end

--- a/spec/functions/simplib/ip/family_hash_spec.rb
+++ b/spec/functions/simplib/ip/family_hash_spec.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simplib::ip::family_hash' do
+  context 'when passed valid data' do
+    it 'converts an Array of addresses' do
+      input = [
+        '1.2.3.4/24',
+        '2.3.4.5',
+        '3.4.5.0/255.255.255.0',
+        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+        '2001:0db8:85a3:0000:0000:8a2e:0370:7334/24'
+      ]
+
+      output ={
+        'ipv4' => {
+          '1.2.3.4/24' => {
+            'address' => '1.2.3.0',
+            'netmask' => {
+              'ddq'  => '255.255.255.0',
+              'cidr' => 24
+            }
+          },
+          '2.3.4.5' => {
+            'address' => '2.3.4.5',
+            'netmask' => {
+              'ddq'  => '255.255.255.255',
+              'cidr' => 32
+            }
+          },
+          '3.4.5.0/255.255.255.0' => {
+            'address' => '3.4.5.0',
+            'netmask' => {
+              'ddq'  => '255.255.255.0',
+              'cidr' => 24
+            }
+          }
+        },
+        'ipv6' => {
+          '2001:0db8:85a3:0000:0000:8a2e:0370:7334' => {
+            'address' => '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+            'netmask' => {
+              'ddq'  => nil,
+              'cidr' => 128
+            }
+          },
+          '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]' => {
+            'address' => '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+            'netmask' => {
+              'ddq'  => nil,
+              'cidr' => 128
+            }
+          },
+          '2001:0db8:85a3:0000:0000:8a2e:0370:7334/24' => {
+            'address' => '[2001:d00::]',
+            'netmask' => {
+              'ddq'  => nil,
+              'cidr' => 24
+            }
+          }
+        }
+      }
+
+      is_expected.to run.with_params(input).and_return(output)
+    end
+
+    it 'converts a single IPv4 address' do
+      input = '1.2.3.4/24'
+
+      output = {
+        'ipv4' => {
+          '1.2.3.4/24' => {
+            'address' => '1.2.3.0',
+            'netmask' => {
+              'ddq'  => '255.255.255.0',
+              'cidr' => 24
+            }
+          }
+        }
+      }
+
+      is_expected.to run.with_params(input).and_return(output)
+    end
+
+    it 'converts a single IPv6 address' do
+      input = '2001:0db8:85a3:0000:0000:8a2e:0370:7334/24'
+
+      output = {
+        'ipv6' => {
+          '2001:0db8:85a3:0000:0000:8a2e:0370:7334/24' => {
+            'address' => '[2001:d00::]',
+            'netmask' => {
+              'ddq'  => nil,
+              'cidr' => 24
+            }
+          }
+        }
+      }
+
+      is_expected.to run.with_params(input).and_return(output)
+    end
+  end
+end


### PR DESCRIPTION
Add `simplib::ip::family_hash` function that takes an IP address or
Array of IP addresses and returns a Hash with the addresses broken down
by family with additional helpful metadata

SIMP-7096 #comment Add simplib::ip::family_hash