### PR TITLE
(SIMP-9521) Replace troubled Windows Vagrant box

### DIFF
--- a/spec/acceptance/suites/windows/nodesets/default.yml
+++ b/spec/acceptance/suites/windows/nodesets/default.yml
@@ -17,7 +17,7 @@ HOSTS:
     roles:
       - windows
     platform: windows-server-amd64
-    box: opentable/win-2012r2-standard-amd64-nocm
+    box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2

--- a/spec/acceptance/suites/windows/nodesets/default.yml
+++ b/spec/acceptance/suites/windows/nodesets/default.yml
@@ -17,8 +17,7 @@ HOSTS:
     roles:
       - windows
     platform: windows-server-amd64
-    box: gusztavvargadr/windows-server
-    box_version: 1809.0.2006.standard
+    box: opentable/win-2012r2-standard-amd64-nocm
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2


### PR DESCRIPTION
This patch replaces a deprecated Vagrant windows-server box with
devopsgroup-io/windows_server-2012r2-standard-amd64-nocm

[SIMP-9521] #close

[SIMP-9521]: https://simp-project.atlassian.net/browse/SIMP-9521