### PR TITLE
(SIMP-7822) Fix Simplib::Systemd::ServiceName

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Aug 20 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.1-0
+- Fixed Simplib::Systemd::ServiceName to accept instance services
+- Added 'any' and 'ALL' to the data_types/hostname spec test
+
 * Tue Aug 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.0-0
 - Added a simplib__auditd fact to return comprehensive information about auditd
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6072,7 +6072,7 @@ Alias of `Variant[Integer[0,7], Enum[
 
 Valid systemd service names
 
-Alias of `Pattern['^([A-Za-z0-9.:_\\\\-]){1,256}$']`
+Alias of `Pattern['^(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}$']`
 
 ### `Simplib::URI`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/data_types/hostname_spec.rb
+++ b/spec/unit/data_types/hostname_spec.rb
@@ -6,6 +6,8 @@ singular_item = 'hostname'
 plural_item = 'hostnames'
 
 valid_data = [
+  'all',
+  'ANY',
   'localhost',
   'localhost.localdomain',
   'my-domain.com',

--- a/types/systemd/servicename.pp
+++ b/types/systemd/servicename.pp
@@ -1,2 +1,2 @@
 # Valid systemd service names
-type Simplib::Systemd::ServiceName = Pattern['^([A-Za-z0-9.:_\\\\-]){1,256}$']
+type Simplib::Systemd::ServiceName = Pattern['^(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}$']


### PR DESCRIPTION
- Fixed Simplib::Systemd::ServiceName to accept instance services
- Added 'any' and 'ALL' to the data_types/hostname spec test

SIMP-7822 #comment Fix Simplib::Systemd::ServiceName data type