### PR TITLE
Allow root to run `puppet lookup --compile`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Dec 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.10.3
+- Fixed
+  - Permit root user to run `puppet lookup --compile` without borking passgen
+
 * Thu Dec 16 2021 ke5C2Fin <noreply@github.com> - 4.10.2
 - Fixed
   - Call `klist -s` instead of `klist` to properly handle cache issues

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
#205 broke `puppet lookup --compile`, which is essential to troubleshoot Hiera lookups when using the top-scope manifest variables in the stock `manifests/site.pp`.  The defaults introduced in that patch assume that the Puppet user is the user executing the command/process.  If the user is root using the default umask of a SIMP server, this result in files that the Puppet Server's `puppet` user will not be able to read.

This patch uses the Puppet settings to look up the configured Puppet user instead of the owner of the current process.

Fixes #267, same root problem as [SIMP-7228]

[SIMP-7228]: https://simp-project.atlassian.net/browse/SIMP-7228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