### PR TITLE
Add a fact to track PCI devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ See [REFERENCE.md](./REFERENCE.md) for all other reference documentation.
   * **ipv6_enabled**         -  Return true if IPv6 is enabled and false if not
   * **login_defs**           -  Return the contents of `/etc/login.defs` as a
                                 hash with downcased keys
+  * **lspci**                -  Return the contents of `lspci` as a hash with a
+                                format of lspci[class][vendor][slot][attr] = value
   * **prelink**              -  Returns a hash containing prelink status
   * **reboot_required**      -  Returns a hash of 'name' => 'reason' entries
   * **root_dir_uuid**        -  Return the UUID of the partition holding the

--- a/lib/facter/lspci.rb
+++ b/lib/facter/lspci.rb
@@ -1,0 +1,55 @@
+# _Description_
+#
+# return the content of lspci as a hash
+Facter.add(:lspci) do
+  confine :kernel => "Linux"
+  retval = {}
+  if Facter::Util::Resolution.which('lspci')
+    slot = ''
+    type = ''
+    vendor = ''
+    Facter::Util::Resolution.exec("lspci -vv -mm -k -b -D 2>/dev/null").each_line do |line|
+      # only parse lines with text
+      if line =~ /.+/
+        txt = line.split(/:\t/)
+        if txt[0] == 'Slot'
+          slot = txt[1].strip
+          type = ''
+          vendor = ''
+          next
+        elsif txt[0] == 'Class'
+          type = txt[1].strip
+          next
+        elsif txt[0] == 'Vendor'
+          vendor = txt[1].strip
+          next
+        end
+
+        if type != '' and slot != '' and vendor != ''
+          if not retval.has_key?(type)
+            retval[type] = {}
+          end
+
+          if not retval[type].has_key?(vendor)
+            retval[type][vendor] = {}
+          end
+
+          if not retval[type][vendor].has_key?(slot)
+            retval[type][vendor][slot] = {}
+          end
+
+          retval[type][vendor][slot][txt[0]] = txt[1].strip
+        end
+      else
+        slot = ''
+        type = ''
+        vendor = ''
+      end
+    end
+  end
+
+  setcode do
+    retval
+  end
+
+end


### PR DESCRIPTION
At times it can be handy to search for M.2 disks or other hardware on the PCI bus.