### PR TITLE
Fix tmp_mount* facts crashing when simplib__mountpoints is nil

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jun 11 2026 Aman Shah <aman@obmondo.com> - 5.0.3
+- Fix tmp_mount* facts raising "undefined method `[]' for nil:NilClass"
+  when simplib__mountpoints resolves to nil
+
 * Sun Jun 07 2026 Steven Pritchard <steve@sicura.us> - 5.0.2
 - Additional cleanup for rubocop
 

--- a/lib/facter/tmp_mounts.rb
+++ b/lib/facter/tmp_mounts.rb
@@ -25,7 +25,7 @@ simplib__tmp_mount_target_dirs.each do |dir|
     confine { File.directory?(dir) }
     setcode do
       simplib__tmp_mount_list ||= Facter.value(:simplib__mountpoints)
-      next unless simplib__tmp_mount_list[dir]
+      next unless simplib__tmp_mount_list && simplib__tmp_mount_list[dir]
       simplib__tmp_mount_list[dir]['options'].join(',')
     end
   end
@@ -35,7 +35,7 @@ simplib__tmp_mount_target_dirs.each do |dir|
     confine { File.directory?(dir) }
     setcode do
       simplib__tmp_mount_list ||= Facter.value(:simplib__mountpoints)
-      next unless simplib__tmp_mount_list[dir]
+      next unless simplib__tmp_mount_list && simplib__tmp_mount_list[dir]
       simplib__tmp_mount_list[dir]['device']
     end
   end
@@ -45,7 +45,7 @@ simplib__tmp_mount_target_dirs.each do |dir|
     confine { File.directory?(dir) }
     setcode do
       simplib__tmp_mount_list ||= Facter.value(:simplib__mountpoints)
-      next unless simplib__tmp_mount_list[dir]
+      next unless simplib__tmp_mount_list && simplib__tmp_mount_list[dir]
       simplib__tmp_mount_list[dir]['filesystem']
     end
   end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/unit/facter/tmp_mounts_spec.rb
+++ b/spec/unit/facter/tmp_mounts_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tmp_mounts facts' do
+  before :each do
+    Facter.clear
+
+    # mock out Facter method called when evaluating confine for :kernel
+    # Facter 4
+    if defined?(Facter::Resolvers::Uname)
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(any_args).and_return('Linux')
+    else
+      allow(Facter::Core::Execution).to receive(:exec).with('uname -s').and_return('Linux')
+    end
+
+    # confine { File.directory?(dir) } passes for the target dirs
+    allow(File).to receive(:directory?).with(any_args).and_call_original
+    ['/tmp', '/var/tmp', '/dev/shm'].each do |dir|
+      allow(File).to receive(:directory?).with(dir).and_return(true)
+    end
+  end
+
+  context 'when simplib__mountpoints resolves to a Hash' do
+    before :each do
+      allow(Facter).to receive(:value).and_call_original
+      allow(Facter).to receive(:value).with(:simplib__mountpoints).and_return(
+        '/tmp' => {
+          'device'     => 'tmpfs',
+          'filesystem' => 'tmpfs',
+          'options'    => ['rw', 'nosuid', 'nodev'],
+        },
+      )
+    end
+
+    it 'returns the mount options for tmp_mount_tmp' do
+      expect(Facter.value('tmp_mount_tmp')).to eq('rw,nosuid,nodev')
+    end
+
+    it 'returns the device for tmp_mount_path_tmp' do
+      expect(Facter.value('tmp_mount_path_tmp')).to eq('tmpfs')
+    end
+
+    it 'returns the filesystem for tmp_mount_fstype_tmp' do
+      expect(Facter.value('tmp_mount_fstype_tmp')).to eq('tmpfs')
+    end
+
+    it 'returns nil for a dir that is not present in the Hash' do
+      expect(Facter.value('tmp_mount_var_tmp')).to be_nil
+    end
+  end
+
+  context 'when simplib__mountpoints resolves to nil' do
+    before :each do
+      allow(Facter).to receive(:value).and_call_original
+      allow(Facter).to receive(:value).with(:simplib__mountpoints).and_return(nil)
+    end
+
+    # Regression: previously raised
+    #   undefined method `[]' for nil:NilClass
+    it 'returns nil without raising for tmp_mount_tmp' do
+      expect { Facter.value('tmp_mount_tmp') }.not_to raise_error
+      expect(Facter.value('tmp_mount_tmp')).to be_nil
+    end
+
+    it 'returns nil without raising for tmp_mount_path_var_tmp' do
+      expect { Facter.value('tmp_mount_path_var_tmp') }.not_to raise_error
+      expect(Facter.value('tmp_mount_path_var_tmp')).to be_nil
+    end
+
+    it 'returns nil without raising for tmp_mount_fstype_dev_shm' do
+      expect { Facter.value('tmp_mount_fstype_dev_shm') }.not_to raise_error
+      expect(Facter.value('tmp_mount_fstype_dev_shm')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Problem

The deprecated `tmp_mount*` facts call `Facter.value(:simplib__mountpoints)` and immediately index the result:

```ruby
simplib__tmp_mount_list ||= Facter.value(:simplib__mountpoints)
next unless simplib__tmp_mount_list[dir]
```

When `simplib__mountpoints` resolves to `nil` — it is confined out on hosts where `/proc/mounts` is unreadable, or its own resolution raises — `simplib__tmp_mount_list` is `nil` and the guard itself dereferences it, raising on every `facter`/`puppet` run:

```
Error: Facter: Error while resolving custom fact fact='tmp_mount_tmp', resolution='<anonymous>': undefined method `[]' for nil:NilClass
```

This fires once per fact — 9 errors total (`/tmp`, `/var/tmp`, `/dev/shm` × options/path/fstype).

### Fix

Guard the list before indexing it:

```ruby
next unless simplib__tmp_mount_list && simplib__tmp_mount_list[dir]
```

Applied to all three `setcode` blocks.

### Tests

Adds `spec/unit/facter/tmp_mounts_spec.rb` covering:
- the nil-`simplib__mountpoints` regression (resolves to `nil`, no exception)
- normal resolution (options / device / filesystem)
- a target dir absent from the mountpoints hash