### PR TITLE
(SIMP-10175) simplib Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,10 @@
 ---
 fixtures:
   repositories:
+    haveged: https://github.com/simp/pupmod-simp-haveged.git
     simpkv: https://github.com/simp/pupmod-simp-simpkv.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    systemd: https://github.com/simp/puppet-systemd.git
 
     # This needs to be in place for the rspec-puppet Hiera 5 hook to work
     # No idea why, it may be because Puppet sees a custom backend and loads all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -356,8 +356,47 @@ pup6.pe-oel:
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup6.pe-win:
+pup6.pe-caller_function:
+  <<: *acceptance_base
+  <<: *pup_6_pe
+  script:
+    - 'bundle exec rake beaker:suites[caller_function,default]'
+
+pup6.pe-ipa_fact:
+  <<: *acceptance_base
+  <<: *pup_6_pe
+  script:
+    - 'bundle exec rake beaker:suites[ipa_fact,default]'
+
+pup6.pe-ipa_fact-oel:
+  <<: *acceptance_base
+  <<: *pup_6_pe
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[ipa_fact,oel]'
+
+pup6.pe-prelink_fact:
+  <<: *acceptance_base
+  <<: *pup_6_pe
+  script:
+    - 'bundle exec rake beaker:suites[prelink_fact,default]'
+
+pup6.pe-windows:
   <<: *acceptance_base
   <<: *pup_6_pe
   script:
     - 'bundle exec rake beaker:suites[windows,default]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'
+
+# caller_function exercises code that depends upon Puppet-internals, so make
+# sure it is run for the latest version of Puppet
+pup7.pe-caller_function:
+  <<: *acceptance_base
+  <<: *pup_7_x
+  script:
+    - 'bundle exec rake beaker:suites[caller_function,default]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
-* Tue Jun 22 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.9.0
+* Tue Jul 06 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.9.0
 - Add a `simplib::cron::to_systemd` function to provide 'best-effort'
   conversions of cron resource parameters to a systemd timespec
 - Fix the simplib__networkmanager fact
+- Fix the ipa fact
 
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.9.0
 - Removed support for Puppet 5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 * Tue Jul 06 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.9.0
-- Add a `simplib::cron::to_systemd` function to provide 'best-effort'
+- Added a `simplib::cron::to_systemd` function to provide 'best-effort'
   conversions of cron resource parameters to a systemd timespec
-- Fix the simplib__networkmanager fact
-- Fix the ipa fact
+- Fixed the simplib__networkmanager fact
+- Fixed a bug where the ipa fact did not detect when an EL8 client was
+  joined to an IPA domain
 
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.9.0
 - Removed support for Puppet 5

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,7 +9,6 @@ HOSTS:
   el7:
     roles:
       - client
-      # roles migrated from now-removed el6 node(s):
       - default
       - master
       - prelink
@@ -21,7 +20,7 @@ HOSTS:
     roles:
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/suites/ipa_fact/nodesets/default.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/default.yml
@@ -9,8 +9,7 @@ HOSTS:
   server-el7:
     roles:
       - default
-      # roles migrated from now-removed el6 node(s):
-      - no
+      - no_fips
       - server
     masterless: true
     platform: el-7-x86_64
@@ -19,20 +18,20 @@ HOSTS:
     vagrant_memsize: 2048
     vagrant_cpus: 2
 
+  client-el8:
+    roles:
+      - client
+    masterless: true
+    platform: el-8-x86_64
+    box: generic/centos8
+    hypervisor: <%= hypervisor %>
+
   client-el7:
     roles:
       - client
     masterless: true
-    platform: el-7-x86_64
-    box: centos/7
-    hypervisor: <%= hypervisor %>
-
-  client-oel7:
-    roles:
-      - client
-    masterless: true
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        centos/7
     hypervisor: <%= hypervisor %>
 
 CONFIG:

--- a/spec/acceptance/suites/ipa_fact/nodesets/oel.yml
+++ b/spec/acceptance/suites/ipa_fact/nodesets/oel.yml
@@ -6,28 +6,40 @@
   end
 -%>
 HOSTS:
-  oel7:
+  server-oel7:
+    roles:
+      - default
+      - no_fips
+      - server
+    masterless: true
+    platform: el-7-x86_64
+    box:        generic/oracle7
+    hypervisor: <%= hypervisor %>
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+
+  client-oel7:
     roles:
       - client
