### PR TITLE
fixes #289  networkmanager returns null keys for some connections.

### DIFF
--- a/lib/facter/simplib__networkmanager.rb
+++ b/lib/facter/simplib__networkmanager.rb
@@ -39,7 +39,8 @@ Facter.add(:simplib__networkmanager) do
       connections.lines.each do |conn|
         name, uuid, type, device = conn.strip.split(':')
 
-        info['connection'][device] = {
+        info['connection'][name] = {
+          'device' => device,
           'uuid' => uuid,
           'type' => type,
           'name' => name


### PR DESCRIPTION
Refactor networkmanager connections so connections without a device are addressable. Prevents null keys from being inserted.