### PR TITLE
Better `assert_optional_dependency`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
-* Mon Jun 20 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
+* Fir Jun 24 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
 - Fixed
   - Allow `assert_optional_dependency` to handle extended version strings
     (Alpha, Beta, RC, 1.2.3.4, etc...)
 
-* Thu Dec 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.10.3
+* Fri Jun 24 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.10.3
 - Fixed
   - Permit root user to run `puppet lookup --compile` without borking passgen
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fir Jun 24 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
+* Fri Jun 24 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
 - Fixed
   - Allow `assert_optional_dependency` to handle extended version strings
     (Alpha, Beta, RC, 1.2.3.4, etc...)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Jun 20 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
+- Fixed
+  - Allow `assert_optional_dependency` to handle extended version strings
+    (Alpha, Beta, RC, 1.2.3.4, etc...)
+
 * Thu Dec 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.10.3
 - Fixed
   - Permit root user to run `puppet lookup --compile` without borking passgen

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.4'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.15.0', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.4'
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.5'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.15.0', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
@@ -38,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.25.0', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/functions/module_metadata/os_supported.pp
+++ b/functions/module_metadata/os_supported.pp
@@ -50,14 +50,17 @@ function simplib::module_metadata::os_supported (
       if $os_info['operatingsystem'] == $facts['os']['name'] {
         $memo and case $_options['release_match'] {
           'full': {
-            $facts['os']['release']['full'] in $os_info['operatingsystemrelease']
+            !$os_info['operatingsystemrelease'] or ($facts['os']['release']['full'] in $os_info['operatingsystemrelease'])
           }
           'major': {
-            $_os_major_releases = $os_info['operatingsystemrelease'].map |$os_release| {
-              split($os_release, '\.')[0]
-            }
+            if $os_info['operatingsystemrelease'] {
+              $_os_major_releases = $os_info['operatingsystemrelease'].map |$os_release| {
+                split($os_release, '\.')[0]
+              }
 
-            $facts['os']['release']['major'] in $_os_major_releases
+              $facts['os']['release']['major'] in $_os_major_releases
+            }
+            else { true }
           }
           default: { true }
         }

--- a/lib/puppet/functions/simplib/assert_optional_dependency.rb
+++ b/lib/puppet/functions/simplib/assert_optional_dependency.rb
@@ -72,6 +72,15 @@ Puppet::Functions.create_function(:'simplib::assert_optional_dependency') do
     return metadata_level[current_level]
   end
 
+  # Concept lifted from 'node-semver'
+  def coerce(version)
+    version
+      .split('-')
+      .first
+      .split('.')[0, 3]
+      .join('.')
+  end
+
   def check_dependency(module_name, module_dependency)
     require 'semantic_puppet'
 
@@ -103,7 +112,7 @@ Puppet::Functions.create_function(:'simplib::assert_optional_dependency') do
           return %(invalid version range '#{module_dependency['version_requirement']}' for '#{_module_name}')
         end
 
-        module_version = module_metadata['version']
+        module_version = coerce(module_metadata['version'])
 
         begin
           module_version = SemanticPuppet::Version.parse(module_version)

--- a/metadata.json
+++ b/metadata.json
@@ -26,95 +26,30 @@
     }
   ],
   "operatingsystem_support": [
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "11 SP1",
-        "12",
-        "15"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8",
-        "9",
-        "10",
-        "11"
-      ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "14.04",
-        "16.04",
-        "18.04",
-        "19.04",
-        "20.04"
-      ]
-    },
-    {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11",
-        "12"
-      ]
-    },
-    {
-      "operatingsystem": "Windows",
-      "operatingsystemrelease": [
-        "Server 2008",
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "2016",
-        "2019",
-        "7",
-        "8",
-        "10"
-      ]
-    },
-    {
-      "operatingsystem": "AIX",
-      "operatingsystemrelease": [
-        "6.1",
-        "7.1",
-        "7.2"
-      ]
-    },
-    {
-      "operatingsystem": "Amazon",
-      "operatingsystemrelease": [
-        "2"
-      ]
-    }
+    { "operatingsystem": "AIX" },
+    { "operatingsystem": "AlmaLinux" },
+    { "operatingsystem": "Amazon" },
+    { "operatingsystem": "Archlinux" },
+    { "operatingsystem": "CentOS" },
+    { "operatingsystem": "Darwin" },
+    { "operatingsystem": "Debian" },
+    { "operatingsystem": "Fedora" },
+    { "operatingsystem": "FreeBSD" },
+    { "operatingsystem": "Gentoo" },
+    { "operatingsystem": "Linux" },
+    { "operatingsystem": "LinuxMint" },
+    { "operatingsystem": "OpenBSD" },
+    { "operatingsystem": "OpenSUSE" },
+    { "operatingsystem": "OracleLinux" },
+    { "operatingsystem": "Pop!_OS" },
+    { "operatingsystem": "RedHat" },
+    { "operatingsystem": "Rocky" },
+    { "operatingsystem": "SLES" },
+    { "operatingsystem": "Scientific" },
+    { "operatingsystem": "Solaris" },
+    { "operatingsystem": "Ubuntu" },
+    { "operatingsystem": "VirtuozzoLinux" },
+    { "operatingsystem": "Windows" }
   ],
   "requirements": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,6 @@
     }
   ],
   "operatingsystem_support": [
-    { "operatingsystem": "AIX" },
     { "operatingsystem": "AlmaLinux" },
     { "operatingsystem": "Amazon" },
     { "operatingsystem": "Archlinux" },
@@ -36,13 +35,12 @@
     { "operatingsystem": "Fedora" },
     { "operatingsystem": "FreeBSD" },
     { "operatingsystem": "Gentoo" },
-    { "operatingsystem": "Linux" },
     { "operatingsystem": "LinuxMint" },
     { "operatingsystem": "OpenBSD" },
     { "operatingsystem": "OpenSUSE" },
     { "operatingsystem": "OracleLinux" },
-    { "operatingsystem": "Pop!_OS" },
     { "operatingsystem": "RedHat" },
+    { "operatingsystem": "Pop!_OS" },
     { "operatingsystem": "Rocky" },
     { "operatingsystem": "SLES" },
     { "operatingsystem": "Scientific" },

--- a/spec/acceptance/suites/windows/nodesets/default.yml
+++ b/spec/acceptance/suites/windows/nodesets/default.yml
@@ -6,26 +6,18 @@
   end
 -%>
 HOSTS:
-  el7:
-    roles:
-      - default
-    platform: el-7-x86_64
-    box: centos/7
-    hypervisor: <%= hypervisor %>
-
   win:
     roles:
       - windows
     platform: windows-server-amd64
-    box: devopsgroup-io/windows_server-2012r2-standard-amd64-nocm
+    box: gusztavvargadr/windows-server
+    box_version: 2102.0.2205
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2
     user: vagrant
     communicator: winrm
     is_cygwin: false
-    ssh:
-      host_key: '+ssh-dss'
 
 CONFIG:
   log_level: verbose
@@ -33,3 +25,14 @@ CONFIG:
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    host_key:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:host_key].join("\n#{' '*6}- ") %>
+    kex:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:kex].join("\n#{' '*6}- ") %>
+    encryption:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:encryption].join("\n#{' '*6}- ") %>
+    hmac:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:hmac].join("\n#{' '*6}- ") %>

