### PR TITLE
(SIMP-MAINT) Fix OS support data type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Wed Nov 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.2-0
 - Added Amazon Linux support
-- Allow the operatingsystemrelease to be optinally defined in metadata.json
-  operatingsystem_support
+- Changed Simplib::Puppet::Metadata::OS_support type to allow the
+  operatingsystemrelease to be optionally defined.
 
 * Fri Oct 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.1-0
 - Fix the use of simplib::debug::inspect when using Bolt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Nov 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.2-0
+- Added Amazon Linux support
+- Allow the operatingsystemrelease to be optinally defined in metadata.json
+  operatingsystem_support
+
 * Fri Oct 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.6.1-0
 - Fix the use of simplib::debug::inspect when using Bolt
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :test do
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
+  # Remove when rspec-puppet 2.8.0 is released
+  gem 'rspec-expectations', '~> 3.9.0'
 end
 
 group :development do

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",
@@ -110,6 +110,12 @@
         "6.1",
         "7.1",
         "7.2"
+      ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2"
       ]
     }
   ],

--- a/types/puppet/metadata/os_support.pp
+++ b/types/puppet/metadata/os_support.pp
@@ -1,5 +1,5 @@
 # The 'operating_support' data structure in metadata.json
 type Simplib::Puppet::Metadata::OS_support = Struct[{
   'operatingsystem'        => String,
-  'operatingsystemrelease' => Array[String]
+  'operatingsystemrelease' => Optional[Array[String]]
 }]


### PR DESCRIPTION
Fixed:
  - Allow the operatingsystemrelease to be optionally defined in
    metadata.json operatingsystem_support