### PR TITLE
(SIMP-9115) simplib unt tests fail Puppet 7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,8 +334,6 @@ pup6.pe-unit:
   <<: *unit_tests
 
 pup7.x-unit:
-  # SIMP-9115
-  allow_failure: true
   <<: *pup_7_x
   <<: *unit_tests
 

--- a/spec/functions/simplib/debug/classtrace_spec.rb
+++ b/spec/functions/simplib/debug/classtrace_spec.rb
@@ -12,7 +12,7 @@ describe 'simplib::debug::classtrace' do
   }}
 
   it {
-    Puppet.expects(:warning).with(%(Simplib::Debug::Classtrace:\n    => Class[main]\n    => Class[Baz]\n    => Bar[test]\n    => Class[Foo])).once
+    expect(Puppet).to receive(:warning).with(%(Simplib::Debug::Classtrace:\n    => Class[main]\n    => Class[Baz]\n    => Bar[test]\n    => Class[Foo])).once
 
     retval = scope.call_function('simplib::debug::classtrace', false)
 

--- a/spec/functions/simplib/debug/inspect_spec.rb
+++ b/spec/functions/simplib/debug/inspect_spec.rb
@@ -16,9 +16,9 @@ describe 'simplib::debug::inspect' do
   }}
 
   it {
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"test_value"' Scope: 'Scope(Class[main])')).once
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"other value"' Location: ':6' Scope: 'Scope(Class[Test])')).once
-    Puppet.expects(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"foo"' Scope: 'Scope(Class[main])')).once
+    expect(Puppet).to receive(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"test_value"' Scope: 'Scope(Class[main])'))
+    expect(Puppet).to receive(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"other value"' Location: ':6' Scope: 'Scope(Class[Test])'))
+    expect(Puppet).to receive(:warning).with(%(Simplib::Debug::Inspect: Type => 'String' Content => '"foo"' Scope: 'Scope(Class[main])'))
 
     retval = scope.call_function('simplib::debug::inspect', 'foo')
 

--- a/spec/functions/simplib/debug/stacktrace_spec.rb
+++ b/spec/functions/simplib/debug/stacktrace_spec.rb
@@ -12,7 +12,7 @@ describe 'simplib::debug::stacktrace' do
   }}
 
   it {
-    Puppet.expects(:warning).with(%(Simplib::Debug::Stacktrace:\n    => unknown:2\n    => unknown:4)).once
+    expect(Puppet).to receive(:warning).with(%(Simplib::Debug::Stacktrace:\n    => unknown:2\n    => unknown:4))
 
     retval = scope.call_function('simplib::debug::stacktrace', false)
 

--- a/spec/functions/simplib/deprecation_spec.rb
+++ b/spec/functions/simplib/deprecation_spec.rb
@@ -1,27 +1,33 @@
 require 'spec_helper'
 
 describe 'simplib::deprecation' do
-  context 'with SIMPLIB_LOG_DEPRECATIONS' do
+  before :each do
+    allow(ENV).to receive(:[]).with(any_args).and_call_original
+  end
+
+  context 'with SIMPLIB_NOLOG_DEPRECATIONS unset' do
+    before :each do
+      expect(ENV).to receive(:[]).with('SIMPLIB_NOLOG_DEPRECATIONS').and_return(nil)
+    end
+
     it 'should display a single warning' do
-      Puppet.expects(:warning).with(includes('test_func is deprecated'))
-      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+      expect(Puppet).to receive(:warning).with(/test_func is deprecated/)
 
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
 
     it 'should display a single warning, despite multiple calls' do
-      Puppet.expects(:warning).with(includes('test_func is deprecated')).once
-      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+      expect(Puppet).to receive(:warning).with(/test_func is deprecated/)
 
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end
+  end
 
+  context 'with SIMPLIB_NOLOG_DEPRECATIONS=true' do
     it  'should not display a warning' do
-      ENV['SIMPLIB_NOLOG_DEPRECATIONS'] = 'true'
-      # This is working around deprecation warnings that get added by Puppet core
-      Puppet.expects(:warning).with(includes('test_func is deprecated')).never
-      Puppet.stubs(:warning).with(Not(includes('test_func is deprecated')))
+      expect(ENV).to receive(:[]).with('SIMPLIB_NOLOG_DEPRECATIONS').and_return('true')
+      expect(Puppet).to_not receive(:warning).with(/test_func is deprecated/)
 
       is_expected.to run.with_params('test_key', 'test_func is deprecated')
     end

--- a/spec/functions/simplib/passgen/gen_password_and_salt_spec.rb
+++ b/spec/functions/simplib/passgen/gen_password_and_salt_spec.rb
@@ -96,7 +96,7 @@ describe 'simplib::passgen::gen_password_and_salt' do
 
   context 'errors' do
     it 'fails when password generation times out' do
-      Timeout.expects(:timeout).with(30).raises(Timeout::Error, 'Timeout')
+      expect(Timeout).to receive(:timeout).with(30).and_raise(Timeout::Error, 'Timeout')
       is_expected.to run.with_params(16, 0, false, 30).and_raise_error(Timeout::Error,
         'Timeout')
     end

--- a/spec/functions/simplib/passgen/gen_salt_spec.rb
+++ b/spec/functions/simplib/passgen/gen_salt_spec.rb
@@ -41,7 +41,7 @@ describe 'simplib::passgen::gen_salt' do
   end
 
   it 'fails when salt generation times out' do
-    Timeout.expects(:timeout).with(20).raises(Timeout::Error, 'Timeout')
+    expect(Timeout).to receive(:timeout).with(20).and_raise(Timeout::Error, 'Timeout')
     is_expected.to run.with_params(20).and_raise_error(Timeout::Error,
       'Timeout')
   end

--- a/spec/functions/simplib/passgen/get_spec.rb
+++ b/spec/functions/simplib/passgen/get_spec.rb
@@ -90,8 +90,8 @@ describe 'simplib::passgen::get' do
         salt_file = File.join(settings['keydir'], "#{id}.salt")
         File.open(salt_file, 'w') { |file| file.puts salt }
 
-        IO.expects(:readlines).with(password_file).
-          raises(Errno::EACCES, 'read failed')
+        expect(IO).to receive(:readlines).with(password_file).
+          and_raise(Errno::EACCES, 'read failed')
         is_expected.to run.with_params(id).and_raise_error(Errno::EACCES,
           'Permission denied - read failed')
       end

--- a/spec/functions/simplib/passgen/legacy/get_spec.rb
+++ b/spec/functions/simplib/passgen/legacy/get_spec.rb
@@ -151,8 +151,8 @@ describe 'simplib::passgen::legacy::get' do
       salt_file = File.join(settings['keydir'], "#{id}.salt")
       File.open(salt_file, 'w') { |file| file.puts salt }
 
-      IO.expects(:readlines).with(password_file).
-        raises(Errno::EACCES, 'read failed')
+      expect(IO).to receive(:readlines).with(password_file).
+        and_raise(Errno::EACCES, 'read failed')
       is_expected.to run.with_params(id).and_raise_error(Errno::EACCES,
         'Permission denied - read failed')
     end

--- a/spec/functions/simplib/passgen/legacy/list_spec.rb
+++ b/spec/functions/simplib/passgen/legacy/list_spec.rb
@@ -70,8 +70,8 @@ describe 'simplib::passgen::legacy::list' do
       subject()
       settings = call_function('simplib::passgen::legacy::common_settings')
       FileUtils.mkdir_p(settings['keydir'])
-      Dir.expects(:chdir).with(settings['keydir']).
-        raises(Errno::EACCES, 'chdir failed')
+      expect(Dir).to receive(:chdir).with(settings['keydir']).
+        and_raise(Errno::EACCES, 'chdir failed')
 
       is_expected.to run.with_params().and_raise_error(Errno::EACCES,
         'Permission denied - chdir failed')

--- a/spec/functions/simplib/passgen/legacy/remove_spec.rb
+++ b/spec/functions/simplib/passgen/legacy/remove_spec.rb
@@ -74,7 +74,7 @@ describe 'simplib::passgen::legacy::remove' do
       password_file = File.join(settings['keydir'], id)
       File.open(password_file, 'w') { |file| file.puts passwords[0] }
 
-      File.stubs(:unlink).with(password_file).raises(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(password_file).and_raise(Errno::EACCES, 'file unlink failed')
 
       is_expected.to run.with_params(id).and_raise_error( RuntimeError,
         /Unable to remove all files:.*#{id}: Permission denied - file unlink failed/m)
@@ -98,12 +98,12 @@ describe 'simplib::passgen::legacy::remove' do
       File.open(salt_file_last, 'w') { |file| file.puts salts[1] }
       File.open(salt_file_last_last, 'w') { |file| file.puts salts[2] }
 
-      File.stubs(:unlink).with(password_file).raises(Errno::EACCES, 'file unlink failed')
-      File.stubs(:unlink).with(password_file_last).raises(Errno::EACCES, 'file unlink failed')
-      File.stubs(:unlink).with(password_file_last_last).raises(Errno::EACCES, 'file unlink failed')
-      File.stubs(:unlink).with(salt_file).raises(Errno::EACCES, 'file unlink failed')
-      File.stubs(:unlink).with(salt_file_last).raises(Errno::EACCES, 'file unlink failed')
-      File.stubs(:unlink).with(salt_file_last_last).raises(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(password_file).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(password_file_last).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(password_file_last_last).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(salt_file).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(salt_file_last).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
+      expect(File).to receive(:unlink).with(salt_file_last_last).exactly(6).times.and_raise(Errno::EACCES, 'file unlink failed')
 
       [
         password_file,

--- a/spec/functions/simplib/passgen/list_spec.rb
+++ b/spec/functions/simplib/passgen/list_spec.rb
@@ -52,8 +52,8 @@ describe 'simplib::passgen::list' do
         subject()
         settings = call_function('simplib::passgen::legacy::common_settings')
         FileUtils.mkdir_p(settings['keydir'])
-        Dir.expects(:chdir).with(settings['keydir']).
-          raises(Errno::EACCES, 'chdir failed')
+        expect(Dir).to receive(:chdir).with(settings['keydir']).
+          and_raise(Errno::EACCES, 'chdir failed')
 
         is_expected.to run.with_params().and_raise_error(Errno::EACCES,
           'Permission denied - chdir failed')

--- a/spec/functions/simplib/passgen/remove_spec.rb
+++ b/spec/functions/simplib/passgen/remove_spec.rb
@@ -75,7 +75,7 @@ describe 'simplib::passgen::remove' do
         password_file = File.join(settings['keydir'], id)
         File.open(password_file, 'w') { |file| file.puts passwords[0] }
 
-        File.stubs(:unlink).with(password_file).raises(Errno::EACCES, 'file unlink failed')
+        expect(File).to receive(:unlink).with(password_file).and_raise(Errno::EACCES, 'file unlink failed')
 
         is_expected.to run.with_params(id).and_raise_error( RuntimeError,
           /Unable to remove all files:.*#{id}: Permission denied - file unlink failed/m)

--- a/spec/functions/simplib/passgen/set_spec.rb
+++ b/spec/functions/simplib/passgen/set_spec.rb
@@ -88,9 +88,9 @@ describe 'simplib::passgen::set' do
       it 'fails when the key directory cannot be created' do
         subject()
         settings = call_function('simplib::passgen::legacy::common_settings')
-        FileUtils.stubs(:mkdir_p).with(
+        expect(FileUtils).to receive(:mkdir_p).with(
             settings['keydir'], {:mode => settings['dir_mode']}
-          ).raises(Errno::EACCES, 'dir create failed')
+          ).and_raise(Errno::EACCES, 'dir create failed')
 
         is_expected.to run.with_params(id, password, salt, {}).
           and_raise_error(RuntimeError, /Could not make directory/)
@@ -100,15 +100,9 @@ describe 'simplib::passgen::set' do
         subject()
         settings = call_function('simplib::passgen::legacy::common_settings')
         password_file = File.join(settings['keydir'], id)
-        # mocha doesn't allow us to tell it to call original implementation
-        # in some cases (which rspec-mocks does).  So, have to mock a
-        # different method in simplib::psssgen::legacy::set::write_file
-#          File.stubs(:open).with(password_file, 'w').
-#            raises(Errno::EACCES, 'file create failed')
-        File.stubs(:chmod).with(settings['file_mode'], password_file).
-          raises(Errno::EACCES, 'file chmod failed')
-        File.stubs(:chmod).with(
-          Not(equals(settings['file_mode'])), Not(equals(password_file)))
+        allow(File).to receive(:chmod).with(any_args).and_call_original
+        expect(File).to receive(:chmod).with(settings['file_mode'], password_file).
+          and_raise(Errno::EACCES, 'file chmod failed')
 
         is_expected.to run.with_params(id, password, salt, {}).
           and_raise_error(Errno::EACCES, /Permission denied/)

--- a/spec/functions/simplib/passgen/simpkv/passgen_spec.rb
+++ b/spec/functions/simplib/passgen/simpkv/passgen_spec.rb
@@ -281,7 +281,7 @@ describe 'simplib::passgen::simpkv::passgen' do
   context 'misc errors' do
 
     it 'fails when password generation times out' do
-      Timeout.expects(:timeout).with(30).raises(Timeout::Error, 'Timeout')
+      expect(Timeout).to receive(:timeout).with(30).and_raise(Timeout::Error, 'Timeout')
       is_expected.to run.with_params('spectest').and_raise_error(RuntimeError,
         /simplib::passgen timed out for 'spectest'!/)
     end

--- a/spec/functions/simplib/simp_version_spec.rb
+++ b/spec/functions/simplib/simp_version_spec.rb
@@ -15,26 +15,27 @@ describe 'simplib::simp_version' do
       }
 
       context 'a valid version exists in simp.version' do
+        before(:each) do
+          allow(File).to receive(:read).with(any_args).and_call_original
+        end
+
         it 'should return the version with whitespace retained' do
-          File.expects(:read).with(simp_version_path).returns(" 6.4.0-0\n")
-          File.stubs(:readable?).with(simp_version_path).returns(true)
-          File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+          expect(File).to receive(:read).with(simp_version_path).and_return(" 6.4.0-0\n")
+          expect(File).to receive(:readable?).with(simp_version_path).and_return(true)
 
           is_expected.to run.and_return(" 6.4.0-0\n")
         end
 
         it "should return the version with 'simp-' stripped" do
-          File.stubs(:readable?).with(simp_version_path).returns(true)
-          File.stubs(:read).with(simp_version_path).returns("simp-5.4.0-0\n")
-          File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+          expect(File).to receive(:readable?).with(simp_version_path).and_return(true)
+          expect(File).to receive(:read).with(simp_version_path).and_return("simp-5.4.0-0\n")
 
           is_expected.to run.and_return("5.4.0-0\n")
         end
 
         it 'should return the version with whitespace stripped when stripping is enabled' do
-          File.stubs(:readable?).with(simp_version_path).returns(true)
-          File.stubs(:read).with(simp_version_path).returns("6.4.0-0\n")
-          File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+          expect(File).to receive(:readable?).with(simp_version_path).and_return(true)
+          expect(File).to receive(:read).with(simp_version_path).and_return("6.4.0-0\n")
 
           is_expected.to run.with_params(true).and_return('6.4.0-0')
         end
@@ -42,9 +43,9 @@ describe 'simplib::simp_version' do
 
       context 'simp.version is empty' do
         it 'should return unknown' do
-          File.stubs(:read).with(simp_version_path).returns("")
-          File.stubs(:readable?).with(simp_version_path).returns(true)
-          File.stubs(:read).with(regexp_matches(/metadata.json/), {:encoding => "utf-8"}).returns('')
+          allow(File).to receive(:read).with(any_args).and_call_original
+          expect(File).to receive(:read).with(simp_version_path).and_return("")
+          expect(File).to receive(:readable?).with(simp_version_path).and_return(true)
 
           is_expected.to run.and_return("unknown\n")
         end
@@ -58,15 +59,15 @@ describe 'simplib::simp_version' do
 
           context 'rpm query succeeds' do
             it 'should return the version with whitespace retained' do
-              File.stubs(:readable?).with(simp_version_path).returns(false)
-              Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).returns("6.4.0-0\n")
+              expect(File).to receive(:readable?).with(simp_version_path).and_return(false)
+              expect(Puppet::Util::Execution).to receive(:execute).with(rpm_query, {:failonfail => true}).and_return("6.4.0-0\n")
 
               is_expected.to run.and_return("6.4.0-0\n")
             end
 
             it 'should return the version with whitespace stripped when stripping is enabled' do
-              File.stubs(:readable?).with(simp_version_path).returns(false)
-              Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).returns("6.4.0-0\n")
+              expect(File).to receive(:readable?).with(simp_version_path).and_return(false)
+              expect(Puppet::Util::Execution).to receive(:execute).with(rpm_query, {:failonfail => true}).and_return("6.4.0-0\n")
 
               is_expected.to run.with_params(true).and_return('6.4.0-0')
             end
@@ -74,8 +75,8 @@ describe 'simplib::simp_version' do
 
           context 'rpm query fails' do
             it 'should return unknown' do
-              File.stubs(:readable?).with(simp_version_path).returns(false)
-              Puppet::Util::Execution.stubs(:execute).with(rpm_query, {:failonfail => true}).raises(Puppet::ExecutionFailure, "Failed")
+              expect(File).to receive(:readable?).with(simp_version_path).and_return(false)
+              expect(Puppet::Util::Execution).to receive(:execute).with(rpm_query, {:failonfail => true}).and_raise(Puppet::ExecutionFailure, "Failed")
 
               is_expected.to run.and_return("unknown\n")
             end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ RSpec.configure do |c|
 #  c.trusted_server_facts = true
 
   c.mock_framework = :rspec
-  c.mock_with :mocha
+  c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')

--- a/spec/unit/facter/cmdline_spec.rb
+++ b/spec/unit/facter/cmdline_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'cmdline' do
   before :each do
     Facter.clear
+    allow(File).to receive(:read).with(any_args).and_call_original
   end
 
   let(:unique_line) {
@@ -14,7 +15,7 @@ describe 'cmdline' do
 
   context '/proc/cmdline exists' do
     it 'and has no duplicate entries' do
-      File.stubs(:read).with('/proc/cmdline').returns(unique_line)
+      expect(File).to receive(:read).with('/proc/cmdline').and_return(unique_line)
       expect(Facter.fact(:cmdline).value).to eq({
         'root'      => '/dev/mapper/VolGroup00-RootVol',
         'ro'        => nil,
@@ -27,7 +28,7 @@ describe 'cmdline' do
     end
 
     it 'and has duplicate entries' do
-      File.stubs(:read).with('/proc/cmdline').returns(dup_line)
+      expect(File).to receive(:read).with('/proc/cmdline').and_return(dup_line)
       expect(Facter.fact(:cmdline).value).to eq({
         'root'      => '/dev/mapper/VolGroup00-RootVol',
         'ro'        => nil,
@@ -45,7 +46,7 @@ describe 'cmdline' do
 
   context '/proc/cmdline does not exist' do
     it 'returns nil' do
-      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return(nil)
       expect(Facter.fact(:defaultgateway).value).to eq('unknown')
     end
   end

--- a/spec/unit/facter/defaultgateway_spec.rb
+++ b/spec/unit/facter/defaultgateway_spec.rb
@@ -15,37 +15,37 @@ EOM
 
   context 'ip command exists' do
     before :each do
-      Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-      Facter::Util::Resolution.stubs(:which).with('ip').returns('/usr/bin/ip')
+      expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+      expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return('/usr/bin/ip')
     end
 
     it 'returns IP address of valid default route' do
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(ipv4route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(ipv4route)
       expect(Facter.fact(:defaultgateway).value).to eq('192.168.221.1')
     end
 
     it 'returns IP address of last valid default route' do
       multiple_defaults = ipv4route + "default via 10.0.2.1 dev eth1"
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(multiple_defaults)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(multiple_defaults)
       expect(Facter.fact(:defaultgateway).value).to eq('10.0.2.1')
     end
 
     it "returns 'unknown' when no default line exists" do
       bad_route = ipv4route.gsub('default', 'oops ')
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(bad_route)
       expect(Facter.fact(:defaultgateway).value).to eq('unknown')
     end
 
     it "returns 'unknown' when IP address could not be extracted from the default line" do
       bad_route = ipv4route.gsub('default via 192.168.221.1 ', 'default via some.fqdn ')
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(bad_route)
       expect(Facter.fact(:defaultgateway).value).to eq('unknown')
     end
   end
 
   context 'ip command does not exist' do
     it "returns 'unknown'" do
-      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return(nil)
       expect(Facter.fact(:defaultgateway).value).to eq('unknown')
     end
   end

--- a/spec/unit/facter/defaultgatewayiface_spec.rb
+++ b/spec/unit/facter/defaultgatewayiface_spec.rb
@@ -15,37 +15,37 @@ EOM
 
   context 'ip command exists' do
     before :each do
-      Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-      Facter::Util::Resolution.stubs(:which).with('ip').returns('/usr/bin/ip')
+      expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+      expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return('/usr/bin/ip')
     end
 
     it 'returns IP address of valid default route' do
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(ipv4route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(ipv4route)
       expect(Facter.fact(:defaultgatewayiface).value).to eq('eth0')
     end
 
     it 'returns IP address of last valid default route' do
       multiple_defaults = ipv4route + "default via 10.0.2.1 dev eth1"
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(multiple_defaults)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(multiple_defaults)
       expect(Facter.fact(:defaultgatewayiface).value).to eq('eth1')
     end
 
     it "returns 'unknown' when no default line exists" do
       bad_route = ipv4route.gsub('default', 'oops ')
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(bad_route)
       expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
     end
 
     it "returns 'unknown' when device could not be extracted from the default line" do
       bad_route = ipv4route.gsub('dev eth0', 'dev ')
-      Facter::Core::Execution.stubs(:exec).with('/usr/bin/ip route').returns(bad_route)
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/bin/ip route').and_return(bad_route)
       expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
     end
   end
 
   context 'ip command does not exist' do
     it "returns 'unknown'" do
-      Facter::Util::Resolution.stubs(:which).with('ip').returns(nil)
+      expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return(nil)
       expect(Facter.fact(:defaultgatewayiface).value).to eq('unknown')
     end
   end

--- a/spec/unit/facter/fips_ciphers_spec.rb
+++ b/spec/unit/facter/fips_ciphers_spec.rb
@@ -4,20 +4,20 @@ describe 'fips_ciphers' do
 
   before :each do
     Facter.clear
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
   end
 
   context 'openssl command exists' do
     it 'returns FIPS ciphers' do
-      Facter::Core::Execution.stubs(:which).with('openssl').returns('/bin/openssl')
-      Facter::Core::Execution.stubs(:exec).with('/bin/openssl ciphers FIPS:-LOW').returns("ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA")
+      expect(Facter::Core::Execution).to receive(:which).with('openssl').and_return('/bin/openssl')
+      expect(Facter::Core::Execution).to receive(:exec).with('/bin/openssl ciphers FIPS:-LOW').and_return("ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA")
       expect(Facter.fact('fips_ciphers').value).to eq(["ECDHE-RSA-AES256-GCM-SHA384","ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA"])
     end
   end
 
   context 'openssl command does not exist' do
     it 'returns nil' do
-      Facter::Core::Execution.stubs(:which).with('openssl').returns(nil)
+      expect(Facter::Core::Execution).to receive(:which).with('openssl').and_return(nil)
       expect(Facter.fact('fips_ciphers').value).to eq(nil)
     end
   end

--- a/spec/unit/facter/grub_version_spec.rb
+++ b/spec/unit/facter/grub_version_spec.rb
@@ -9,8 +9,8 @@ describe 'grub_version' do
 
   context 'when using Legacy GRUB' do
     it do
-      Facter::Util::Resolution.stubs(:which).with('grub').returns(true)
-      Facter::Util::Resolution.stubs(:exec).with('grub --version').returns("grub (GNU GRUB 0.97)\n")
+      expect(Facter::Util::Resolution).to receive(:which).with('grub').and_return(true)
+      expect(Facter::Util::Resolution).to receive(:exec).with('grub --version').and_return("grub (GNU GRUB 0.97)\n")
 
       expect(Facter.fact('grub_version').value).to eq('0.97')
     end
@@ -18,9 +18,9 @@ describe 'grub_version' do
 
   context 'when using GRUB2' do
     it do
-      Facter::Util::Resolution.stubs(:which).with('grub').returns(false)
-      Facter::Util::Resolution.stubs(:which).with('grub2-mkconfig').returns(true)
-      Facter::Util::Resolution.stubs(:exec).with('grub2-mkconfig --version').returns("grub2-mkconfig (GRUB) 2.02~beta2\n")
+      expect(Facter::Util::Resolution).to receive(:which).with('grub').and_return(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('grub2-mkconfig').and_return(true)
+      expect(Facter::Util::Resolution).to receive(:exec).with('grub2-mkconfig --version').and_return("grub2-mkconfig (GRUB) 2.02~beta2\n")
 
       expect(Facter.fact('grub_version').value).to eq('2.02~beta2')
     end

--- a/spec/unit/facter/init_systems_spec.rb
+++ b/spec/unit/facter/init_systems_spec.rb
@@ -9,9 +9,9 @@ describe 'init_systems' do
 
   context 'when on a base system' do
     before(:each) do
-      Facter::Util::Resolution.stubs(:which).with('initctl').returns(false)
-      Facter::Util::Resolution.stubs(:which).with('systemctl').returns(false)
-      Dir.stubs(:exist?).with('/etc/init.d').returns false
+      expect(Facter::Util::Resolution).to receive(:which).with('initctl').and_return(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('systemctl').and_return(false)
+      expect(Dir).to receive(:exist?).with('/etc/init.d').and_return false
     end
 
     it { expect(Facter.fact('init_systems').value).to eq(['rc']) }
@@ -19,9 +19,9 @@ describe 'init_systems' do
 
   context 'with initctl' do
     before(:each) do
-      Facter::Util::Resolution.stubs(:which).with('initctl').returns(true)
-      Facter::Util::Resolution.stubs(:which).with('systemctl').returns(false)
-      Dir.stubs(:exist?).with('/etc/init.d').returns(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('initctl').and_return(true)
+      expect(Facter::Util::Resolution).to receive(:which).with('systemctl').and_return(false)
+      expect(Dir).to receive(:exist?).with('/etc/init.d').and_return(false)
     end
 
     it { expect(Facter.fact('init_systems').value).to eq(['rc', 'upstart']) }
@@ -29,9 +29,9 @@ describe 'init_systems' do
 
   context 'with systemctl' do
     before(:each) do
-      Facter::Util::Resolution.stubs(:which).with('initctl').returns(false)
-      Facter::Util::Resolution.stubs(:which).with('systemctl').returns(true)
-      Dir.stubs(:exist?).with('/etc/init.d').returns(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('initctl').and_return(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('systemctl').and_return(true)
+      expect(Dir).to receive(:exist?).with('/etc/init.d').and_return(false)
     end
 
     it { expect(Facter.fact('init_systems').value).to eq(['rc', 'systemd']) }
@@ -39,9 +39,9 @@ describe 'init_systems' do
 
   context 'with /etc/init.d' do
     before(:each) do
-      Facter::Util::Resolution.stubs(:which).with('initctl').returns(false)
-      Facter::Util::Resolution.stubs(:which).with('systemctl').returns(false)
-      Dir.stubs(:exist?).with('/etc/init.d').returns(true)
+      expect(Facter::Util::Resolution).to receive(:which).with('initctl').and_return(false)
+      expect(Facter::Util::Resolution).to receive(:which).with('systemctl').and_return(false)
+      expect(Dir).to receive(:exist?).with('/etc/init.d').and_return(true)
     end
 
     it { expect(Facter.fact('init_systems').value).to eq(['rc', 'sysv']) }
@@ -49,9 +49,9 @@ describe 'init_systems' do
 
   context 'with all' do
     before(:each) do
-      Facter::Util::Resolution.stubs(:which).with('initctl').returns(true)
-      Facter::Util::Resolution.stubs(:which).with('systemctl').returns(true)
-      Dir.stubs(:exist?).with('/etc/init.d').returns(true)
+      expect(Facter::Util::Resolution).to receive(:which).with('initctl').and_return(true)
+      expect(Facter::Util::Resolution).to receive(:which).with('systemctl').and_return(true)
+      expect(Dir).to receive(:exist?).with('/etc/init.d').and_return(true)
     end
 
     it { expect(Facter.fact('init_systems').value).to eq(['rc', 'upstart', 'systemd', 'sysv']) }

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe "custom fact ipa" do
+  before :each do
+    allow(File).to receive(:read).with(any_args).and_call_original
+  end
+
   let (:ipa_query_options) {
     {:timeout => 30}
   }
@@ -54,19 +58,19 @@ describe "custom fact ipa" do
     Facter.clear
 
     # mock out Facter method called when evaluating confine for :kernel
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
   end
 
   context 'host is joined to IPA domain' do
     context 'IPA server is available' do
       context 'kinit is not required' do
         it 'should execute only ipa commands and report local env + connected status' do
-          Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-          Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-          File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-          File.expects(:read).with('/etc/ipa/default.conf').returns(default_conf)
-          Facter::Core::Execution.expects(:execute).with(ipa_env_query, ipa_query_options).returns(ipa_env)
-          Facter::Core::Execution.expects(:execute).with(ipa_env_server_query, ipa_query_options).returns(ipa_server_env)
+          expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
+          expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
+          expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
+          expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+          expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_query, ipa_query_options).and_return(ipa_env)
+          expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_server_query, ipa_query_options).and_return(ipa_server_env)
           expect(Facter.fact('ipa').value).to eq({
             'connected' => true,
             'domain'    => 'example.com',
@@ -79,13 +83,13 @@ describe "custom fact ipa" do
 
       context 'kinit is required' do
         it 'should execute kinit + ipa commands and return local env + connected status' do
-          Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-          Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-          File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-          File.expects(:read).with('/etc/ipa/default.conf').returns(default_conf)
-          Facter::Core::Execution.expects(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).returns('')
-          Facter::Core::Execution.expects(:execute).twice.with( ipa_env_query, ipa_query_options).returns('', ipa_env)
-          Facter::Core::Execution.expects(:execute).with(ipa_env_server_query, ipa_query_options).returns(ipa_server_env)
+          expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
+          expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
+          expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
+          expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('')
+          expect(Facter::Core::Execution).to receive(:execute).twice.with( ipa_env_query, ipa_query_options).and_return('', ipa_env)
+          expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_server_query, ipa_query_options).and_return(ipa_server_env)
           expect(Facter.fact('ipa').value).to eq({
             'connected' => true,
             'domain'    => 'example.com',
@@ -99,12 +103,12 @@ describe "custom fact ipa" do
 
     context 'IPA server is not available' do
       it 'should return defaults from /etc/ipa/default.conf and disconnected status' do
-        Facter::Core::Execution.expects(:which).with('kinit').returns('/usr/bin/kinit')
-        Facter::Core::Execution.expects(:which).with('ipa').returns('/usr/bin/ipa')
-        File.expects(:exist?).with('/etc/ipa/default.conf').returns(true)
-        File.expects(:read).with('/etc/ipa/default.conf').returns(default_conf)
-        Facter::Core::Execution.expects(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).returns('some error message')
-        Facter::Core::Execution.expects(:execute).twice.with(ipa_env_query, ipa_query_options).returns('')
+        expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
+        expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
+        expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
+        expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+        expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('some error message')
+        expect(Facter::Core::Execution).to receive(:execute).twice.with(ipa_env_query, ipa_query_options).and_return('')
         expect(Facter.fact('ipa').value).to eq({
           'connected' => false,
           'domain'    => 'example.com',

--- a/spec/unit/facter/login_defs_spec.rb
+++ b/spec/unit/facter/login_defs_spec.rb
@@ -5,7 +5,9 @@ describe "custom fact login_defs" do
   before(:each) do
     Facter.clear
 
-    Facter.stubs(:value).with(:operatingsystem).returns('Linux')
+    allow(Facter).to receive(:value).with(any_args).and_call_original
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('Linux')
+    allow(File).to receive(:read).with(any_args).and_call_original
   end
 
   context 'with a well formed /etc/login.defs' do
@@ -45,18 +47,9 @@ MD5_CRYPT_ENAB  no
     }
 
     it 'should return hash of values from /etc/login.defs with appropriate conversions' do
-      File.expects(:exist?).with('/etc/login.defs').returns(true)
-      File.expects(:readable?).with('/etc/login.defs').returns(true)
-      File.expects(:read).with('/etc/login.defs').returns(login_defs_content)
-
-      # This resets the stubbing code in Mocha to ensure that the code does not
-      # try to catch any other calls to the stubbed methods above.
-      #
-      # This is not documented well and is almost always what you want in
-      # Puppet testing
-      File.stubs(:exist?).with(Not(equals('/etc/login.defs')))
-      File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
-      File.stubs(:read).with(Not(equals('/etc/login.defs')))
+      expect(File).to receive(:exist?).with('/etc/login.defs').and_return(true)
+      expect(File).to receive(:readable?).with('/etc/login.defs').and_return(true)
+      expect(File).to receive(:read).with('/etc/login.defs').and_return(login_defs_content)
 
       expect(Facter.fact('login_defs').value).to eq({
         "mail_dir"        =>"/var/spool/mail",
@@ -83,13 +76,9 @@ MD5_CRYPT_ENAB  no
 
   context 'with an empty login.defs' do
     it 'should return hash of the uid_min and gid_min defaults' do
-      File.expects(:exist?).with('/etc/login.defs').returns(true)
-      File.expects(:readable?).with('/etc/login.defs').returns(true)
-      File.expects(:read).with('/etc/login.defs').returns('')
-
-      File.stubs(:exist?).with(Not(equals('/etc/login.defs')))
-      File.stubs(:readable?).with(Not(equals('/etc/login.defs')))
-      File.stubs(:read).with(Not(equals('/etc/login.defs')))
+      expect(File).to receive(:exist?).with('/etc/login.defs').and_return(true)
+      expect(File).to receive(:readable?).with('/etc/login.defs').and_return(true)
+      expect(File).to receive(:read).with('/etc/login.defs').and_return('')
 
       expect(Facter.fact('login_defs').value).to eq({ })
     end

--- a/spec/unit/facter/prelink_spec.rb
+++ b/spec/unit/facter/prelink_spec.rb
@@ -26,14 +26,16 @@ EOM
     Facter.clear
 
     # mock out Facter method called when evaluating confine for :kernel
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+
+    allow(File).to receive(:read).with(any_args).and_call_original
   end
 
   context '/etc/sysconfig/prelink enables prelinking' do
     it 'should return hash with enabled status' do
-      Facter::Core::Execution.expects(:which).with('prelink').returns('/usr/sbin/prelink')
-      File.expects(:exist?).with('/etc/sysconfig/prelink').returns(true)
-      File.expects(:read).with('/etc/sysconfig/prelink').returns(sysconfig_prelink_enabled)
+      expect(Facter::Core::Execution).to receive(:which).with('prelink').and_return('/usr/sbin/prelink')
+      expect(File).to receive(:exist?).with('/etc/sysconfig/prelink').and_return(true)
+      expect(File).to receive(:read).with('/etc/sysconfig/prelink').and_return(sysconfig_prelink_enabled)
 
       expect(Facter.fact('prelink').value).to eq({ 'enabled' => true })
     end
@@ -41,33 +43,33 @@ EOM
 
   context '/etc/sysconfig/prelink disables prelinking' do
     it 'should return hash with disabled status' do
-      Facter::Core::Execution.expects(:which).with('prelink').returns('/usr/sbin/prelink')
-      File.expects(:exist?).with('/etc/sysconfig/prelink').returns(true)
-      File.expects(:read).with('/etc/sysconfig/prelink').returns(sysconfig_prelink_disabled)
+      expect(Facter::Core::Execution).to receive(:which).with('prelink').and_return('/usr/sbin/prelink')
+      expect(File).to receive(:exist?).with('/etc/sysconfig/prelink').and_return(true)
+      expect(File).to receive(:read).with('/etc/sysconfig/prelink').and_return(sysconfig_prelink_disabled)
       expect(Facter.fact('prelink').value).to eq({ 'enabled' => false })
     end
   end
 
   context '/etc/sysconfig/prelink does not specify prelinking action' do
     it 'should return hash with disabled status' do
-      Facter::Core::Execution.expects(:which).with('prelink').returns('/usr/sbin/prelink')
-      File.expects(:exist?).with('/etc/sysconfig/prelink').returns(true)
-      File.expects(:read).with('/etc/sysconfig/prelink').returns(sysconfig_prelink_unspecified)
+      expect(Facter::Core::Execution).to receive(:which).with('prelink').and_return('/usr/sbin/prelink')
+      expect(File).to receive(:exist?).with('/etc/sysconfig/prelink').and_return(true)
+      expect(File).to receive(:read).with('/etc/sysconfig/prelink').and_return(sysconfig_prelink_unspecified)
       expect(Facter.fact('prelink').value).to eq({ 'enabled' => false })
     end
   end
 
   context '/etc/sysconfig/prelink is absent' do
     it 'should return hash with disabled status' do
-      Facter::Core::Execution.expects(:which).with('prelink').returns('/usr/sbin/prelink')
-      File.expects(:exist?).with('/etc/sysconfig/prelink').returns(false)
+      expect(Facter::Core::Execution).to receive(:which).with('prelink').and_return('/usr/sbin/prelink')
+      expect(File).to receive(:exist?).with('/etc/sysconfig/prelink').and_return(false)
       expect(Facter.fact('prelink').value).to eq({ 'enabled' => false })
     end
   end
 
   context 'prelink executable is not available' do
     it 'should return nil' do
-      Facter::Core::Execution.expects(:which).with('prelink').returns(nil)
+      expect(Facter::Core::Execution).to receive(:which).with('prelink').and_return(nil)
 
       expect(Facter.fact('prelink').value).to be nil
     end

--- a/spec/unit/facter/simplib__auditd_spec.rb
+++ b/spec/unit/facter/simplib__auditd_spec.rb
@@ -4,167 +4,163 @@ describe 'simplib__auditd' do
   before :each  do
     Facter.clear
 
-    Facter.stubs(:value).with(:kernel).returns('Linux')
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-
-    Facter::Util::Resolution.stubs(:which).with('auditctl').returns('/sbin/auditctl')
-    Facter::Util::Resolution.stubs(:which).with('ps').returns('/bin/ps')
+    allow(Facter).to receive(:value).with(any_args).and_call_original
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    expect(Facter::Util::Resolution).to receive(:which).with('ps').and_return('/bin/ps')
   end
 
   context 'with auditctl not present' do
     it do
-      Facter::Util::Resolution.stubs(:which).with('auditctl').returns(nil)
+      expect(Facter::Util::Resolution).to receive(:which).with('auditctl').and_return(nil)
 
       expect(Facter.fact('simplib__auditd').value).to be_nil
     end
   end
 
-  context 'with audit disabled in the kernel' do
-    it do
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -s').returns("\n")
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -v').returns("\n")
-      Facter.stubs(:value).with('cmdline').returns({ 'audit' => '0'})
+  context 'with auditctl present' do
+    before :each  do
+      expect(Facter::Util::Resolution).to receive(:which).with('auditctl').and_return('/sbin/auditctl')
+    end
 
-      expect(Facter.fact('simplib__auditd').value).to eq(
+    context 'with audit disabled in the kernel' do
+      it do
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -s').and_return("\n")
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -v').and_return("\n")
+        expect(Facter).to receive(:value).with('cmdline').and_return({ 'audit' => '0'})
+
+        expect(Facter.fact('simplib__auditd').value).to eq(
+          {
+            'enforcing'        => false,
+            'kernel_enforcing' => false,
+            'enabled'          => false
+          }
+        )
+      end
+    end
+
+    context 'with auditd disabled and audit enabled in the kernel after reboot' do
+      it do
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -v').and_return("1.2.3\n")
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -s').and_return("\n")
+        expect(Facter).to receive(:value).with('cmdline').and_return({ 'audit' => '1'})
+
+        expect(Facter.fact('simplib__auditd').value).to eq(
+          {
+            'enforcing'        => false,
+            'kernel_enforcing' => true,
+            'enabled'          => false,
+            'version'          => '1.2.3'
+          }
+        )
+      end
+    end
+
+    context 'after reboot where auditd was disabled before reboot' do
+      before(:each) do
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -v').and_return("1.2.3\n")
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -s')
+          .and_return( <<~AUDITCTL_S
+                   enabled 0
+                   failure 1
+                   pid 1337
+                   rate_limit 0
+                   backlog_limit 64
+                   lost 0
+                   backlog 0
+                   backlog_wait_time 60000
+                   loginuid_immutable 0 unlocked
+                   AUDITCTL_S
+                  )
+      end
+
+      let(:simplib__auditd_value_explicit) do
         {
-          'enforcing'        => false,
-          'kernel_enforcing' => false,
-          'enabled'          => false
+          'enforcing'          => false,
+          'kernel_enforcing'   => true,
+          'enabled'            => false,
+          'version'            => '1.2.3',
+          'failure'            => 1,
+          'pid'                => 1337,
+          'rate_limit'         => 0,
+          'backlog_limit'      => 64,
+          'lost'               => 0,
+          'backlog'            => 0,
+          'backlog_wait_time'  => 60000,
+          'loginuid_immutable' => '0 unlocked'
         }
-      )
+      end
+
+      let(:simplib__auditd_value_implicit) do
+        # without auditd running, in the absence of cmdline option,
+        # have no way of knowing
+        simplib__auditd_value_explicit.merge({'kernel_enforcing' => false})
+      end
+
+      context 'with audit explicitly enabled in the kernel' do
+        it do
+          expect(Facter).to receive(:value).with('cmdline').and_return({ 'audit' => '1'})
+          expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value_explicit)
+        end
+      end
+
+      context 'with audit implicitly enabled in the kernel' do
+        it do
+          expect(Facter).to receive(:value).with('cmdline').and_return({})
+          expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value_implicit)
+        end
+      end
+
     end
-  end
 
-  context 'with auditd disabled and audit enabled in the kernel after reboot' do
-    it do
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -v').returns("1.2.3\n")
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -s').returns("\n")
-      Facter.stubs(:value).with('cmdline').returns({ 'audit' => '1'})
+    context 'with a properly functioning auditd' do
+      before(:each) do
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -v').and_return("1.2.3\n")
+        expect(Facter::Core::Execution).to receive(:exec).with('/sbin/auditctl -s')
+          .and_return( <<~AUDITCTL_S
+                   enabled 1
+                   failure 1
+                   pid 1337
+                   rate_limit 0
+                   backlog_limit 64
+                   lost 0
+                   backlog 0
+                   backlog_wait_time 60000
+                   loginuid_immutable 0 unlocked
+                   AUDITCTL_S
+                  )
+        expect(Facter::Core::Execution).to receive(:exec).with('/bin/ps -e')
+          .and_return( <<~PS_OUTPUT
+            PID TTY          TIME CMD
+              1 ?        00:00:04 systemd
+              2 ?        00:00:00 kthreadd
+              3 ?        00:00:00 kauditd
+              4 ?        00:00:00 auditd
+            PS_OUTPUT
+           )
+      end
 
-      expect(Facter.fact('simplib__auditd').value).to eq(
+      let(:simplib__auditd_value) do
         {
-          'enforcing'        => false,
-          'kernel_enforcing' => true,
-          'enabled'          => false,
-          'version'          => '1.2.3'
+          'enforcing'          => true,
+          'kernel_enforcing'   => true,
+          'enabled'            => true,
+          'version'            => '1.2.3',
+          'failure'            => 1,
+          'pid'                => 1337,
+          'rate_limit'         => 0,
+          'backlog_limit'      => 64,
+          'lost'               => 0,
+          'backlog'            => 0,
+          'backlog_wait_time'  => 60000,
+          'loginuid_immutable' => '0 unlocked'
         }
-      )
-    end
-  end
-
-  context 'with auditd disabled before reboot' do
-    before(:each) do
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -v').returns("1.2.3\n")
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -s')
-        .returns( <<~AUDITCTL_S
-                 enabled 1
-                 failure 1
-                 pid 1337
-                 rate_limit 0
-                 backlog_limit 64
-                 lost 0
-                 backlog 0
-                 backlog_wait_time 60000
-                 loginuid_immutable 0 unlocked
-                 AUDITCTL_S
-                )
-      Facter::Core::Execution.expects(:exec).with('/bin/ps -e')
-        .returns( <<~PS_OUTPUT
-          PID TTY          TIME CMD
-            1 ?        00:00:04 systemd
-            2 ?        00:00:00 kthreadd
-            3 ?        00:00:00 kauditd
-          PS_OUTPUT
-         )
-    end
-
-    let(:simplib__auditd_value) do
-      {
-        'enforcing'          => false,
-        'kernel_enforcing'   => true,
-        'enabled'            => true,
-        'version'            => '1.2.3',
-        'failure'            => 1,
-        'pid'                => 1337,
-        'rate_limit'         => 0,
-        'backlog_limit'      => 64,
-        'lost'               => 0,
-        'backlog'            => 0,
-        'backlog_wait_time'  => 60000,
-        'loginuid_immutable' => '0 unlocked'
-      }
-    end
-
-    context 'with audit explicitly enabled in the kernel' do
-      it do
-        Facter.stubs(:value).with('cmdline').returns({ 'audit' => '1'})
-        expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value)
       end
-    end
 
-    context 'with audit implicitly enabled in the kernel' do
-      it do
-        Facter.stubs(:value).with('cmdline').returns({})
-        expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value)
-      end
-    end
-  end
-
-  context 'with a properly functioning auditd' do
-    before(:each) do
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -v').returns("1.2.3\n")
-      Facter::Core::Execution.expects(:exec).with('/sbin/auditctl -s')
-        .returns( <<~AUDITCTL_S
-                 enabled 1
-                 failure 1
-                 pid 1337
-                 rate_limit 0
-                 backlog_limit 64
-                 lost 0
-                 backlog 0
-                 backlog_wait_time 60000
-                 loginuid_immutable 0 unlocked
-                 AUDITCTL_S
-                )
-      Facter::Core::Execution.expects(:exec).with('/bin/ps -e')
-        .returns( <<~PS_OUTPUT
-          PID TTY          TIME CMD
-            1 ?        00:00:04 systemd
-            2 ?        00:00:00 kthreadd
-            3 ?        00:00:00 kauditd
-            4 ?        00:00:00 auditd
-          PS_OUTPUT
-         )
-    end
-
-    let(:simplib__auditd_value) do
-      {
-        'enforcing'          => true,
-        'kernel_enforcing'   => true,
-        'enabled'            => true,
-        'version'            => '1.2.3',
-        'failure'            => 1,
-        'pid'                => 1337,
-        'rate_limit'         => 0,
-        'backlog_limit'      => 64,
-        'lost'               => 0,
-        'backlog'            => 0,
-        'backlog_wait_time'  => 60000,
-        'loginuid_immutable' => '0 unlocked'
-      }
-    end
-
-    context 'with audit explicitly enabled in the kernel' do
-      it do
-        Facter.stubs(:value).with('cmdline').returns({ 'audit' => '1'})
-        expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value)
-      end
-    end
-
-    context 'with audit implicitly enabled in the kernel' do
-      it do
-        Facter.stubs(:value).with('cmdline').returns({})
-        expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value)
+      context 'with audit explicitly or implicitly enabled in the kernel' do
+        it do
+          expect(Facter.fact('simplib__auditd').value).to eq(simplib__auditd_value)
+        end
       end
     end
   end

--- a/spec/unit/facter/simplib__firewalls_spec.rb
+++ b/spec/unit/facter/simplib__firewalls_spec.rb
@@ -4,11 +4,11 @@ describe "simplib__firewalls" do
 
   before :each do
     Facter.clear
-
-    Facter::Util::Resolution.expects(:which).with('firewalld').returns('/usr/bin/firewalld')
-    Facter::Util::Resolution.expects(:which).with('nft').returns('/usr/bin/nft')
-    Facter::Util::Resolution.expects(:which).with('pfctl').returns('/bin/pfctl')
-    Facter::Util::Resolution.stubs(:which).with(Not(any_of('firewalld','nft','pfctl')))
+    allow(Facter::Util::Resolution).to receive(:which).with(any_args).and_call_original
+    expect(Facter::Util::Resolution).to receive(:which).with('firewalld').and_return('/usr/bin/firewalld')
+    expect(Facter::Util::Resolution).to receive(:which).with('iptables').and_return(nil)
+    expect(Facter::Util::Resolution).to receive(:which).with('nft').and_return('/usr/bin/nft')
+    expect(Facter::Util::Resolution).to receive(:which).with('pfctl').and_return('/bin/pfctl')
   end
 
   it { expect(Facter.fact('simplib__firewalls').value).to eq(['firewalld','nft','pf']) }

--- a/spec/unit/facter/simplib__mountpoints_spec.rb
+++ b/spec/unit/facter/simplib__mountpoints_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe 'simplib__mountpoints' do
   before :each do
     Facter.clear
-    Facter.stubs(:value).with(:kernel).returns('Linux')
-    File.stubs(:exist?).with('/proc/mounts').returns(true)
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+    expect(File).to receive(:exist?).with('/proc/mounts').and_return(true)
 
     class EtcStub
       attr_accessor :name
@@ -16,9 +16,9 @@ describe 'simplib__mountpoints' do
       end
     end
 
-    Etc.stubs(:getgrgid).with(953).returns(EtcStub.new)
+    expect(Etc).to receive(:getgrgid).with(953).and_return(EtcStub.new)
 
-    Facter::Core::Execution.stubs(:execute).with('cat /proc/mounts 2> /dev/null', :on_fail => nil).returns(
+    expect(Facter::Core::Execution).to receive(:execute).with('cat /proc/mounts 2> /dev/null', :on_fail => nil).and_return(
       <<~EL7_PROC_MOUNTS,
       rootfs / rootfs rw 0 0
       sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
@@ -56,26 +56,26 @@ describe 'simplib__mountpoints' do
     )
 
     # Standard systemd tmp.mount
-    Facter::Core::Execution.stubs(:execute).with('findmnt /tmp', :on_fail => nil).returns(
+    expect(Facter::Core::Execution).to receive(:execute).with('findmnt /tmp', :on_fail => nil).and_return(
       <<~EL7_FINDMNT_TMP,
       TARGET SOURCE FSTYPE OPTIONS
       /tmp   tmpfs  tmpfs  rw,seclabel
       EL7_FINDMNT_TMP
     )
     # Bind mounted onto itself
-    Facter::Core::Execution.stubs(:execute).with('findmnt /var/tmp', :on_fail => nil).returns(
+    expect(Facter::Core::Execution).to receive(:execute).with('findmnt /var/tmp', :on_fail => nil).and_return(
       <<~EL7_FINDMNT_VAR_TMP,
       TARGET   SOURCE              FSTYPE OPTIONS
       /var/tmp /dev/sda1[/var/tmp] xfs    rw,relatime,seclabel,attr2,inode64,noquota
       EL7_FINDMNT_VAR_TMP
     )
-    Facter::Core::Execution.stubs(:execute).with('findmnt /dev/shm', :on_fail => nil).returns(
+    expect(Facter::Core::Execution).to receive(:execute).with('findmnt /dev/shm', :on_fail => nil).and_return(
       <<~EL7_FINDMNT_DEV_SHM,
       TARGET   SOURCE FSTYPE OPTIONS
       /dev/shm tmpfs  tmpfs  rw,nosuid,nodev,seclabel
       EL7_FINDMNT_DEV_SHM
     )
-    Facter::Core::Execution.stubs(:execute).with('findmnt /proc', :on_fail => nil).returns(
+    expect(Facter::Core::Execution).to receive(:execute).with('findmnt /proc', :on_fail => nil).and_return(
       <<~EL7_FINDMNT_PROC,
       TARGET SOURCE FSTYPE OPTIONS
       /proc  proc   proc   rw,nosuid,nodev,noexec,relatime,hidepid=2,gid=953
@@ -163,7 +163,7 @@ describe 'simplib__mountpoints' do
 
   context 'when Facter does not have a filled "mountpoints" fact' do
     before :each do
-      Facter.stubs(:value).with('mountpoints').returns(nil)
+      expect(Facter).to receive(:value).with('mountpoints').and_return(nil)
     end
 
     it 'returns the minimally filled fact' do
@@ -284,7 +284,7 @@ describe 'simplib__mountpoints' do
     end
 
     before :each do
-      Facter.stubs(:value).with('mountpoints').returns(facter_mountpoints)
+      expect(Facter).to receive(:value).with('mountpoints').and_return(facter_mountpoints)
     end
 
     it 'returns the merged fact' do

--- a/spec/unit/facter/simplib__networkmanager_spec.rb
+++ b/spec/unit/facter/simplib__networkmanager_spec.rb
@@ -4,12 +4,12 @@ describe 'simplib__networkmanager' do
 
   before :each do
     Facter.clear
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-    Facter::Util::Resolution.stubs(:which).with('nmcli').returns('/usr/sbin/nmcli')
+    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    expect(Facter::Util::Resolution).to receive(:which).with('nmcli').and_return('/usr/sbin/nmcli')
 
-    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nmcli -t -m multiline general status', :on_fail => :failed).returns(general_status)
-    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nmcli -t general hostname', :on_fail => :failed).returns(general_hostname)
-    Facter::Core::Execution.stubs(:execute).with('/usr/sbin/nmcli -t connection show', :on_fail => :failed).returns(connections)
+    expect(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nmcli -t -m multiline general status', :on_fail => :failed).and_return(general_status)
+    expect(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nmcli -t general hostname', :on_fail => :failed).and_return(general_hostname)
+    expect(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nmcli -t connection show', :on_fail => :failed).and_return(connections)
   end
 
   context 'nmcli fails' do

--- a/spec/unit/facter/simplib__numa_spec.rb
+++ b/spec/unit/facter/simplib__numa_spec.rb
@@ -5,17 +5,18 @@ require 'spec_helper'
 describe 'simplib__numa' do
   before :each do
     Facter.clear
-    Facter.stubs(:value).with(:kernel).returns('Linux')
-    File.expects(:exist?).with('/sys/devices/system/node').once.returns(true)
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+    expect(File).to receive(:exist?).with('/sys/devices/system/node').and_return(true)
+    allow(File).to receive(:read).with(any_args).and_call_original
   end
 
   context 'with files set for two NUMA zones ' do
     before :each do
-      File.expects(:exist?).with('/sys/devices/system/node/possible').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/possible').once.returns("0-1")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/possible').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/possible').and_return("0-1")
 
-      File.expects(:exist?).with('/sys/devices/system/node/online').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/online').once.returns("0-1")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/online').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/online').and_return("0-1")
 
       @memory1_tempdir = Dir.mktmpdir
       @memory2_tempdir = Dir.mktmpdir
@@ -26,7 +27,7 @@ describe 'simplib__numa' do
       Dir.mkdir(node0)
       Dir.mkdir(node1)
 
-      Dir.stubs(:glob).with('/sys/devices/system/node/node*').returns([node0, node1])
+      expect(Dir).to receive(:glob).with('/sys/devices/system/node/node*').and_return([node0, node1])
     end
 
     after :each do
@@ -129,11 +130,11 @@ describe 'simplib__numa' do
 
   context 'with files set for one NUMA zone online ' do
     before :each do
-      File.expects(:exist?).with('/sys/devices/system/node/possible').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/possible').once.returns("0-1")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/possible').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/possible').and_return("0-1")
 
-      File.expects(:exist?).with('/sys/devices/system/node/online').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/online').once.returns("0")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/online').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/online').and_return("0")
 
       @memory1_tempdir = Dir.mktmpdir
       @memory2_tempdir = Dir.mktmpdir
@@ -144,7 +145,7 @@ describe 'simplib__numa' do
       Dir.mkdir(node0)
       Dir.mkdir(node1)
 
-      Dir.stubs(:glob).with('/sys/devices/system/node/node*').returns([node0, node1])
+      expect(Dir).to receive(:glob).with('/sys/devices/system/node/node*').and_return([node0, node1])
     end
 
     after :each do
@@ -247,11 +248,11 @@ describe 'simplib__numa' do
 
   context 'with files set for one NUMA zone ' do
     before :each do
-      File.expects(:exist?).with('/sys/devices/system/node/possible').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/possible').once.returns("0")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/possible').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/possible').and_return("0")
 
-      File.expects(:exist?).with('/sys/devices/system/node/online').once.returns(true)
-      File.expects(:read).with('/sys/devices/system/node/online').once.returns("0")
+      expect(File).to receive(:exist?).with('/sys/devices/system/node/online').and_return(true)
+      expect(File).to receive(:read).with('/sys/devices/system/node/online').and_return("0")
 
       @memory1_tempdir = Dir.mktmpdir
 
@@ -259,7 +260,7 @@ describe 'simplib__numa' do
 
       Dir.mkdir(node0)
 
-      Dir.stubs(:glob).with('/sys/devices/system/node/node*').returns([node0])
+      expect(Dir).to receive(:glob).with('/sys/devices/system/node/node*').and_return([node0])
     end
 
     after :each do

--- a/spec/unit/facter/simplib__secure_boot_enabled_spec.rb
+++ b/spec/unit/facter/simplib__secure_boot_enabled_spec.rb
@@ -5,12 +5,12 @@ require 'spec_helper'
 describe 'simplib__secure_boot_enabled' do
   before :each do
     Facter.clear
-    Facter.stubs(:value).with(:kernel).returns('Linux')
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
   end
 
   context 'without SecureBoot files in /sys/firmware/efi/efivars' do
     it do
-      Dir.stubs(:glob).with('/sys/firmware/efi/efivars/SecureBoot-*').returns([])
+      expect(Dir).to receive(:glob).with('/sys/firmware/efi/efivars/SecureBoot-*').and_return([])
 
       expect(Facter.fact('simplib__secure_boot_enabled').value).to match(false)
     end
@@ -21,8 +21,8 @@ describe 'simplib__secure_boot_enabled' do
       @sb_tempfile = Tempfile.new('simplib__secure_boot_enabled')
       @sm_tempfile = Tempfile.new('simplib__secure_boot_enabled')
 
-      Dir.stubs(:glob).with('/sys/firmware/efi/efivars/SecureBoot-*').returns([@sb_tempfile.path])
-      Dir.stubs(:glob).with('/sys/firmware/efi/efivars/SetupMode-*').returns([@sm_tempfile.path])
+      allow(Dir).to receive(:glob).with('/sys/firmware/efi/efivars/SecureBoot-*').and_return([@sb_tempfile.path])
+      allow(Dir).to receive(:glob).with('/sys/firmware/efi/efivars/SetupMode-*').and_return([@sm_tempfile.path])
     end
 
     after :each do

--- a/spec/unit/facter/simplib__sshd_config_spec.rb
+++ b/spec/unit/facter/simplib__sshd_config_spec.rb
@@ -5,22 +5,13 @@ describe "simplib__sshd_config" do
   before :each do
     Facter.clear
 
-    Facter::Util::Resolution.expects(:which).with('sshd').returns('/usr/bin/sshd')
-    Facter::Core::Execution.expects(:execute).with('/usr/bin/sshd -. 2>&1', :on_fail => :failed).returns(openssh_version['full_version'])
+    expect(Facter::Util::Resolution).to receive(:which).with('sshd').and_return('/usr/bin/sshd')
+    expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/sshd -. 2>&1', :on_fail => :failed).and_return(openssh_version['full_version'])
 
-    File.expects(:exist?).with('/etc/ssh/sshd_config').at_least_once.returns(true)
-    File.expects(:readable?).with('/etc/ssh/sshd_config').returns(true)
-    File.expects(:read).with('/etc/ssh/sshd_config').returns(sshd_config_content)
-
-    # This resets the stubbing code in Mocha to ensure that the code does not
-    # try to catch any other calls to the stubbed methods above.
-    #
-    # This is not documented well and is almost always what you want in
-    # Puppet testing
-
-    File.stubs(:exist?).with(Not(equals('/etc/ssh/sshd_config')))
-    File.stubs(:readable?).with(Not(equals('/etc/ssh/sshd_config')))
-    File.stubs(:read).with(Not(equals('/etc/ssh/sshd_config')))
+    expect(File).to receive(:exist?).with('/etc/ssh/sshd_config').and_return(true).at_least(:once)
+    expect(File).to receive(:readable?).with('/etc/ssh/sshd_config').and_return(true)
+    allow(File).to receive(:read).with(any_args).and_call_original
+    expect(File).to receive(:read).with('/etc/ssh/sshd_config').and_return(sshd_config_content)
   end
 
   let(:openssh_version) {{

--- a/spec/unit/puppet/type/init_ulimit_spec.rb
+++ b/spec/unit/puppet/type/init_ulimit_spec.rb
@@ -5,11 +5,6 @@ require 'spec_helper'
 init_ulimit_type = Puppet::Type.type(:init_ulimit)
 
 describe init_ulimit_type do
-  before(:each) do
-    @catalog = Puppet::Resource::Catalog.new
-    Puppet::Type::Reboot_notify.any_instance.stubs(:catalog).returns(@catalog)
-  end
-
   context 'when setting parameters' do
     it 'should accept valid input' do
       resource = init_ulimit_type.new(

--- a/spec/unit/puppet/type/reboot_notify_spec.rb
+++ b/spec/unit/puppet/type/reboot_notify_spec.rb
@@ -7,7 +7,7 @@ reboot_notify_type = Puppet::Type.type(:reboot_notify)
 describe reboot_notify_type do
   before(:each) do
     @catalog = Puppet::Resource::Catalog.new
-    Puppet::Type::Reboot_notify.any_instance.stubs(:catalog).returns(@catalog)
+    allow_any_instance_of(Puppet::Type::Reboot_notify).to receive(:catalog).and_return(@catalog)
   end
 
   context 'when setting parameters' do

--- a/spec/unit/puppet/type/runlevel_spec.rb
+++ b/spec/unit/puppet/type/runlevel_spec.rb
@@ -7,7 +7,7 @@ runlevel_type = Puppet::Type.type(:runlevel)
 describe runlevel_type do
   before(:each) do
     @catalog = Puppet::Resource::Catalog.new
-    Puppet::Type::Runlevel.any_instance.stubs(:catalog).returns(@catalog)
+    allow_any_instance_of(Puppet::Type::Runlevel).to receive(:catalog).and_return(@catalog)
   end
 
   context 'when setting parameters' do


### PR DESCRIPTION
Converted unit tests to use rspec mocks in order
to solve the problem in which unit tests fail
on Puppet 7 because all instances of `File.read`
could not be mocked.

SIMP-9115 #close