--- a/spec/functions/assert_metadata_spec.rb
+++ b/spec/functions/assert_metadata_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe 'simplib::assert_metadata' do
+  module_metadata = {
+    'name' => 'simp-simplib',
+    'version' => '1.2.3',
+    'author' => 'Yep',
+    'summary' => 'Stubby',
+    'license' => 'Apache-2.0',
+    'operatingsystem_support' => [
+      {
+        'operatingsystem' => 'Ubuntu',
+        'operatingsystemrelease' => ['14.04']
+      }
+    ]
+  }.to_json
+
   valid_facts = {
     :os => {
       'name' => 'Ubuntu',
@@ -56,6 +70,14 @@ describe 'simplib::assert_metadata' do
       'validate' => false
     }
   }
+
+  let(:pre_condition) do
+    <<~PRE_CONDITION
+      function load_module_metadata(String $any) {
+        parsejson('#{module_metadata}')
+      }
+    PRE_CONDITION
+  end
 
   context 'with no version matching' do
     context 'on a supported OS' do

--- a/spec/functions/module_metadata/assert_spec.rb
+++ b/spec/functions/module_metadata/assert_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe 'simplib::module_metadata::assert' do
+  module_metadata = {
+    'name' => 'simp-simplib',
+    'version' => '1.2.3',
+    'author' => 'Yep',
+    'summary' => 'Stubby',
+    'license' => 'Apache-2.0',
+    'operatingsystem_support' => [
+      {
+        'operatingsystem' => 'Ubuntu',
+        'operatingsystemrelease' => ['14.04']
+      }
+    ]
+  }.to_json
+
   valid_facts = {
     :os => {
       'name' => 'Ubuntu',
@@ -90,6 +104,14 @@ describe 'simplib::module_metadata::assert' do
       }
     }
   }
+
+  let(:pre_condition) do
+    <<~PRE_CONDITION
+      function load_module_metadata(String $any) {
+        parsejson('#{module_metadata}')
+      }
+    PRE_CONDITION
+  end
 
   context 'with no version matching' do
     context 'on a supported OS' do

