### PR TITLE
Fix Simplib::Hostname to comply with RFC 1123, Section 2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,27 @@
+* Thu Jul 30 2026 Steven Pritchard <steve@sicura.us> - 7.0.0
+- BREAKING CHANGE: (#351) Correct `Simplib::Hostname` so that it enforces the
+  host name restrictions of RFC 1123, Section 2.1. The highest-level label may
+  no longer be all-numeric, so malformed dotted-decimal addresses such as
+  `1.2.3.400` and `10.0.0.256` are now rejected instead of validating as host
+  names. This also fixes `Simplib::Host`, which silently accepted those values
+  because it falls back to `Simplib::Hostname` when `Simplib::IP` does not
+  match
+- BREAKING CHANGE: `Simplib::Hostname` and `Simplib::Domain` are now anchored
+  to the whole string rather than to a line. Multi-line strings containing a
+  single valid line, such as `"foo.com\nevil"`, are no longer accepted
+- `Simplib::Hostname` now accepts single-character host names such as `a`. The
+  previous pattern imposed a two-character minimum on the highest-level label
+  that has no basis in RFC 1123
+- `Simplib::Hostname` now enforces the 63-octet label and 253-octet name
+  length limits that `Simplib::Domain` already enforced
+- Fix `Simplib::Domain` so that a trailing period does not bypass the
+  all-numeric TLD check (`0.` and `test.400.` were accepted)
+- Apply the same corrections to `Simplib::Hostname::Port`.
+  `Simplib::Host::Port`, `Simplib::Netlist`, `Simplib::Netlist::Host`, and
+  `Simplib::Netlist::Port` inherit the fixes
+- Add the previously missing type alias tests for `Simplib::Hostname`,
+  `Simplib::Hostname::Port`, `Simplib::Host`, and `Simplib::Host::Port`
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 6.0.2
 - Resolved puppet-lint manifest whitespace offenses; disabled the crashing strict_indent check
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -112,8 +112,8 @@
 * [`Simplib::EmailAddress`](#Simplib--EmailAddress): Matches valid email addresses
 * [`Simplib::Host`](#Simplib--Host): Matches a single IP Address or Hostname
 * [`Simplib::Host::Port`](#Simplib--Host--Port): Matches a single IP Address or Hostname with a Port
-* [`Simplib::Hostname`](#Simplib--Hostname): Valid Hostnames - May not match Unicode and does not validate against TLD registry
-* [`Simplib::Hostname::Port`](#Simplib--Hostname--Port): Valid Hostnames with ports - May not match Unicode and does not validate against TLD registry
+* [`Simplib::Hostname`](#Simplib--Hostname): Valid Hostnames  Complies with the host name restrictions of RFC 1123, Section 2.1:   * only ASCII alpha + numbers + hyphens are allowed  * l
+* [`Simplib::Hostname::Port`](#Simplib--Hostname--Port): Valid Hostnames with ports  The host name portion complies with the host name restrictions of RFC 1123, Section 2.1. See Simplib::Hostname fo
 * [`Simplib::IP`](#Simplib--IP): Matches a single IP Address
 * [`Simplib::IP::CIDR`](#Simplib--IP--CIDR): Matches valid CIDR IP addresses
 * [`Simplib::IP::Port`](#Simplib--IP--Port): Matches valid IP addresses with Ports
@@ -5770,10 +5770,9 @@ Complies with TLD restrictions from Section 2 of RFC 3696:
  * TLDs cannot be all-numeric
  * TLDs must be able to end with a period
  * A DNS label may be no more than 63 octets long
+ * A domain name may be no more than 253 octets long
 
-RegEx developed and tested at http://rubular.com/r/4yZ7R8v42f
-
-Alias of `Pattern['^(?i-mx:(?=^.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+$)([a-z0-9-]{1,63})(?<!-)\.?)\z']`
+Alias of `Pattern['\A(?i-mx:(?=.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?\z)([a-z0-9-]{1,63})(?<!-)\.?)\z']`
 
 ### <a name="Simplib--Domainlist"></a>`Simplib::Domainlist`
 
@@ -5801,15 +5800,32 @@ Alias of `Variant[Simplib::IP::Port, Simplib::Hostname::Port]`
 
 ### <a name="Simplib--Hostname"></a>`Simplib::Hostname`
 
-Valid Hostnames - May not match Unicode and does not validate against TLD registry
+Valid Hostnames
 
-Alias of `Pattern['^(?i-mx:(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]{2}|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?)$']`
+Complies with the host name restrictions of RFC 1123, Section 2.1:
+
+ * only ASCII alpha + numbers + hyphens are allowed
+ * labels can't begin or end with hyphens
+ * the highest-level label cannot be all-numeric, so that a host name can
+   never be confused with a dotted-decimal IP address
+ * a DNS label may be no more than 63 octets long
+ * a host name may be no more than 253 octets long
+ * host names may end with a period
+
+May not match Unicode and does not validate against the TLD registry
+
+Alias of `Pattern['\A(?i-mx:(?=.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?\z)([a-z0-9-]{1,63})(?<!-)\.?)\z']`
 
 ### <a name="Simplib--Hostname--Port"></a>`Simplib::Hostname::Port`
 
-Valid Hostnames with ports - May not match Unicode and does not validate against TLD registry
+Valid Hostnames with ports
 
-Alias of `Pattern['^(?i-mx:(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]{2}|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?):([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$']`
+The host name portion complies with the host name restrictions of RFC 1123,
+Section 2.1. See Simplib::Hostname for the full list.
+
+May not match Unicode and does not validate against the TLD registry
+
+Alias of `Pattern['\A(?i-mx:(?=[^:]{1,253}:)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?:)([a-z0-9-]{1,63})(?<!-)\.?):([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\z']`
 
 ### <a name="Simplib--IP"></a>`Simplib::IP`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simplib",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "author": "SIMP Team",
   "summary": "A collection of common SIMP functions, facts, and types",
   "license": "Apache-2.0",

--- a/spec/type_aliases/domain_spec.rb
+++ b/spec/type_aliases/domain_spec.rb
@@ -40,6 +40,22 @@ describe 'Simplib::Domain' do
           it { is_expected.not_to allow_value('0212') }
           it { is_expected.not_to allow_value('test.0') }
           it { is_expected.not_to allow_value('t.t.t.t.0') }
+          it { is_expected.not_to allow_value('1.2.3.400') }
+        end
+
+        context 'a trailing period does not bypass the all-numeric check' do
+          # Regression: the previous pattern anchored the all-numeric check
+          # with '$', which a trailing period stepped past
+          it { is_expected.not_to allow_value('0.') }
+          it { is_expected.not_to allow_value('test.400.') }
+          it { is_expected.not_to allow_value('1.2.3.400.') }
+        end
+
+        context 'the pattern is anchored to the whole string' do
+          # Regression: the previous pattern used line anchors, so any
+          # multi-line string containing one valid line was accepted
+          it { is_expected.not_to allow_value("test.com\nevil") }
+          it { is_expected.not_to allow_value("evil\ntest.com") }
         end
 
         context 'A DNS label may be no more than 63 octets long' do

--- a/spec/type_aliases/host/port_spec.rb
+++ b/spec/type_aliases/host/port_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'Simplib::Host::Port' do
+  # Simplib::Host::Port is Variant[Simplib::IP::Port, Simplib::Hostname::Port]
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid IP addresses and ports' do
+        it { is_expected.to allow_value('1.2.3.4:80') }
+        it { is_expected.to allow_value('10.0.0.255:65535') }
+        it { is_expected.to allow_value('[::1]:80') }
+      end
+
+      context 'with valid host names and ports' do
+        it { is_expected.to allow_value('a:80') }
+        it { is_expected.to allow_value('foo:80') }
+        it { is_expected.to allow_value('foo.example.com:443') }
+        it { is_expected.to allow_value('foo.example.com.:443') }
+      end
+
+      context 'with malformed IPv4 addresses' do
+        it { is_expected.not_to allow_value('1.2.3.400:80') }
+        it { is_expected.not_to allow_value('10.0.0.256:80') }
+        it { is_expected.not_to allow_value('400:80') }
+      end
+
+      context 'with other invalid values' do
+        it { is_expected.not_to allow_value('') }
+        it { is_expected.not_to allow_value('foo.example.com') }
+        it { is_expected.not_to allow_value('foo:65536') }
+        it { is_expected.not_to allow_value("foo.example.com:80\nevil") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/host_spec.rb
+++ b/spec/type_aliases/host_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'Simplib::Host' do
+  # Simplib::Host is Variant[Simplib::IP, Simplib::Hostname], so it must accept
+  # anything that is a valid IP address or a valid host name, and nothing else.
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid IP addresses' do
+        it { is_expected.to allow_value('1.2.3.4') }
+        it { is_expected.to allow_value('10.0.0.255') }
+        it { is_expected.to allow_value('255.255.255.255') }
+        it { is_expected.to allow_value('0.0.0.0') }
+        it { is_expected.to allow_value('::1') }
+        it { is_expected.to allow_value('2001:db8::1') }
+      end
+
+      context 'with valid host names' do
+        it { is_expected.to allow_value('a') }
+        it { is_expected.to allow_value('foo') }
+        it { is_expected.to allow_value('foo.example.com') }
+        it { is_expected.to allow_value('foo.example.com.') }
+        it { is_expected.to allow_value('3com') }
+      end
+
+      context 'with malformed IPv4 addresses' do
+        # These are neither valid IP addresses nor valid host names. They were
+        # accepted before the Simplib::Hostname fix, which meant Simplib::Host
+        # silently accepted fat-fingered octets.
+        it { is_expected.not_to allow_value('1.2.3.400') }
+        it { is_expected.not_to allow_value('10.0.0.256') }
+        it { is_expected.not_to allow_value('999.999.999.999') }
+        it { is_expected.not_to allow_value('400') }
+        it { is_expected.not_to allow_value('1.2.3.400.') }
+      end
+
+      context 'with other invalid values' do
+        it { is_expected.not_to allow_value('') }
+        it { is_expected.not_to allow_value('1.2.3.0/24') }
+        it { is_expected.not_to allow_value('foo.example.com:80') }
+        it { is_expected.not_to allow_value("foo.example.com\nevil") }
+        it { is_expected.not_to allow_value("evil\nfoo.example.com") }
+        it { is_expected.not_to allow_value('-foo.example.com') }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/hostname/port_spec.rb
+++ b/spec/type_aliases/hostname/port_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'Simplib::Hostname::Port' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid host names and ports' do
+        it { is_expected.to allow_value('foo.example.com:80') }
+        it { is_expected.to allow_value('my-host.test.local:443') }
+        it { is_expected.to allow_value('3com:1') }
+        it { is_expected.to allow_value('foo.example.com.:80') }
+        it { is_expected.to allow_value('FOO.EXAMPLE.COM:80') }
+
+        context 'single-character labels are valid' do
+          it { is_expected.to allow_value('a:80') }
+        end
+
+        context 'port boundaries' do
+          it { is_expected.to allow_value('foo:0') }
+          it { is_expected.to allow_value('foo:65535') }
+        end
+      end
+
+      context 'with invalid host names and ports' do
+        context 'the highest-level label cannot be all-numeric' do
+          it { is_expected.not_to allow_value('1.2.3.400:123') }
+          it { is_expected.not_to allow_value('10.0.0.256:80') }
+          it { is_expected.not_to allow_value('400:80') }
+          it { is_expected.not_to allow_value('400.:80') }
+          # Valid IPv4 addresses with ports are Simplib::IP::Port
+          it { is_expected.not_to allow_value('1.2.3.4:80') }
+        end
+
+        context "labels can't begin or end with hyphens" do
+          it { is_expected.not_to allow_value('-foo:80') }
+          it { is_expected.not_to allow_value('foo-:80') }
+        end
+
+        context 'ports must be present and in range' do
+          it { is_expected.not_to allow_value('foo.example.com') }
+          it { is_expected.not_to allow_value('foo:') }
+          it { is_expected.not_to allow_value('foo:65536') }
+          it { is_expected.not_to allow_value('foo:99999') }
+          it { is_expected.not_to allow_value('foo:http') }
+        end
+
+        context 'length limits' do
+          it { is_expected.not_to allow_value("#{'a' * 64}:80") }
+          it { is_expected.not_to allow_value("#{'a' * 254}:80") }
+        end
+
+        context 'the pattern is anchored to the whole string' do
+          it { is_expected.not_to allow_value("foo.com:80\nevil") }
+          it { is_expected.not_to allow_value("evil\nfoo.com:80") }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/hostname_spec.rb
+++ b/spec/type_aliases/hostname_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe 'Simplib::Hostname' do
+  # Tests cover the host name restrictions of RFC 1123, Section 2.1
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid host names' do
+        context 'only ASCII alpha + numbers + hyphens are allowed' do
+          it { is_expected.to allow_value('test') }
+          it { is_expected.to allow_value('test.com') }
+          it { is_expected.to allow_value('foo.example.com') }
+          it { is_expected.to allow_value('my-host.test.local') }
+          it { is_expected.to allow_value('0.t-t.0.t') }
+          it { is_expected.to allow_value('0-0') }
+          it { is_expected.to allow_value('0-0.0-0.0-0') }
+          it { is_expected.to allow_value('0f') }
+          it { is_expected.to allow_value('f0') }
+          it { is_expected.to allow_value('3com') }
+          it { is_expected.to allow_value('test.00f') }
+        end
+
+        context 'single-character labels are valid' do
+          # Regression: the previous pattern imposed an unfounded
+          # two-character minimum on the highest-level label
+          it { is_expected.to allow_value('a') }
+          it { is_expected.to allow_value('t') }
+          it { is_expected.to allow_value('a.example.com') }
+        end
+
+        context 'host names are case insensitive' do
+          it { is_expected.to allow_value('FOO.EXAMPLE.COM') }
+          it { is_expected.to allow_value('Foo.Example.Com') }
+        end
+
+        context 'host names may end with a period' do
+          it { is_expected.to allow_value('t.') }
+          it { is_expected.to allow_value('test.com.') }
+        end
+
+        context 'length limits' do
+          it { is_expected.to allow_value('a' * 63) }
+          it { is_expected.to allow_value("#{(['a' * 63] * 3).join('.')}.#{'a' * 61}") }
+        end
+      end
+
+      context 'with invalid host names' do
+        context 'the highest-level label cannot be all-numeric' do
+          # A valid host name can never have the dotted-decimal form #.#.#.#,
+          # since the highest-level label is always alphabetic (RFC 1123 s2.1).
+          # Without this, an out-of-range IPv4 address such as a fat-fingered
+          # octet validates as a host name.
+          it { is_expected.not_to allow_value('1.2.3.400') }
+          it { is_expected.not_to allow_value('10.0.0.256') }
+          it { is_expected.not_to allow_value('999.999.999.999') }
+          it { is_expected.not_to allow_value('1.2.3.4') }
+          it { is_expected.not_to allow_value('400') }
+          it { is_expected.not_to allow_value('0') }
+          it { is_expected.not_to allow_value('0212') }
+          it { is_expected.not_to allow_value('test.0') }
+          it { is_expected.not_to allow_value('t.t.t.t.0') }
+        end
+
+        context 'a trailing period does not bypass the all-numeric check' do
+          it { is_expected.not_to allow_value('400.') }
+          it { is_expected.not_to allow_value('test.400.') }
+          it { is_expected.not_to allow_value('1.2.3.400.') }
+        end
+
+        context "labels can't begin or end with hyphens" do
+          it { is_expected.not_to allow_value('-test') }
+          it { is_expected.not_to allow_value('test-') }
+          it { is_expected.not_to allow_value('test-.test') }
+          it { is_expected.not_to allow_value('test.-test') }
+        end
+
+        context 'a DNS label may be no more than 63 octets long' do
+          it { is_expected.not_to allow_value('a' * 64) }
+          it { is_expected.not_to allow_value('an-extremely-long-dns-label-that-is-just-over-63-characters-long.test') }
+          it { is_expected.not_to allow_value('test.an-extremely-long-dns-label-that-is-just-over-63-characters-long') }
+        end
+
+        context 'a host name may be no more than 253 octets long' do
+          it { is_expected.not_to allow_value("#{(['a' * 63] * 3).join('.')}.#{'a' * 62}") }
+        end
+
+        context 'the pattern is anchored to the whole string' do
+          # Regression: the previous pattern used line anchors, so any
+          # multi-line string containing one valid line was accepted
+          it { is_expected.not_to allow_value("foo.com\nevil") }
+          it { is_expected.not_to allow_value("evil\nfoo.com") }
+          it { is_expected.not_to allow_value("1.2.3.400\nfoo.com") }
+          it { is_expected.not_to allow_value("test.com\n") }
+        end
+      end
+
+      context 'with silly things' do
+        it { is_expected.not_to allow_value('') }
+        it { is_expected.not_to allow_value('.') }
+        it { is_expected.not_to allow_value('.host.test.local') }
+        it { is_expected.not_to allow_value('host..local') }
+        it { is_expected.not_to allow_value('host test.local') }
+        it { is_expected.not_to allow_value('my:host.test.local') }
+        it { is_expected.not_to allow_value('myhost:80') }
+        it { is_expected.not_to allow_value('1.2.3.0/24') }
+        it { is_expected.not_to allow_value([]) }
+        it { is_expected.not_to allow_value(:undef) }
+      end
+    end
+  end
+end

--- a/spec/unit/data_types/host/port_spec.rb
+++ b/spec/unit/data_types/host/port_spec.rb
@@ -10,12 +10,18 @@ valid_data = [
   'localhost.localdomain:443',
   'my-domain.com:22',
   '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
+  # Single-character host names are valid per RFC 1123, Section 2.1
+  'a:80',
 ]
 
 invalid_data = [
   'a',
   'my_domain.com',
   '0.0.0',
+  # Neither a valid IP address nor a valid host name
+  '1.2.3.400:80',
+  '10.0.0.256:80',
+  '400:80',
   '1.2.3.4/24',
   '1.2.3.4/255.255.224.0',
 ]

--- a/spec/unit/data_types/host_spec.rb
+++ b/spec/unit/data_types/host_spec.rb
@@ -14,12 +14,18 @@ valid_data = [
   '1.2.3.4',
   '::1',
   '[::1]',
+  # Single-character host names are valid per RFC 1123, Section 2.1
+  'a',
 ]
 
 invalid_data = [
-  'a',
   'my_domain.com',
   '0.0.0',
+  # Neither a valid IP address nor a valid host name
+  '1.2.3.400',
+  '10.0.0.256',
+  '400',
+  "my-domain.com\nevil",
   '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
   '1.2.3.4/24',
   '1.2.3.4/255.255.224.0',

--- a/spec/unit/data_types/hostname/port_spec.rb
+++ b/spec/unit/data_types/hostname/port_spec.rb
@@ -10,11 +10,17 @@ valid_data = [
   'localhost.localdomain:80',
   'my-domain.com:22',
   'aa.bb:65535',
+  # Single-character host names are valid per RFC 1123, Section 2.1
+  'a:80',
 ]
 
 invalid_data = [
   'a',
   'my_domain.com',
+  # The highest-level label may not be all-numeric (RFC 1123, Section 2.1)
+  '1.2.3.400:123',
+  '10.0.0.256:80',
+  '400:80',
   '0.0.0',
   '0.0.0.0',
   '1.2.3.4',

--- a/spec/unit/data_types/hostname_spec.rb
+++ b/spec/unit/data_types/hostname_spec.rb
@@ -12,14 +12,24 @@ valid_data = [
   'localhost.localdomain',
   'my-domain.com',
   'aa.bb',
+  # Single-character host names are valid per RFC 1123, Section 2.1
+  'a',
+  'a.bb',
 ]
 
 invalid_data = [
-  'a',
   'my_domain.com',
   '0.0.0',
   '0.0.0.0',
   '1.2.3.4',
+  # The highest-level label may not be all-numeric, so a malformed
+  # dotted-decimal address is not a host name (RFC 1123, Section 2.1)
+  '1.2.3.400',
+  '10.0.0.256',
+  '400',
+  '400.',
+  '1.2.3.400.',
+  "my-domain.com\nevil",
   '1.2.3.4/24',
   '1.2.3.4/255.255.224.0',
   '1.2.3.4:443',

--- a/spec/unit/data_types/netlist_spec.rb
+++ b/spec/unit/data_types/netlist_spec.rb
@@ -18,15 +18,24 @@ valid_data = [
     '::1',
     '[::1]',
     '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443',
+    # Single-character host names are valid per RFC 1123, Section 2.1
+    'a',
   ],
 ]
 
 invalid_data = [
   'localhost',
   [
-    'a',
     '0.0.0',
     '1.2.3.256',
+  ],
+  # Verify the malformed dotted-decimal address on its own, rather than
+  # relying on another entry in the list to fail the match
+  [
+    '1.2.3.400',
+  ],
+  [
+    '400',
   ],
 ]
 

--- a/types/domain.pp
+++ b/types/domain.pp
@@ -7,7 +7,6 @@
 #  * TLDs cannot be all-numeric
 #  * TLDs must be able to end with a period
 #  * A DNS label may be no more than 63 octets long
+#  * A domain name may be no more than 253 octets long
 #
-# RegEx developed and tested at http://rubular.com/r/4yZ7R8v42f
-#
-type Simplib::Domain = Pattern['^(?i-mx:(?=^.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+$)([a-z0-9-]{1,63})(?<!-)\.?)\z']
+type Simplib::Domain = Pattern['\A(?i-mx:(?=.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?\z)([a-z0-9-]{1,63})(?<!-)\.?)\z']

--- a/types/hostname.pp
+++ b/types/hostname.pp
@@ -1,2 +1,15 @@
-# Valid Hostnames - May not match Unicode and does not validate against TLD registry
-type Simplib::Hostname = Pattern['^(?i-mx:(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]{2}|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?)$']
+# Valid Hostnames
+#
+# Complies with the host name restrictions of RFC 1123, Section 2.1:
+#
+#  * only ASCII alpha + numbers + hyphens are allowed
+#  * labels can't begin or end with hyphens
+#  * the highest-level label cannot be all-numeric, so that a host name can
+#    never be confused with a dotted-decimal IP address
+#  * a DNS label may be no more than 63 octets long
+#  * a host name may be no more than 253 octets long
+#  * host names may end with a period
+#
+# May not match Unicode and does not validate against the TLD registry
+#
+type Simplib::Hostname = Pattern['\A(?i-mx:(?=.{1,253}\z)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?\z)([a-z0-9-]{1,63})(?<!-)\.?)\z']

--- a/types/hostname/port.pp
+++ b/types/hostname/port.pp
@@ -1,2 +1,8 @@
-# Valid Hostnames with ports - May not match Unicode and does not validate against TLD registry
-type Simplib::Hostname::Port = Pattern['^(?i-mx:(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]{2}|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?):([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$']
+# Valid Hostnames with ports
+#
+# The host name portion complies with the host name restrictions of RFC 1123,
+# Section 2.1. See Simplib::Hostname for the full list.
+#
+# May not match Unicode and does not validate against the TLD registry
+#
+type Simplib::Hostname::Port = Pattern['\A(?i-mx:(?=[^:]{1,253}:)((?!-)[a-z0-9-]{1,63}(?<!-)\.)*(?!-|\d+\.?:)([a-z0-9-]{1,63})(?<!-)\.?):([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])\z']


### PR DESCRIPTION
Fixes #351.

`Simplib::Hostname` matched any label made of ASCII alphanumerics and hyphens, with a two-character minimum on the highest-level label. That minimum has no basis in RFC 1123, and it was not sufficient to separate host names from dotted-decimal addresses — it excluded `1.2.3.4` only because the final octet is a single digit, so any malformed address ending in a two- or three-digit octet validated as a host name.

Since `Simplib::Host = Variant[Simplib::IP, Simplib::Hostname]` falls back to the host name branch, this meant `Simplib::Host` silently accepted fat-fingered IPv4 addresses — exactly the class of configuration error it exists to catch.

| value | before | after |
|---|---|---|
| `1.2.3.400` | accepted | rejected |
| `10.0.0.256` | accepted | rejected |
| `999.999.999.999` | accepted | rejected |
| `400` | accepted | rejected |
| `a` | rejected | accepted |
| `foo.example.com` | accepted | accepted |
| `1.2.3.4` | accepted (as `Simplib::IP`) | accepted (as `Simplib::IP`) |

The fix rebuilds the pattern around the rule RFC 1123 §2.1 actually states — a valid host name can never have the dotted-decimal form, because the highest-level label is always alphabetic — reusing the `(?!-|\d+\.?\z)` guard that `Simplib::Domain` has always had. The two types now agree.

`simplib::validate_net_list` already carried an explicit workaround for this, with a comment noting that quad-dotted addresses validate as host names. That workaround is now redundant (left in place; it is harmless).

## Two further defects in the same family

**Newline injection — `Simplib::Hostname` and `Simplib::Domain`.** Both were anchored with `^`…`$`. Puppet's `Pattern` performs a regex *search*, and `^`/`$` are **line** anchors in Ruby, so any multi-line string containing one valid line matched:

| value | `Simplib::Hostname` before | `Simplib::Domain` before |
|---|---|---|
| `"foo.com\nevil"` | accepted | accepted |
| `"evil\nfoo.com"` | accepted | accepted |

This matters because host names validated by these types are routinely interpolated into generated configuration files, where an embedded newline is an injection primitive. Both are now anchored with `\A`/`\z`. The IP types were never affected — they already use `\A`/`\z` internally.

**Trailing period bypassed `Simplib::Domain`'s all-numeric guard.** The guard was `(?!-|\d+$)`, and `$` does not match before a trailing `.`, so `0.`, `test.400.`, and `1.2.3.400.` were accepted while `0` was correctly rejected. Now `(?!-|\d+\.?\z)`.

## Also in this change

* `Simplib::Hostname` accepts single-character host names (`a`), which RFC 1123 permits.
* `Simplib::Hostname` enforces the 63-octet label and 253-octet name limits that `Simplib::Domain` already enforced.
* The same corrections are applied to `Simplib::Hostname::Port`. `Simplib::Host`, `Simplib::Host::Port`, `Simplib::Netlist`, `Simplib::Netlist::Host`, and `Simplib::Netlist::Port` inherit every fix without modification.

## Tests

New `spec/type_aliases/` specs for `Simplib::Hostname`, `Simplib::Hostname::Port`, `Simplib::Host`, and `Simplib::Host::Port`, covering each RFC rule, the length limits, hyphen placement, trailing periods, and whole-string anchoring. These follow the `allow_value` style already used for the closest sibling type, `Simplib::Domain`.

Two existing expectations in `spec/unit/data_types/` encoded the bug and are corrected:

* `host_spec.rb` and `hostname_spec.rb` both listed `a` under `invalid_data`, asserting the unfounded two-character minimum as intended behavior.
* `netlist_spec.rb` *did* list `1.2.3.256` under `invalid_data`, so the malformed-octet case was anticipated — but it only ever appeared inside an array alongside `a` and `0.0.0`, and `Simplib::Netlist` fails if any element fails. The array was rejected because of `a`, not because of `1.2.3.256`. The intended assertion never actually held. `1.2.3.400` and `400` are now verified as standalone single-element lists.

**Note for review:** this leaves two spec files per type, split across the repo's two conventions (`spec/type_aliases/` and `spec/unit/data_types/`). Happy to consolidate in either direction if you have a preference.

Full suite: 11577 examples, 0 failures. `rake lint`, `rake syntax`, and RuboCop are clean. `REFERENCE.md` regenerated.

## Compatibility

Breaking change; `metadata.json` bumped 6.0.2 → **7.0.0**.

* **Tightening:** values that are neither valid IPs nor RFC-1123-valid host names now fail type checks. Any site with such a value in Hiera will start failing catalog compilation instead of silently accepting it.
* **Loosening:** single-character host names are now accepted. Strictly additive.

`Simplib::Host`/`Simplib::Hostname` are referenced in roughly 79 files across ~31 `pupmod-simp-*` modules, so dependency floors will need a coordinated review.

I scanned every non-vendor YAML across all `pupmod-simp-*` repos for host-valued keys whose validity changes under the new pattern. The only matches are four deliberately-invalid negative-test fixtures in `pupmod-simp-simp_options` (which now fail on the type rather than on `simplib::validate_net_list` — the intended outcome), plus one `ipaddress` fact of `172.16.254.254`, which is a valid IPv4 and so still matches `Simplib::Host` via `Simplib::IP`. No legitimate configuration in the workspace breaks.

## Out of scope

`PuppetX::SIMP::Simplib.hostname_only?` carries the same permissive regex, but its contract is intentional and explicitly tested (`hostname_only?('1.2.3.4') == true`), and its only consumers — `simplib::validate_net_list` and `simplib::nets2cidr` — check for IP addresses first by design. Changing it is a separate decision.

Several other `Pattern` types use `^`…`$` line anchors and have the same newline exposure (`Simplib::Umask`, `Simplib::Macaddress`, `Simplib::EmailAddress`, `Simplib::Uri`, and the `Simplib::Libcrypt::*` family). Worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
