### PR TITLE
(SIMP-10745) Fix simplib__crypto_policy_state fact

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jan 19 2024 ben <benrobertson9876@gmail.com> - 4.12.2
+- Fix simplib__crypto_policy_state fact to include custom policies
+
 * Thu Oct 12 2023 Steven Pritchard <steve@sicura.us> - 4.12.1
 - Update Gemfile
 - Fix GHA release workflow

--- a/lib/facter/simplib__crypto_policy_state.rb
+++ b/lib/facter/simplib__crypto_policy_state.rb
@@ -41,7 +41,7 @@ Facter.add('simplib__crypto_policy_state') do
       combined_policies = global_policies + user_policies
 
       # Fallback for 8.0
-      if combined_policies.empty?
+      if global_policies.empty?
         combined_policies = Dir.glob('/usr/share/crypto-policies/*').select{|x| File.directory?(x)}
       end
 

--- a/lib/facter/simplib__crypto_policy_state.rb
+++ b/lib/facter/simplib__crypto_policy_state.rb
@@ -37,13 +37,15 @@ Facter.add('simplib__crypto_policy_state') do
 
       # This is everything past EL8.0
       global_policies = Dir.glob('/usr/share/crypto-policies/policies/*.pol')
+      user_policies = Dir.glob('/usr/share/crypto-policies/policies/*.pol')
+      combined_policies = global_policies + user_policies
 
       # Fallback for 8.0
-      if global_policies.empty?
-        global_policies = Dir.glob('/usr/share/crypto-policies/*').select{|x| File.directory?(x)}
+      if combined_policies.empty?
+        combined_policies = Dir.glob('/usr/share/crypto-policies/*').select{|x| File.directory?(x)}
       end
 
-      system_state['global_policies_available'] = global_policies.map{|x| File.basename(x, '.pol')}
+      system_state['global_policies_available'] = combined_policies.map{|x| File.basename(x, '.pol')}
     end
 
     system_state

--- a/lib/facter/simplib__crypto_policy_state.rb
+++ b/lib/facter/simplib__crypto_policy_state.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Provides the state of the configured crypto policies
+# @summary Provides the state of the configured crypto policies
 #
 # @see update-crypto-policy(8)
 #
@@ -36,16 +36,14 @@ Facter.add('simplib__crypto_policy_state') do
       system_state['global_policy_applied'] = !Array(output).grep(%r{is applied}).empty? if output
 
       # This is everything past EL8.0
-      global_policies = Dir.glob('/usr/share/crypto-policies/policies/*.pol')
-      user_policies = Dir.glob('/etc/crypto-policies/policies/*.pol')
-      combined_policies = global_policies + user_policies
+      global_policies = Dir.glob(['/usr/share/crypto-policies/policies/*.pol', '/etc/crypto-policies/policies/*.pol'])
 
       # Fallback for 8.0
       if global_policies.empty?
-        combined_policies = Dir.glob('/usr/share/crypto-policies/*').select{|x| File.directory?(x)}
+        global_policies = Dir.glob('/usr/share/crypto-policies/*').select { |x| File.directory?(x) }
       end
 
-      system_state['global_policies_available'] = combined_policies.map{|x| File.basename(x, '.pol')}
+      system_state['global_policies_available'] = global_policies.map { |x| File.basename(x, '.pol') }.uniq
     end
 
     system_state

--- a/lib/facter/simplib__crypto_policy_state.rb
+++ b/lib/facter/simplib__crypto_policy_state.rb
@@ -37,7 +37,7 @@ Facter.add('simplib__crypto_policy_state') do
 
       # This is everything past EL8.0
       global_policies = Dir.glob('/usr/share/crypto-policies/policies/*.pol')
-      user_policies = Dir.glob('/usr/share/crypto-policies/policies/*.pol')
+      user_policies = Dir.glob('/etc/crypto-policies/policies/*.pol')
       combined_policies = global_policies + user_policies
 
       # Fallback for 8.0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/facter/simplib__crypto_policy_state_spec.rb
+++ b/spec/unit/facter/simplib__crypto_policy_state_spec.rb
@@ -19,7 +19,7 @@ describe 'simplib__crypto_policy_state' do
       expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return("DEFAULT\n")
 
 