--- a/spec/functions/simplib/assert_optional_dependency_spec.rb
+++ b/spec/functions/simplib/assert_optional_dependency_spec.rb
@@ -15,6 +15,10 @@ describe 'simplib::assert_optional_dependency' do
           },
           {
             'name'                => 'dep/two'
+          },
+          {
+            'name'                => 'dep-three',
+            'version_requirement' => '>= 1.2.3 < 2.0.0'
           }
         ]
       }
@@ -32,6 +36,13 @@ describe 'simplib::assert_optional_dependency' do
     {
       'name'    => 'dep-two',
       'version' => '3.4.5'
+    }
+  }
+
+  let(:dep_three_metadata) {
+    {
+      'name'    => 'dep-three',
+      'version' => '1.2.3-alpha'
     }
   }
 
@@ -57,6 +68,8 @@ describe 'simplib::assert_optional_dependency' do
       expect(func).to receive(:call_function).with('load_module_metadata', 'one').and_return(dep_one_metadata)
       expect(func).to receive(:call_function).with('simplib::module_exist', 'two').and_return(true)
       expect(func).to receive(:call_function).with('load_module_metadata', 'two').and_return(dep_two_metadata)
+      expect(func).to receive(:call_function).with('simplib::module_exist', 'three').and_return(true)
+      expect(func).to receive(:call_function).with('load_module_metadata', 'three').and_return(dep_three_metadata)
       is_expected.to run.with_params('my/module')
     end
 
@@ -125,7 +138,7 @@ describe 'simplib::assert_optional_dependency' do
       it 'should fail' do
         expect(func).to_not receive(:call_function).with('simplib::module_exist', 'one')
 
-        expect{is_expected.to run.with_params('my/module', 'three')}.to raise_error(%r('three' not found in metadata.json))
+        expect{is_expected.to run.with_params('my/module', 'badmod')}.to raise_error(%r('badmod' not found in metadata.json))
       end
     end
   end
@@ -137,6 +150,8 @@ describe 'simplib::assert_optional_dependency' do
       expect(func).to receive(:call_function).with('load_module_metadata', 'one').and_return(dep_one_bad_version)
       expect(func).to receive(:call_function).with('simplib::module_exist', 'two').and_return(true)
       expect(func).to receive(:call_function).with('load_module_metadata', 'two').and_return(dep_two_metadata)
+      expect(func).to receive(:call_function).with('simplib::module_exist', 'three').and_return(true)
+      expect(func).to receive(:call_function).with('load_module_metadata', 'three').and_return(dep_three_metadata)
 
       expect{ is_expected.to run.with_params('my/module') }.to raise_error(%r('one-.+' does not satisfy)m)
     end

--- a/spec/functions/simplib/simp_version_spec.rb
+++ b/spec/functions/simplib/simp_version_spec.rb
@@ -17,6 +17,7 @@ describe 'simplib::simp_version' do
       context 'a valid version exists in simp.version' do
         before(:each) do
           allow(File).to receive(:read).with(any_args).and_call_original
+          allow(File).to receive(:readable?).with(any_args).and_call_original
         end
 
         it 'should return the version with whitespace retained' do

--- a/spec/unit/facter/defaultgateway_spec.rb
+++ b/spec/unit/facter/defaultgateway_spec.rb
@@ -15,7 +15,7 @@ EOM
 
   context 'ip command exists' do
     before :each do
-      expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+      allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
       expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return('/usr/bin/ip')
     end
 

--- a/spec/unit/facter/defaultgatewayiface_spec.rb
+++ b/spec/unit/facter/defaultgatewayiface_spec.rb
@@ -15,7 +15,7 @@ EOM
 
   context 'ip command exists' do
     before :each do
-      expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+      allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
       expect(Facter::Util::Resolution).to receive(:which).with('ip').and_return('/usr/bin/ip')
     end
 

--- a/spec/unit/facter/fips_ciphers_spec.rb
+++ b/spec/unit/facter/fips_ciphers_spec.rb
@@ -4,7 +4,7 @@ describe 'fips_ciphers' do
 
   before :each do
     Facter.clear
-    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
   end
 
   context 'openssl command exists' do

--- a/spec/unit/facter/init_systems_spec.rb
+++ b/spec/unit/facter/init_systems_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 describe 'init_systems' do
   before :each do
     Facter.clear
+
+    allow(Dir).to receive(:exist?).with(any_args).and_call_original
   end
 
   context 'when on a base system' do

--- a/spec/unit/facter/login_defs_spec.rb
+++ b/spec/unit/facter/login_defs_spec.rb
@@ -8,6 +8,7 @@ describe "custom fact login_defs" do
     allow(Facter).to receive(:value).with(any_args).and_call_original
     allow(Facter).to receive(:value).with(:operatingsystem).and_return('Linux')
     allow(File).to receive(:read).with(any_args).and_call_original
