### PR TITLE
(SIMP-9427) Add simplib::params2hash()

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.6'
   Include:
   - "**/*.rb"
   Exclude:
@@ -29,9 +29,9 @@ Lint/RaiseException:
   Enabled: true
 Lint/StructNewOverride:
   Enabled: false
-GetText:
+I18n/GetText:
   Enabled: false
-GetText/DecorateString:
+I18n/GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
@@ -124,11 +124,11 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+I18n/GetText/DecorateFunctionMessage:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+I18n/GetText/DecorateStringFormattingUsingInterpolation:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+I18n/GetText/DecorateStringFormattingUsingPercent:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
@@ -157,6 +157,8 @@ RSpec/ExampleLength:
 RSpec/MessageExpectation:
   Enabled: false
 RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/NestedGroups:
   Enabled: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Apr 29 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.8.0
+- Add a `simplib::params2hash()` function to return all of the calling scope's
+  parameters as a Hash
+
 * Mon Feb 01 2021 Kendall Moore <kendall.moore@onyxpoint.com> - 4.7.1
 - Add net.ipv6.conf.all.disable_ipv6 to simplib_sysctl
 

--- a/Gemfile.project
+++ b/Gemfile.project
@@ -7,5 +7,5 @@ group :test do
 end
 
 group :system_tests do
-  gem 'docker-api', '~> 2.1'
+  gem 'beaker-windows'
 end

--- a/Gemfile.project
+++ b/Gemfile.project
@@ -1,9 +1,11 @@
 group :test do
   gem 'rubocop'
+  gem 'rubocop-rake'
   gem 'rubocop-rspec'
   gem 'rubocop-i18n'
+  gem 'super_diff'
 end
 
 group :system_tests do