-      expect(Dir).to receive(:glob).with('/usr/share/crypto-policies/policies/*.pol').and_return(
+      expect(Dir).to receive(:glob).with(:'/usr/share/crypto-policies/policies/*.pol',:'/etc/crypto-policies/policies/*.pol').and_return(
         [
           '/usr/share/crypto-policies/policies/DEFAULT.pol',
           '/usr/share/crypto-policies/policies/LEGACY.pol'

--- a/spec/unit/facter/simplib__crypto_policy_state_spec.rb
+++ b/spec/unit/facter/simplib__crypto_policy_state_spec.rb
@@ -8,30 +8,29 @@ describe 'simplib__crypto_policy_state' do
 
     # Mock out Facter method called when evaluating confine for :kernel
     allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
-    expect(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
 
     # Ensure that something sane is returned when finding the command
-    expect(Facter::Util::Resolution).to receive(:which).with('update-crypto-policies').and_return('update-crypto-policies')
+    allow(Facter::Util::Resolution).to receive(:which).with('update-crypto-policies').and_return('update-crypto-policies')
   end
 
   context 'with a functional update-crypto-policies command' do
     before :each do
-      expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return("DEFAULT\n")
+      allow(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return("DEFAULT\n")
 
-
-      expect(Dir).to receive(:glob).with('/usr/share/crypto-policies/policies/*.pol').and_return(
+      allow(Dir).to receive(:glob).with(['/usr/share/crypto-policies/policies/*.pol', '/etc/crypto-policies/policies/*.pol']).and_return(
         [
           '/usr/share/crypto-policies/policies/DEFAULT.pol',
-          '/usr/share/crypto-policies/policies/LEGACY.pol'
-        ]
+          '/usr/share/crypto-policies/policies/LEGACY.pol',
+          '/etc/crypto-policies/policies/DEFAULT.pol',
+          '/etc/crypto-policies/policies/CUSTOM.pol',
+        ],
       )
-
-      expect(Dir).to receive(:glob).with('/etc/crypto-policies/policies/*.pol').and_return([])
     end
 
     context 'when applied' do
       before :each do
-        expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --is-applied', on_fail: false).and_return("The configured policy is applied\n")
+        allow(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --is-applied', on_fail: false).and_return("The configured policy is applied\n")
       end
 
       it do
@@ -39,7 +38,7 @@ describe 'simplib__crypto_policy_state' do
           {
             'global_policy' => 'DEFAULT',
             'global_policy_applied' => true,
-            'global_policies_available' => ['DEFAULT', 'LEGACY']
+            'global_policies_available' => ['DEFAULT', 'LEGACY', 'CUSTOM']
           },
         )
       end
@@ -47,7 +46,7 @@ describe 'simplib__crypto_policy_state' do
 
     context 'when not applied' do
       before :each do
-        expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --is-applied', on_fail: false).and_return("The configured policy is NOT applied\n")
+        allow(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --is-applied', on_fail: false).and_return("The configured policy is NOT applied\n")
       end
 
       it do
@@ -55,7 +54,7 @@ describe 'simplib__crypto_policy_state' do
           {
             'global_policy' => 'DEFAULT',
             'global_policy_applied' => false,
-            'global_policies_available' => ['DEFAULT', 'LEGACY']
+            'global_policies_available' => ['DEFAULT', 'LEGACY', 'CUSTOM']
           },
         )
       end
@@ -64,7 +63,7 @@ describe 'simplib__crypto_policy_state' do
 
   context 'with a non-functional update-crypto-policies command' do
     it 'returns a nil value' do
-      expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return(false)
+      allow(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return(false)
 
       expect(Facter.fact('simplib__crypto_policy_state').value).to be_nil
     end

--- a/spec/unit/facter/simplib__crypto_policy_state_spec.rb
+++ b/spec/unit/facter/simplib__crypto_policy_state_spec.rb
@@ -19,12 +19,14 @@ describe 'simplib__crypto_policy_state' do
       expect(Facter::Core::Execution).to receive(:execute).with('update-crypto-policies --no-reload --show', on_fail: false).and_return("DEFAULT\n")
 
 
-      expect(Dir).to receive(:glob).with(:'/usr/share/crypto-policies/policies/*.pol',:'/etc/crypto-policies/policies/*.pol').and_return(
+      expect(Dir).to receive(:glob).with('/usr/share/crypto-policies/policies/*.pol').and_return(
         [
           '/usr/share/crypto-policies/policies/DEFAULT.pol',
           '/usr/share/crypto-policies/policies/LEGACY.pol'
         ]
       )
+
+      expect(Dir).to receive(:glob).with('/etc/crypto-policies/policies/*.pol').and_return([])
     end
 
     context 'when applied' do


### PR DESCRIPTION
RHEL 8 has two locations in which crypto-policies are stored. 

- /etc/crypto-policies/policies/*.pol For user generated custom crypto policies

- /usr/share/crypto-policies/policies/*.pol For built in systems crypto policies

Presently the simplib__crypto_policy_state fact is only checking system crypto policy directory.

See RHEL documentation. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening#creating-and-setting-a-custom-system-wide-cryptographic-policy_using-the-system-wide-cryptographic-policies