+    allow(File).to receive(:readable?).with(any_args).and_call_original
   end
 
   context 'with a well formed /etc/login.defs' do

--- a/spec/unit/facter/prelink_spec.rb
+++ b/spec/unit/facter/prelink_spec.rb
@@ -26,7 +26,7 @@ EOM
     Facter.clear
 
     # mock out Facter method called when evaluating confine for :kernel
-    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
 
     allow(File).to receive(:read).with(any_args).and_call_original
   end

--- a/spec/unit/facter/puppet_settings_spec.rb
+++ b/spec/unit/facter/puppet_settings_spec.rb
@@ -4,10 +4,14 @@ require 'spec_helper'
 describe "custom fact puppet_settings" do
 
   before(:each) do
-    if Facter.collection.respond_to?(:load)
-      Facter.collection.load(:puppet_settings)
-    else
-      Facter.collection.loader.load(:puppet_settings)
+    begin
+      if Facter.collection.respond_to?(:load)
+        Facter.collection.load(:puppet_settings)
+      else
+        Facter.collection.loader.load(:puppet_settings)
+      end
+    rescue
+      # Facter 4 noop
     end
   end
 

--- a/spec/unit/facter/simplib__auditd_spec.rb
+++ b/spec/unit/facter/simplib__auditd_spec.rb
@@ -6,7 +6,7 @@ describe 'simplib__auditd' do
 
     allow(Facter).to receive(:value).with(any_args).and_call_original
     allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
-    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
     expect(Facter::Util::Resolution).to receive(:which).with('ps').and_return('/bin/ps')
   end
 

--- a/spec/unit/facter/simplib__crypto_policy_state_spec.rb
+++ b/spec/unit/facter/simplib__crypto_policy_state_spec.rb
@@ -7,7 +7,7 @@ describe 'simplib__crypto_policy_state' do
     Facter.clear
 
     # Mock out Facter method called when evaluating confine for :kernel
-    # expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
     expect(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
 
     # Ensure that something sane is returned when finding the command

--- a/spec/unit/facter/simplib__mountpoints_spec.rb
+++ b/spec/unit/facter/simplib__mountpoints_spec.rb
@@ -5,7 +5,15 @@ require 'spec_helper'
 describe 'simplib__mountpoints' do
   before :each do
     Facter.clear
-    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+
+    # mock out Facter method called when evaluating confine for :kernel
+    # Facter 4
+    if defined?(Facter::Resolvers::Uname)
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(any_args).and_return('Linux')
+    else
+      allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    end
+
     expect(File).to receive(:exist?).with('/proc/mounts').and_return(true)
 
     class EtcStub

--- a/spec/unit/facter/simplib__networkmanager_spec.rb
+++ b/spec/unit/facter/simplib__networkmanager_spec.rb
@@ -4,7 +4,14 @@ describe 'simplib__networkmanager' do
 
   before :each do
     Facter.clear
-    expect(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    # mock out Facter method called when evaluating confine for :kernel
+    # Facter 4
+    if defined?(Facter::Resolvers::Uname)
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(any_args).and_return('Linux')
+    else
+      allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    end
+
     expect(Facter::Util::Resolution).to receive(:which).with('nmcli').and_return('/usr/sbin/nmcli')
 
     expect(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/nmcli -t -m multiline general status').and_return(general_status)

--- a/spec/unit/facter/simplib__sshd_config_spec.rb
+++ b/spec/unit/facter/simplib__sshd_config_spec.rb
@@ -5,12 +5,14 @@ describe "simplib__sshd_config" do
   before :each do
     Facter.clear
 
+    allow(File).to receive(:read).with(any_args).and_call_original
+    allow(File).to receive(:readable?).with(any_args).and_call_original
+
     expect(Facter::Util::Resolution).to receive(:which).with('sshd').and_return('/usr/bin/sshd')
     expect(Facter::Core::Execution).to receive(:execute).with('/usr/bin/sshd -. 2>&1', :on_fail => :failed).and_return(openssh_version['full_version'])
 
     expect(File).to receive(:exist?).with('/etc/ssh/sshd_config').and_return(true).at_least(:once)
     expect(File).to receive(:readable?).with('/etc/ssh/sshd_config').and_return(true)
-    allow(File).to receive(:read).with(any_args).and_call_original
     expect(File).to receive(:read).with('/etc/ssh/sshd_config').and_return(sshd_config_content)
   end
 


### PR DESCRIPTION
- Fixed
  - Allow `assert_optional_dependency` to handle extended version strings
    (Alpha, Beta, RC, 1.2.3.4, etc...)
  - Allow `module_metadata::os_supported` to handle metadata where the
    version is not specified (all versions supported)
- Changed
  - Support all versions of known OSs

Needs simp/rubygem-simp-rspec-puppet-facts#43
Closes #271
