### PR TITLE
Relax passgen UID/GID logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Jul 07 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.10.4
+- Fixed
+  - If the user/group Puppet's settings doesn't exist on the OS,
+    passgen's file ownership falls back to the owner of the compiler's process
+
 * Fri Jun 24 2022 Trevor Vaughan <tvaughan@sicura.us> - 4.10.3
 - Fixed
   - Allow `assert_optional_dependency` to handle extended version strings

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",


### PR DESCRIPTION
The latest passgen broke spec and acceptance tests for EE; `Puppet.settings[:user]` defaults to `puppet` even on systems where there is no puppet user.  This patch checks for the existence of the intended passgen (Puppet) user, and if it doesn't exist it defaults to the owner of the process running passgen. 