-  gem 'beaker-windows'
+  gem 'docker-api', '~> 2.1'
 end

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,7 +54,7 @@
 * [`simplib::module_metadata::os_supported`](#simplibmodule_metadataos_supported): Returns whether or not the passed module is supported per the module's metadata.json.
 * [`simplib::nets2cidr`](#simplibnets2cidr): Take an input list of networks and returns an equivalent `Array` in CIDR notation.  * Hostnames are passed through untouched. * Terminates ca
 * [`simplib::nets2ddq`](#simplibnets2ddq): Tranforms a list of networks into an equivalent array in dotted quad notation.  * IPv4 CIDR networks are converted to dotted quad notation ne
-* [`simplib::params2hash`](#simplibparams2hash): Returns a Hash of the parameters of the calling resource
+* [`simplib::params2hash`](#simplibparams2hash): Returns a Hash of the parameters of the calling resource  This is meant to get the parameters of classes and defined types. The behavior when
 * [`simplib::parse_hosts`](#simplibparse_hosts): Convert an `Array` of items that may contain port numbers or protocols into a structured `Hash` of host information.  * Works with Hostnames 
 * [`simplib::passgen`](#simplibpassgen): Generates/retrieves a random password string or its hash for a passed identifier.  * Supports 2 modes:   * simpkv     * Password info is stor
 * [`simplib::passgen::gen_password_and_salt`](#simplibpassgengen_password_and_salt): Generates a password and salt  * Password length, complexity and complex-only settings are specified by   the caller. * Salt length, complexi
@@ -2481,9 +2481,15 @@ Type: Ruby 4.x API
 
 Returns a Hash of the parameters of the calling resource
 
+This is meant to get the parameters of classes and defined types.
+The behavior when calling from other contexts is undefined
+
 #### `simplib::params2hash(Optional[Array[String[1]]] $prune)`
 
 Returns a Hash of the parameters of the calling resource
+
+This is meant to get the parameters of classes and defined types.
+The behavior when calling from other contexts is undefined
 
 Returns: `Hash` All in-scope parameters
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,6 +54,7 @@
 * [`simplib::module_metadata::os_supported`](#simplibmodule_metadataos_supported): Returns whether or not the passed module is supported per the module's metadata.json.
 * [`simplib::nets2cidr`](#simplibnets2cidr): Take an input list of networks and returns an equivalent `Array` in CIDR notation.  * Hostnames are passed through untouched. * Terminates ca
 * [`simplib::nets2ddq`](#simplibnets2ddq): Tranforms a list of networks into an equivalent array in dotted quad notation.  * IPv4 CIDR networks are converted to dotted quad notation ne
+* [`simplib::params2hash`](#simplibparams2hash): Returns a Hash of the parameters of the calling resource
 * [`simplib::parse_hosts`](#simplibparse_hosts): Convert an `Array` of items that may contain port numbers or protocols into a structured `Hash` of host information.  * Works with Hostnames 
 * [`simplib::passgen`](#simplibpassgen): Generates/retrieves a random password string or its hash for a passed identifier.  * Supports 2 modes:   * simpkv     * Password info is stor
 * [`simplib::passgen::gen_password_and_salt`](#simplibpassgengen_password_and_salt): Generates a password and salt  * Password length, complexity and complex-only settings are specified by   the caller. * Salt length, complexi
@@ -2473,6 +2474,24 @@ Data type: `String`
 
 String containing the list of networks to
 convert; list elements are separated by spaces, commas or semicolons.
+
+### <a name="simplibparams2hash"></a>`simplib::params2hash`
+
+Type: Ruby 4.x API
+
+Returns a Hash of the parameters of the calling resource
+
+#### `simplib::params2hash(Optional[Array[String[1]]] $prune)`
+
+Returns a Hash of the parameters of the calling resource
+
+Returns: `Hash` All in-scope parameters
+
+##### `prune`
+
+Data type: `Optional[Array[String[1]]]`
+
+Parameters that you wish to exclude from the output
 
 ### <a name="simplibparse_hosts"></a>`simplib::parse_hosts`
 

--- a/lib/puppet/functions/simplib/params2hash.rb
+++ b/lib/puppet/functions/simplib/params2hash.rb
@@ -1,4 +1,7 @@
 # Returns a Hash of the parameters of the calling resource
+#
+# This is meant to get the parameters of classes and defined types.
+# The behavior when calling from other contexts is undefined
 Puppet::Functions.create_function(:'simplib::params2hash', Puppet::Functions::InternalFunction) do
 
   # @param prune

--- a/lib/puppet/functions/simplib/params2hash.rb
+++ b/lib/puppet/functions/simplib/params2hash.rb
@@ -1,0 +1,26 @@
+# Returns a Hash of the parameters of the calling resource
+Puppet::Functions.create_function(:'simplib::params2hash', Puppet::Functions::InternalFunction) do
+
+  # @param prune
+  #   Parameters that you wish to exclude from the output
+  #
+  # @return [Hash]
+  #   All in-scope parameters
+  dispatch :params2hash do
+    scope_param()
+    optional_param 'Array[String[1]]', :prune
+  end
+
+  def params2hash(scope, prune=[])
+    param_hash = scope.resource.to_hash
+
+    prune << :name if (scope.resource.type == 'Class')
+
+    prune.each do |to_prune|
+      next if to_prune.nil?
+      param_hash.delete(to_prune.to_sym)
+    end
+
+    return param_hash
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/functions/simplib/params2hash_spec.rb
+++ b/spec/functions/simplib/params2hash_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+describe 'simplib::params2hash' do
+  let(:pre_condition) {%{
+    class foo(
+      $param1 = 'foo',
+      $prune_me = 'bar',
+      $array = ['one', 'two'],
+      $hash = { 'key' => 'value' }
+    ){
+      $random_var = 'should be ignored'
+
+      notify { 'test': message => 'this is a test'}
+
+      $_params = simplib::params2hash()
+
+      notify { 'class_json': message => $_params.to_json }
+    }
+
+    include 'foo'
+
+    define bar (
+      $param1 = 'foo',
+      $prune_me = 'bar',
+      $array = ['one', 'two'],
+      $hash = { 'key' => 'value' }
+    ){
+      notify { 'test2': message => 'this is another test'}
+
+      $_params = simplib::params2hash()
+
+      notify { 'define_json': message => $_params.to_json }
+    }
+
+    bar{ 'baz': }
+  }}
+
+  it {
+    class_output = JSON.load(catalogue.resource('Notify[class_json]')[:message])
+
+    expect(class_output).to match(
+      {
+        'param1'   => 'foo',
+        'prune_me' => 'bar',
+        'array'    => ['one', 'two'],
+        'hash'     => {'key' => 'value'}
+      }
+    )
+
+    define_output = JSON.load(catalogue.resource('Notify[define_json]')[:message])
+
+    expect(define_output).to match(
+      {
+        'name'     => 'baz',
+        'param1'   => 'foo',
+        'prune_me' => 'bar',
+        'array'    => ['one', 'two'],
+        'hash'     => {'key' => 'value'}
+      }
+    )
+  }
+
+  context 'when pruning values' do
+    let(:pre_condition) {%{
+      class foo(
+        $param1 = 'foo',
+        $prune_me = 'bar',
+        $array = ['one', 'two'],
+        $hash = { 'key' => 'value' }
+      ){
+        notify { 'test': message => 'this is a test'}
+
+        $_params = simplib::params2hash(['prune_me'])
+
+        notify { 'class_json': message => $_params.to_json }
+      }
+
+      include 'foo'
+
+      define bar (
+        $param1 = 'foo',
+        $prune_me = 'bar',
+        $array = ['one', 'two'],
+        $hash = { 'key' => 'value' }
+      ){
+        notify { 'test2': message => 'this is another test'}
+
+        $_params = simplib::params2hash(['prune_me'])
+
+        notify { 'define_json': message => $_params.to_json }
+      }
+
+      bar{ 'baz': }
+    }}
+
+    it {
+      class_output = JSON.load(catalogue.resource('Notify[class_json]')[:message])
+
+      expect(class_output).to match(
+        {
+          'param1'   => 'foo',
+          'array'    => ['one', 'two'],
+          'hash'     => {'key' => 'value'}
+        }
+      )
+
+      define_output = JSON.load(catalogue.resource('Notify[define_json]')[:message])
+
+      expect(define_output).to match(
+        {
+          'name'     => 'baz',
+          'param1'   => 'foo',
+          'array'    => ['one', 'two'],
+          'hash'     => {'key' => 'value'}
+        }
+      )
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet'
+require 'super_diff/rspec'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts
 
@@ -7,19 +10,21 @@ require 'pathname'
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
+module_name = File.basename(File.expand_path(File.join(__FILE__, '../..')))
 
-if !ENV.key?( 'TRUSTED_NODE_DATA' )
-  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
-  ENV['TRUSTED_NODE_DATA']='yes'
+if ENV['PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
 end
 
-default_hiera_config =<<-EOM
+default_hiera_config = <<~HIERA_CONFIG
 ---
 version: 5
 hierarchy:
   - name: SIMP Compliance Engine
     lookup_key: compliance_markup::enforcement
+    options:
+      enabled_sce_versions: [2]
   - name: Custom Test Hiera
     path: "%{custom_hiera}.yaml"
   - name: "%{module_name}"
@@ -29,7 +34,7 @@ hierarchy:
 defaults:
   data_hash: yaml_data
   datadir: "stub"
-EOM
+HIERA_CONFIG
 
 # This can be used from inside your spec tests to set the testable environment.
 # You can use this to stub out an ENC.
@@ -67,26 +72,23 @@ def set_hieradata(hieradata)
   RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
 end
 
-if not File.directory?(File.join(fixture_path,'hieradata')) then
-  FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
+unless File.directory?(File.join(fixture_path, 'hieradata'))
+  FileUtils.mkdir_p(File.join(fixture_path, 'hieradata'))
 end
 
-if not File.directory?(File.join(fixture_path,'modules',module_name)) then
-  FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
+unless File.directory?(File.join(fixture_path, 'modules', module_name))
+  FileUtils.mkdir_p(File.join(fixture_path, 'modules', module_name))
 end
 
 RSpec.configure do |c|
   # If nothing else...
   c.default_facts = {
-    :production => {
+    production: {
       #:fqdn           => 'production.rspec.test.localdomain',
-      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      path: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      concat_basedir: '/tmp'
     }
   }
-
-#FIXME Windows tests fail when enabled
-#  c.trusted_server_facts = true
 
   c.mock_framework = :rspec
   c.mock_with :rspec
@@ -94,12 +96,12 @@ RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
 
-  c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
+  c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 
   # Useless backtrace noise
   backtrace_exclusion_patterns = [
-    /spec_helper/,
-    /gems/
+    %r{spec_helper},
+    %r{gems},
   ]
 
   if c.respond_to?(:backtrace_exclusion_patterns)
@@ -108,9 +110,10 @@ RSpec.configure do |c|
     c.backtrace_clean_patterns = backtrace_exclusion_patterns
   end
 
+  # rubocop:disable RSpec/BeforeAfterAll
   c.before(:all) do
-    data = YAML.load(default_hiera_config)
-    data.keys.each do |key|
+    data = YAML.safe_load(default_hiera_config)
+    data.each_key do |key|
       next unless data[key].is_a?(Hash)
 
       if data[key][:datadir] == 'stub'
@@ -124,31 +127,33 @@ RSpec.configure do |c|
       f.write data.to_yaml
     end
   end
+  # rubocop:enable RSpec/BeforeAfterAll
 
   c.before(:each) do
     @spec_global_env_temp = Dir.mktmpdir('simpspec')
 
     if defined?(environment)
       set_environment(environment)
-      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp, environment.to_s))
     end
 
     # ensure the user running these tests has an accessible environmentpath
+    Puppet[:digest_algorithm] = 'sha256'
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
 
     # sanitize hieradata
     if defined?(hieradata)
-      set_hieradata(hieradata.gsub(':','_'))
+      set_hieradata(hieradata.gsub(':', '_'))
     elsif defined?(class_name)
-      set_hieradata(class_name.gsub(':','_'))
+      set_hieradata(class_name.gsub(':', '_'))
     end
   end
 
   c.after(:each) do
     # clean up the mocked environmentpath
-    FileUtils.remove_entry_secure(@spec_global_env_temp)
+    FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
 end
@@ -156,12 +161,7 @@ end
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
   begin
     Pathname.new(dir).realpath
-  rescue
-    fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
+  rescue StandardError
+    raise "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
   end
-end
-
-if ENV['PUPPET_DEBUG']
-  Puppet::Util::Log.level = :debug
-  Puppet::Util::Log.newdestination(:console)
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,10 +1,15 @@
-# frozen_string_literal: true
-
 require 'beaker-rspec'
 require 'tmpdir'
 require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
+
+require 'beaker/puppet_install_helper'
+require 'beaker-windows'
+include BeakerWindows::Path
+include BeakerWindows::Powershell
+include BeakerWindows::Registry
+include BeakerWindows::WindowsFeature
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
@@ -17,9 +22,40 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
+hosts.each do |host|
+  # https://petersouter.co.uk/testing-windows-puppet-with-beaker/
+  case host['platform']
+  when /windows/
+    GEOTRUST_GLOBAL_CA = <<-EOM.freeze
+-----BEGIN CERTIFICATE-----
+MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
+YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
+EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
+R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
+9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
+fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
+iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
+1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
+bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
+MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
+ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
+uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
+Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
+tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
+PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
+hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
+5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
+-----END CERTIFICATE-----
+    EOM
+    install_cert_on_windows(host, 'geotrustglobal', GEOTRUST_GLOBAL_CA)
+  end
+end
+
+
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host
-  fix_errata_on hosts
+  fix_errata_on(hosts)
 
   # Readable test descriptions
   c.formatter = :documentation
@@ -27,29 +63,29 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     begin
+      nonwin = hosts.dup
+      nonwin.delete_if {|h| h[:platform] =~ /windows/ }
       # Install modules and dependencies from spec/fixtures/modules
-      copy_fixture_modules_to(hosts)
+      copy_fixture_modules_to( nonwin )
       begin
-        server = only_host_with_role(hosts, 'server')
+        server = only_host_with_role(nonwin, 'server')
       rescue ArgumentError => e
-        server = only_host_with_role(hosts, 'default')
+        server = only_host_with_role(nonwin, 'default')
       end
-
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on(server, hosts, cert_dir)
-        hosts.each { |sut| copy_pki_to(sut, cert_dir, '/etc/pki/simp-testing') }
+        run_fake_pki_ca_on(server, nonwin, cert_dir )
+        nonwin.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
       end
 
       # add PKI keys
       copy_keydist_to(server)
     rescue StandardError, ScriptError => e
-      raise e unless ENV['PRY']
-
-      # rubocop:disable Lint/Debugger
-      require 'pry'
-      binding.pry
-      # rubocop:enable Lint/Debugger
+      if ENV['PRY']
+        require 'pry'; binding.pry
+      else
+        raise e
+      end
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,15 +1,10 @@
+# frozen_string_literal: true
+
 require 'beaker-rspec'
 require 'tmpdir'
 require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
-
-require 'beaker/puppet_install_helper'
-require 'beaker-windows'
-include BeakerWindows::Path
-include BeakerWindows::Powershell
-include BeakerWindows::Registry
-include BeakerWindows::WindowsFeature
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
@@ -22,40 +17,9 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
-hosts.each do |host|
-  # https://petersouter.co.uk/testing-windows-puppet-with-beaker/
-  case host['platform']
-  when /windows/
-    GEOTRUST_GLOBAL_CA = <<-EOM.freeze
------BEGIN CERTIFICATE-----
-MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
-MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
-YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
-EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
-R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
-9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
-fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
-iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
-1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
-bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
-MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
-ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
-uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
-Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
-tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
-PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
-hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
-5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
------END CERTIFICATE-----
-    EOM
-    install_cert_on_windows(host, 'geotrustglobal', GEOTRUST_GLOBAL_CA)
-  end
-end
-
-
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host
-  fix_errata_on(hosts)
+  fix_errata_on hosts
 
   # Readable test descriptions
   c.formatter = :documentation
@@ -63,29 +27,29 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     begin
-      nonwin = hosts.dup
-      nonwin.delete_if {|h| h[:platform] =~ /windows/ }
       # Install modules and dependencies from spec/fixtures/modules
-      copy_fixture_modules_to( nonwin )
+      copy_fixture_modules_to(hosts)
       begin
-        server = only_host_with_role(nonwin, 'server')
+        server = only_host_with_role(hosts, 'server')
       rescue ArgumentError => e
-        server = only_host_with_role(nonwin, 'default')
+        server = only_host_with_role(hosts, 'default')
       end
+
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on(server, nonwin, cert_dir )
-        nonwin.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+        run_fake_pki_ca_on(server, hosts, cert_dir)
+        hosts.each { |sut| copy_pki_to(sut, cert_dir, '/etc/pki/simp-testing') }
       end
 
       # add PKI keys
       copy_keydist_to(server)
     rescue StandardError, ScriptError => e
-      if ENV['PRY']
-        require 'pry'; binding.pry
-      else
-        raise e
-      end
+      raise e unless ENV['PRY']
+
+      # rubocop:disable Lint/Debugger
+      require 'pry'
+      binding.pry
+      # rubocop:enable Lint/Debugger
     end
   end
 end


### PR DESCRIPTION
Added:
  - Add a `simplib::params2hash()` function to return all of the calling scope's
    parameters as a Hash

SIMP-9427 #comment added simplib::params2hash() to make sssd management easier