### PR TITLE
(SIMP-8590)  Fix simplib::debug::inspect with Bolt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Oct 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.1-0
+- Fix the use of simplib::debug::inspect when using Bolt
+
 * Thu Sep 24 2020 Pat Riehecky <riehecky@fnal.gov> - 4.6.0-0
 - Add simplib__numa to collect NUMA-related facts
 

--- a/lib/puppet/functions/simplib/debug/inspect.rb
+++ b/lib/puppet/functions/simplib/debug/inspect.rb
@@ -20,12 +20,20 @@ Puppet::Functions.create_function(:'simplib::debug::inspect', Puppet::Functions:
 
   def inspect(scope, to_inspect, print=true)
     data = {
-      :type        => to_inspect.class,
-      :content     => to_inspect.to_pson,
-      :module_name => scope.source.module_name,
-      :file        => scope.source.file,
-      :line        => scope.source.line
+      :type     => to_inspect.class,
+      :content  => to_inspect.to_pson
     }
+
+    if scope
+      data[:scope] = scope.to_s
+
+      if scope.source
+        data[:module_name] = scope.source.module_name
+        data[:file] = scope.source.file
+        data[:line] = scope.source.line
+      end
+    end
+
 
     if print
       msg = [
@@ -34,12 +42,16 @@ Puppet::Functions.create_function(:'simplib::debug::inspect', Puppet::Functions:
         "Content => '#{data[:content]}'"
       ]
 
-      unless data[:module_name].empty?
+      if data[:module_name] && !data[:module_name].empty?
         msg << "Module: '#{data[:module_name]}'"
       end
 
       if data[:file]
         msg << "Location: '#{data[:file]}:#{data[:line]}'"
+      end
+
+      if data[:scope]
+        msg << "Scope: '#{data[:scope]}'"
       end
 
       msg = msg.join(' ')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/debug/inspect_spec.rb
+++ b/spec/functions/simplib/debug/inspect_spec.rb
@@ -16,9 +16,9 @@ describe 'simplib::debug::inspect' do
   }}
 
   it {
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"test_value"')).once
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"other value"' Location: ':6')).once
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"foo"')).once
+    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"test_value"' Scope: 'Scope(Class[main])')).once
+    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"other value"' Location: ':6' Scope: 'Scope(Class[Test])')).once
+    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"foo"' Scope: 'Scope(Class[main])')).once
 
     retval = scope.call_function('simplib::debug::inspect', 'foo')
 
@@ -26,6 +26,7 @@ describe 'simplib::debug::inspect' do
       :type        => String,
       :content     => '"foo"',
       :module_name => '',
+      :scope       => "Scope(Class[main])",
       :file        => nil,
       :line        => nil
     })


### PR DESCRIPTION
Fixed:
* Bolt does not set scope.source. The code was reworked to optionally
  pull scope.source and simply insert the scope as a string as a
  fallback.

SIMP-8590 #close