-      - default
-      - master
-      - prelink
+    masterless: true
     platform:   el-7-x86_64
     box:        generic/oracle7
     hypervisor: <%= hypervisor %>
 
-  oel8:
+  client-oel8:
     roles:
       - client
+    masterless: true
     platform:   el-8-x86_64
     box:        generic/oracle8
     hypervisor: <%= hypervisor %>
+
 
 CONFIG:
   log_level: verbose
   type: aio
   vagrant_memsize: 256
   vagrant_cpus: 1
-<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
-  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
+  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -57,6 +57,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on(hosts)
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -14,11 +14,11 @@ describe "custom fact ipa" do
   }
 
   let (:ipa_env_query) {
-    '/usr/bin/ipa env domain server realm basedn tls_ca_cert'
+    '/bin/true && LC_ALL=en_US.UTF-8 /usr/bin/ipa env domain server realm basedn tls_ca_cert'
   }
 
   let (:ipa_env_server_query) {
-    '/usr/bin/ipa env --server host'
+    '/bin/true && LC_ALL=en_US.UTF-8 /usr/bin/ipa env --server host'
   }
 
   let (:default_conf) {
@@ -62,13 +62,21 @@ describe "custom fact ipa" do
   end
 
   context 'host is joined to IPA domain' do
+
+    before(:each) do
+      expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
+      expect(Facter::Core::Execution).to receive(:which).with('klist').and_return('/usr/bin/klist')
+      expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
+      expect(Facter::Core::Execution).to receive(:which).with('true').and_return('/bin/true')
+    end
+
     context 'IPA server is available' do
       context 'kinit is not required' do
         it 'should execute only ipa commands and report local env + connected status' do
-          expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
-          expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
           expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
           expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+          allow_any_instance_of(Process::Status).to receive(:success?).and_return(true)
           expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_query, ipa_query_options).and_return(ipa_env)
           expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_server_query, ipa_query_options).and_return(ipa_server_env)
           expect(Facter.fact('ipa').value).to eq({
@@ -83,12 +91,12 @@ describe "custom fact ipa" do
 
       context 'kinit is required' do
         it 'should execute kinit + ipa commands and return local env + connected status' do
-          expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
-          expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
           expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
           expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+          allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
           expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('')
-          expect(Facter::Core::Execution).to receive(:execute).twice.with( ipa_env_query, ipa_query_options).and_return('', ipa_env)
+          expect(Facter::Core::Execution).to receive(:execute).with( ipa_env_query, ipa_query_options).and_return(ipa_env)
           expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_server_query, ipa_query_options).and_return(ipa_server_env)
           expect(Facter.fact('ipa').value).to eq({
             'connected' => true,
@@ -103,12 +111,12 @@ describe "custom fact ipa" do
 
     context 'IPA server is not available' do
       it 'should return defaults from /etc/ipa/default.conf and disconnected status' do
-        expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
-        expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')
         expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
         expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
+        expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+        allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
         expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('some error message')
-        expect(Facter::Core::Execution).to receive(:execute).twice.with(ipa_env_query, ipa_query_options).and_return('')
+        expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_query, ipa_query_options).and_return('')
         expect(Facter.fact('ipa').value).to eq({
           'connected' => false,
           'domain'    => 'example.com',

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -64,6 +64,7 @@ describe "custom fact ipa" do
   context 'host is joined to IPA domain' do
 
     before(:each) do
+      expect(ENV).to receive(:fetch).with('LANG', 'en_US.UTF-8').and_return('en_US.UTF-8')
       expect(Facter::Core::Execution).to receive(:which).with('kinit').and_return('/usr/bin/kinit')
       expect(Facter::Core::Execution).to receive(:which).with('klist').and_return('/usr/bin/klist')
       expect(Facter::Core::Execution).to receive(:which).with('ipa').and_return('/usr/bin/ipa')


### PR DESCRIPTION
* Fixes
  * Fix the IPA fact
* Changes (@lnemsick-simp)
  * Add a Puppet 7 acceptance test
  * Fixe ipa_fact test suite
  * Reinstate GitLab test jobs for caller_function, ipa_fact, and prelink_fact
    suites
  * Split default nodeset for ipa_fact suite into nodesets for CentOS and Oracle
    boxes and then added corresponding *el8 nodes to them
  * Fail acceptance tests if no examples are executed.

SIMP-9666 #comment pupmod-simp-simplib acceptance tests configured
SIMP-10175 #close
SIMP-10303 #close