### PR TITLE
klist -> klist -s

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Dec 16 2021 ke5C2Fin <noreply@github.com> - 4.10.2
+- Fixed
+  - Call `klist -s` instead of `klist` to properly handle cache issues
+
 * Thu Sep 23 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.10.1
 - Fixed
   - Increased randomization in simplib::gen_random_password

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.7', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end

--- a/lib/facter/ipa.rb
+++ b/lib/facter/ipa.rb
@@ -69,7 +69,7 @@ Facter.add(:ipa) do
     # We won't know if we are connected to a server until later
     defaults['connected'] = false
 
-    Facter::Core::Execution.execute(klist)
+    Facter::Core::Execution.execute("#{klist} -s")
     unless $?.success?
       # Obtain host Kerberos token so we can use IPA API
       kinit_msg = Facter::Core::Execution.execute("#{kinit} -k 2>&1", options = {:timeout => kinit_timeout})

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -76,7 +76,7 @@ describe "custom fact ipa" do
         it 'should execute only ipa commands and report local env + connected status' do
           expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
           expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
-          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist -s')
           allow_any_instance_of(Process::Status).to receive(:success?).and_return(true)
           expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_query, ipa_query_options).and_return(ipa_env)
           expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_server_query, ipa_query_options).and_return(ipa_server_env)
@@ -94,7 +94,7 @@ describe "custom fact ipa" do
         it 'should execute kinit + ipa commands and return local env + connected status' do
           expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
           expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
-          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+          expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist -s')
           allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
           expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('')
           expect(Facter::Core::Execution).to receive(:execute).with( ipa_env_query, ipa_query_options).and_return(ipa_env)
@@ -114,7 +114,7 @@ describe "custom fact ipa" do
       it 'should return defaults from /etc/ipa/default.conf and disconnected status' do
         expect(File).to receive(:exist?).with('/etc/ipa/default.conf').and_return(true)
         expect(File).to receive(:read).with('/etc/ipa/default.conf').and_return(default_conf)
-        expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist')
+        expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/klist -s')
         allow_any_instance_of(Process::Status).to receive(:success?).and_return(false)
         expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/kinit -k 2>&1', kinit_query_options).and_return('some error message')
         expect(Facter::Core::Execution).to receive(:execute).with(ipa_env_query, ipa_query_options).and_return('')


### PR DESCRIPTION
Change klist to klist -s to so that it returns 1 when credentials cache cannot be read or is expired, thereby triggering the following kinit.

el7, el8, simp/sssd, simp/simp_ipa
Without this the ipa fact fails and the simp/sssd module removes the ipa domain and provider files if the credential cache is expired.