### PR TITLE
Anchor remaining Simplib Pattern types to the whole string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,27 @@
   `Simplib::Netlist::Port` inherit the fixes
 - Add the previously missing type alias tests for `Simplib::Hostname`,
   `Simplib::Hostname::Port`, `Simplib::Host`, and `Simplib::Host::Port`
+- BREAKING CHANGE: (#353) Anchor the remaining `Pattern` types to the whole
+  string with `\A`...`\z` instead of the line anchors `^`...`$`. Because
+  Puppet's `Pattern` performs a regex search, any multi-line string containing
+  a single valid line satisfied these types, which made an embedded newline a
+  config-injection primitive. Affects `Simplib::EmailAddress`,
+  `Simplib::Macaddress`, `Simplib::Umask`, `Simplib::URI`,
+  `Simplib::Systemd::ServiceName`, `Simplib::ShadowPass`, and all twelve
+  `Simplib::Libcrypt::*` types. The IPv4/IPv6 types were already anchored
+  internally and are unchanged
+- BREAKING CHANGE: Exclude newlines from the salt in
+  `Simplib::Libcrypt::MD5_FreeBSD`. The salt is a negated character class,
+  which matches a newline even when the pattern is anchored, so a newline
+  could be smuggled into the middle of an otherwise valid value
+- Fix `Simplib::Libcrypt::Yescrypt`, which has never been loadable (#354).
+  It was defined in `types/libcrypt/yescript.pp`, so the autoloader could not
+  find it, and the corresponding `Simplib::ShadowPass` branch silently never
+  matched - yescrypt hashes, the default on recent Fedora and EL10, were
+  rejected. Renamed to `types/libcrypt/yescrypt.pp`
+- Add type alias tests for the twelve `Simplib::Libcrypt::*` types, which had
+  no direct coverage, and for `Simplib::EmailAddress`, `Simplib::Umask`,
+  `Simplib::URI`, and `Simplib::Systemd::ServiceName`
 
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 6.0.2
 - Resolved puppet-lint manifest whitespace offenses; disabled the crashing strict_indent check

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -130,7 +130,7 @@
 * [`Simplib::Libcrypt::Bcrypt`](#Simplib--Libcrypt--Bcrypt): Regular expression pulled from the crypt(5) man page
 * [`Simplib::Libcrypt::Bigcrypt`](#Simplib--Libcrypt--Bigcrypt): Regular expression pulled from the crypt(5) man page
 * [`Simplib::Libcrypt::DES`](#Simplib--Libcrypt--DES): Regular expression pulled from the crypt(5) man page
-* [`Simplib::Libcrypt::MD5_FreeBSD`](#Simplib--Libcrypt--MD5_FreeBSD): Regular expression pulled from the crypt(5) man page
+* [`Simplib::Libcrypt::MD5_FreeBSD`](#Simplib--Libcrypt--MD5_FreeBSD): Regular expression pulled from the crypt(5) man page  The salt is a negated character class, which matches a newline even when the pattern is
 * [`Simplib::Libcrypt::MD5_Sun`](#Simplib--Libcrypt--MD5_Sun): Regular expression pulled from the crypt(5) man page lint:ignore:single_quote_string_with_variables
 * [`Simplib::Libcrypt::NTHASH`](#Simplib--Libcrypt--NTHASH): Regular expression pulled from the crypt(5) man page
 * [`Simplib::Libcrypt::SHA1`](#Simplib--Libcrypt--SHA1): Regular expression pulled from the crypt(5) man page
@@ -5784,7 +5784,7 @@ Alias of `Array[Simplib::Domain]`
 
 Matches valid email addresses
 
-Alias of `Pattern['^.+@.+$']`
+Alias of `Pattern['\A.+@.+\z']`
 
 ### <a name="Simplib--Host"></a>`Simplib::Host`
 
@@ -5958,80 +5958,83 @@ Alias of `Pattern['^(?x-mi:(?:(?x-mi:\A\[(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^_[./0-9A-Za-z]{19}$']`
+Alias of `Pattern['\A_[./0-9A-Za-z]{19}\z']`
 
 ### <a name="Simplib--Libcrypt--Bcrypt"></a>`Simplib::Libcrypt::Bcrypt`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$2[abxy]\$[0-9]{2}\$[./A-Za-z0-9]{53}$']`
+Alias of `Pattern['\A\$2[abxy]\$[0-9]{2}\$[./A-Za-z0-9]{53}\z']`
 
 ### <a name="Simplib--Libcrypt--Bigcrypt"></a>`Simplib::Libcrypt::Bigcrypt`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^[./0-9A-Za-z]{13,178}$']`
+Alias of `Pattern['\A[./0-9A-Za-z]{13,178}\z']`
 
 ### <a name="Simplib--Libcrypt--DES"></a>`Simplib::Libcrypt::DES`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^[./0-9A-Za-z]{13}$']`
+Alias of `Pattern['\A[./0-9A-Za-z]{13}\z']`
 
 ### <a name="Simplib--Libcrypt--MD5_FreeBSD"></a>`Simplib::Libcrypt::MD5_FreeBSD`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$1\$[^$]{1,8}\$[./0-9A-Za-z]{22}$']`
+The salt is a negated character class, which matches a newline even when the
+pattern is anchored to the whole string, so newlines are excluded explicitly
+
+Alias of `Pattern['\A\$1\$[^$\n]{1,8}\$[./0-9A-Za-z]{22}\z']`
 
 ### <a name="Simplib--Libcrypt--MD5_Sun"></a>`Simplib::Libcrypt::MD5_Sun`
 
 Regular expression pulled from the crypt(5) man page
 lint:ignore:single_quote_string_with_variables
 
-Alias of `Pattern['^\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}$']`
+Alias of `Pattern['\A\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}\z']`
 
 ### <a name="Simplib--Libcrypt--NTHASH"></a>`Simplib::Libcrypt::NTHASH`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$3\$\$[0-9a-f]{32}$']`
+Alias of `Pattern['\A\$3\$\$[0-9a-f]{32}\z']`
 
 ### <a name="Simplib--Libcrypt--SHA1"></a>`Simplib::Libcrypt::SHA1`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$sha1\$[1-9][0-9]+\$[./0-9A-Za-z]{1,64}\$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}$']`
+Alias of `Pattern['\A\$sha1\$[1-9][0-9]+\$[./0-9A-Za-z]{1,64}\$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}\z']`
 
 ### <a name="Simplib--Libcrypt--SHA2_256"></a>`Simplib::Libcrypt::SHA2_256`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$5\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{43}$']`
+Alias of `Pattern['\A\$5\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{43}\z']`
 
 ### <a name="Simplib--Libcrypt--SHA2_512"></a>`Simplib::Libcrypt::SHA2_512`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$6\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{86}$']`
+Alias of `Pattern['\A\$6\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{86}\z']`
 
 ### <a name="Simplib--Libcrypt--Scrypt"></a>`Simplib::Libcrypt::Scrypt`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$7\$[./A-Za-z0-9]{11,97}\$[./A-Za-z0-9]{43}$']`
+Alias of `Pattern['\A\$7\$[./A-Za-z0-9]{11,97}\$[./A-Za-z0-9]{43}\z']`
 
 ### <a name="Simplib--Libcrypt--Yescrypt"></a>`Simplib::Libcrypt::Yescrypt`
 
 Regular expression pulled from the crypt(5) man page
 
-Alias of `Pattern['^\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}$']`
+Alias of `Pattern['\A\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}\z']`
 
 ### <a name="Simplib--Macaddress"></a>`Simplib::Macaddress`
 
 Matches MAC addresses
 
-Alias of `Pattern['^[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}$']`
+Alias of `Pattern['\A[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\z']`
 
 ### <a name="Simplib--Netlist"></a>`Simplib::Netlist`
 
@@ -6171,7 +6174,7 @@ They are ordered of most to least commonly used for optimization.
 
 Just because they are allowed, does not mean that you should use them....
 
-Alias of `Variant[Enum['*','!','!!'], Pattern['^!.*'], Simplib::Libcrypt::SHA2_512, Simplib::Libcrypt::SHA2_256, Simplib::Libcrypt::SHA1, Simplib::Libcrypt::MD5_Sun, Simplib::Libcrypt::MD5_FreeBSD, Simplib::Libcrypt::NTHASH, Simplib::Libcrypt::Bcrypt, Simplib::Libcrypt::Scrypt, Simplib::Libcrypt::Yescrypt]`
+Alias of `Variant[Enum['*','!','!!'], Pattern['\A!.*\z'], Simplib::Libcrypt::SHA2_512, Simplib::Libcrypt::SHA2_256, Simplib::Libcrypt::SHA1, Simplib::Libcrypt::MD5_Sun, Simplib::Libcrypt::MD5_FreeBSD, Simplib::Libcrypt::NTHASH, Simplib::Libcrypt::Bcrypt, Simplib::Libcrypt::Scrypt, Simplib::Libcrypt::Yescrypt]`
 
 ### <a name="Simplib--Syslog--CFacility"></a>`Simplib::Syslog::CFacility`
 
@@ -6363,17 +6366,17 @@ Variant[Integer[0,7], Enum[
 
 Valid systemd service names
 
-Alias of `Pattern['^(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}$']`
+Alias of `Pattern['\A(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}\z']`
 
 ### <a name="Simplib--URI"></a>`Simplib::URI`
 
 Matches URI strings
 
-Alias of `Pattern['^[a-zA-Z][a-zA-Z0-9+-.]*://.*$']`
+Alias of `Pattern['\A[a-zA-Z][a-zA-Z0-9+-.]*://.*\z']`
 
 ### <a name="Simplib--Umask"></a>`Simplib::Umask`
 
 Matches umask patterns
 
-Alias of `Pattern['^[0-7]{3,4}$']`
+Alias of `Pattern['\A[0-7]{3,4}\z']`
 

--- a/spec/type_aliases/emailaddress_spec.rb
+++ b/spec/type_aliases/emailaddress_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Simplib::EmailAddress' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('user@example.com') }
+        it { is_expected.to allow_value('a@b') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('user') }
+        it { is_expected.not_to allow_value('@example.com') }
+        it { is_expected.not_to allow_value('user@') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("user@example.com\nevil") }
+        it { is_expected.not_to allow_value("evil\nuser@example.com") }
+        it { is_expected.not_to allow_value("user@example.com\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/bcrypt_spec.rb
+++ b/spec/type_aliases/libcrypt/bcrypt_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::Bcrypt' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
+        it { is_expected.to allow_value('$2y$10$RT.Z68QWbhbg5.TOba4gGOBEvj6anWfvPBaU3F1HMHTSz5g75Vrme') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$2c$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
+        it { is_expected.not_to allow_value('$2a$7$short') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe\nevil") }
+        it { is_expected.not_to allow_value("evil\n$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe") }
+        it { is_expected.not_to allow_value("$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/bigcrypt_spec.rb
+++ b/spec/type_aliases/libcrypt/bigcrypt_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::Bigcrypt' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('a' * 13) }
+        it { is_expected.to allow_value('a' * 178) }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('a' * 12) }
+        it { is_expected.not_to allow_value('a' * 179) }
+        it { is_expected.not_to allow_value("#{'a' * 12}$") }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("#{'a' * 13}\nevil") }
+        it { is_expected.not_to allow_value("evil\n#{'a' * 13}") }
+        it { is_expected.not_to allow_value("#{'a' * 13}\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/bsdiextendeddes_spec.rb
+++ b/spec/type_aliases/libcrypt/bsdiextendeddes_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::BSDIExtendedDES' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('_aaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('_aaaaaaaaaaaaaaaaaa') }
+        it { is_expected.not_to allow_value('aaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("_aaaaaaaaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\n_aaaaaaaaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("_aaaaaaaaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/des_spec.rb
+++ b/spec/type_aliases/libcrypt/des_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::DES' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('aaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('aaaaaaaaaaaa') }
+        it { is_expected.not_to allow_value('aaaaaaaaaaaaaa') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("aaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\naaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("aaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/md5_freebsd_spec.rb
+++ b/spec/type_aliases/libcrypt/md5_freebsd_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::MD5_FreeBSD' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$1$$aaaaaaaaaaaaaaaaaaaaaa') }
+        it { is_expected.not_to allow_value('$1$0nIBDEfm$short') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.\nevil") }
+        it { is_expected.not_to allow_value("evil\n$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.") }
+        it { is_expected.not_to allow_value("$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.\n") }
+
+        # The salt is a negated character class, which matches a newline even
+        # when the pattern is anchored to the whole string, so a newline could
+        # be smuggled into the middle of an otherwise valid value
+        it { is_expected.not_to allow_value("$1$0nIB\nEfm$QNNyqbDS5ZkwScfmvI37z.") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/md5_sun_spec.rb
+++ b/spec/type_aliases/libcrypt/md5_sun_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::MD5_Sun' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$md5$RPgLF6IJ$aaaaaaaaaaaaaaaaaaaaaa') }
+        it { is_expected.to allow_value('$md5,rounds=5000$RPgLF6IJ$aaaaaaaaaaaaaaaaaaaaaa') }
+        it { is_expected.to allow_value('$md5$RPgLF6IJ$$aaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$md5$RPgLF6IJ$short') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$md5$RPgLF6IJ$aaaaaaaaaaaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\n$md5$RPgLF6IJ$aaaaaaaaaaaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("$md5$RPgLF6IJ$aaaaaaaaaaaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/nthash_spec.rb
+++ b/spec/type_aliases/libcrypt/nthash_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::NTHASH' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$3$$0480cf9c8755c691c629f6595c2e7238') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$3$0480cf9c8755c691c629f6595c2e7238') }
+        it { is_expected.not_to allow_value('$3$$0480CF9C8755C691C629F6595C2E7238') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$3$$0480cf9c8755c691c629f6595c2e7238\nevil") }
+        it { is_expected.not_to allow_value("evil\n$3$$0480cf9c8755c691c629f6595c2e7238") }
+        it { is_expected.not_to allow_value("$3$$0480cf9c8755c691c629f6595c2e7238\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/scrypt_spec.rb
+++ b/spec/type_aliases/libcrypt/scrypt_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::Scrypt' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$7$C6..../....SodiumChloride$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$7$short$aaa') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$7$C6..../....SodiumChloride$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\n$7$C6..../....SodiumChloride$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("$7$C6..../....SodiumChloride$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/sha1_spec.rb
+++ b/spec/type_aliases/libcrypt/sha1_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::SHA1' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$sha1$40000$jtNX3nZ2$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$sha1$40000$jtNX3nZ2$tooshort') }
+        it { is_expected.not_to allow_value('$sha1$0$salt$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$sha1$40000$jtNX3nZ2$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\n$sha1$40000$jtNX3nZ2$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("$sha1$40000$jtNX3nZ2$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/sha2_256_spec.rb
+++ b/spec/type_aliases/libcrypt/sha2_256_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::SHA2_256' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9') }
+        it { is_expected.to allow_value('$5$rounds=5000$4E8kXNLiy$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$5$') }
+        it { is_expected.not_to allow_value('$5$salt$tooshort') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9\nevil") }
+        it { is_expected.not_to allow_value("evil\n$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9") }
+        it { is_expected.not_to allow_value("$5$4E8kXNLiykgBk$NviJTE3NgOvqoF0hXlhFbbYknIpTZqqVqihav8ZM2h9\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/sha2_512_spec.rb
+++ b/spec/type_aliases/libcrypt/sha2_512_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::SHA2_512' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
+        it { is_expected.to allow_value('$6$rounds=5000$h6k81gwg$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$6$') }
+        it { is_expected.not_to allow_value('$6$salt$tooshort') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1\nevil") }
+        it { is_expected.not_to allow_value("evil\n$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1") }
+        it { is_expected.not_to allow_value("$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/libcrypt/yescrypt_spec.rb
+++ b/spec/type_aliases/libcrypt/yescrypt_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'Simplib::Libcrypt::Yescrypt' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('$y$j9T$aaaa$short') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nevil") }
+        it { is_expected.not_to allow_value("evil\n$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        it { is_expected.not_to allow_value("$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/shadowpass_spec.rb
+++ b/spec/type_aliases/shadowpass_spec.rb
@@ -16,12 +16,30 @@ describe 'Simplib::ShadowPass' do
         it { is_expected.to allow_value('$2a$07$ybS56Js6xCcu5SxFwa2NsODRF109WEitIY52THiZh.eFdfQg8ovNe') }
         it { is_expected.to allow_value('$2y$10$RT.Z68QWbhbg5.TOba4gGOBEvj6anWfvPBaU3F1HMHTSz5g75Vrme') }
         it { is_expected.to allow_value('$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.') }
+
+        # Regression: types/libcrypt/yescript.pp defined
+        # Simplib::Libcrypt::Yescrypt, so the autoloader never found it and
+        # this branch of the Variant silently never matched
+        it { is_expected.to allow_value('$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') }
       end
 
       context 'with invalid entries' do
         it { is_expected.not_to allow_value('*$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1') }
         it { is_expected.not_to allow_value('$6$') }
         it { is_expected.not_to allow_value('mycleartextpassword') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. An injected newline in the
+        # shadow password field is a file-injection primitive. See #353.
+        it { is_expected.not_to allow_value("$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1\nevil") }
+        it { is_expected.not_to allow_value("evil\n$6$h6k81gwg$J5QJ3DWz9G2CeIHMEXRfhd7Ocem.NNfQimxw/OUa2m/PD3Mx6q67ntjELlVgye4kHxG5ZfMAXLjioGWISJYFE1") }
+        it { is_expected.not_to allow_value("$1$0nIBDEfm$QNNyqbDS5ZkwScfmvI37z.\nevil") }
+
+        # The disabled-entry branch, Pattern['\A!.*\z']
+        it { is_expected.not_to allow_value("!locked\nevil") }
+        it { is_expected.not_to allow_value("evil\n!locked") }
       end
     end
   end

--- a/spec/type_aliases/simplib_macaddress_spec.rb
+++ b/spec/type_aliases/simplib_macaddress_spec.rb
@@ -19,6 +19,14 @@ describe 'Simplib::Macaddress' do
         it { is_expected.not_to allow_value('CA:FE:BE:EF::11') }
         it { is_expected.not_to allow_value('OO:PS:NO:TH:EX:11') }
       end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("CA:FE:BE:EF:00:11\nevil") }
+        it { is_expected.not_to allow_value("evil\nCA:FE:BE:EF:00:11") }
+        it { is_expected.not_to allow_value("CA:FE:BE:EF:00:11\n") }
+      end
     end
   end
 end

--- a/spec/type_aliases/systemd/servicename_spec.rb
+++ b/spec/type_aliases/systemd/servicename_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'Simplib::Systemd::ServiceName' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('sshd.service') }
+        it { is_expected.to allow_value('foo@bar.service') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('bad name.service') }
+        it { is_expected.not_to allow_value('bad/name.service') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("sshd.service\nevil") }
+        it { is_expected.not_to allow_value("evil\nsshd.service") }
+        it { is_expected.not_to allow_value("sshd.service\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/umask_spec.rb
+++ b/spec/type_aliases/umask_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'Simplib::Umask' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('077') }
+        it { is_expected.to allow_value('0077') }
+        it { is_expected.to allow_value('000') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('0778') }
+        it { is_expected.not_to allow_value('08') }
+        it { is_expected.not_to allow_value('00000') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("077\nevil") }
+        it { is_expected.not_to allow_value("evil\n077") }
+        it { is_expected.not_to allow_value("077\n") }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/uri_spec.rb
+++ b/spec/type_aliases/uri_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'Simplib::URI' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with valid entries' do
+        it { is_expected.to allow_value('https://example.com/x') }
+        it { is_expected.to allow_value('ldap://example.com:389') }
+      end
+
+      context 'with invalid entries' do
+        it { is_expected.not_to allow_value('example.com') }
+        it { is_expected.not_to allow_value('://example.com') }
+        it { is_expected.not_to allow_value('1http://example.com') }
+      end
+
+      context 'the pattern is anchored to the whole string' do
+        # Regression: line anchors let any multi-line string containing a
+        # single valid line satisfy the type. See #353.
+        it { is_expected.not_to allow_value("https://example.com/x\nevil") }
+        it { is_expected.not_to allow_value("evil\nhttps://example.com/x") }
+        it { is_expected.not_to allow_value("https://example.com/x\n") }
+      end
+    end
+  end
+end

--- a/types/emailaddress.pp
+++ b/types/emailaddress.pp
@@ -1,2 +1,2 @@
 # Matches valid email addresses
-type Simplib::EmailAddress = Pattern['^.+@.+$']
+type Simplib::EmailAddress = Pattern['\A.+@.+\z']

--- a/types/libcrypt/bcrypt.pp
+++ b/types/libcrypt/bcrypt.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::Bcrypt = Pattern['^\$2[abxy]\$[0-9]{2}\$[./A-Za-z0-9]{53}$']
+type Simplib::Libcrypt::Bcrypt = Pattern['\A\$2[abxy]\$[0-9]{2}\$[./A-Za-z0-9]{53}\z']

--- a/types/libcrypt/bigcrypt.pp
+++ b/types/libcrypt/bigcrypt.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::Bigcrypt = Pattern['^[./0-9A-Za-z]{13,178}$']
+type Simplib::Libcrypt::Bigcrypt = Pattern['\A[./0-9A-Za-z]{13,178}\z']

--- a/types/libcrypt/bsdiextendeddes.pp
+++ b/types/libcrypt/bsdiextendeddes.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::BSDIExtendedDES = Pattern['^_[./0-9A-Za-z]{19}$']
+type Simplib::Libcrypt::BSDIExtendedDES = Pattern['\A_[./0-9A-Za-z]{19}\z']

--- a/types/libcrypt/des.pp
+++ b/types/libcrypt/des.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::DES = Pattern['^[./0-9A-Za-z]{13}$']
+type Simplib::Libcrypt::DES = Pattern['\A[./0-9A-Za-z]{13}\z']

--- a/types/libcrypt/md5_freebsd.pp
+++ b/types/libcrypt/md5_freebsd.pp
@@ -1,2 +1,5 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::MD5_FreeBSD = Pattern['^\$1\$[^$]{1,8}\$[./0-9A-Za-z]{22}$']
+#
+# The salt is a negated character class, which matches a newline even when the
+# pattern is anchored to the whole string, so newlines are excluded explicitly
+type Simplib::Libcrypt::MD5_FreeBSD = Pattern['\A\$1\$[^$\n]{1,8}\$[./0-9A-Za-z]{22}\z']

--- a/types/libcrypt/md5_sun.pp
+++ b/types/libcrypt/md5_sun.pp
@@ -1,4 +1,4 @@
 # Regular expression pulled from the crypt(5) man page
 # lint:ignore:single_quote_string_with_variables
-type Simplib::Libcrypt::MD5_Sun = Pattern['^\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}$']
+type Simplib::Libcrypt::MD5_Sun = Pattern['\A\$md5(,rounds=[1-9][0-9]+)?\$[./0-9A-Za-z]{8}\${1,2}[./0-9A-Za-z]{22}\z']
 # lint:endignore

--- a/types/libcrypt/nthash.pp
+++ b/types/libcrypt/nthash.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::NTHASH = Pattern['^\$3\$\$[0-9a-f]{32}$']
+type Simplib::Libcrypt::NTHASH = Pattern['\A\$3\$\$[0-9a-f]{32}\z']

--- a/types/libcrypt/scrypt.pp
+++ b/types/libcrypt/scrypt.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::Scrypt = Pattern['^\$7\$[./A-Za-z0-9]{11,97}\$[./A-Za-z0-9]{43}$']
+type Simplib::Libcrypt::Scrypt = Pattern['\A\$7\$[./A-Za-z0-9]{11,97}\$[./A-Za-z0-9]{43}\z']

--- a/types/libcrypt/sha1.pp
+++ b/types/libcrypt/sha1.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::SHA1 = Pattern['^\$sha1\$[1-9][0-9]+\$[./0-9A-Za-z]{1,64}\$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}$']
+type Simplib::Libcrypt::SHA1 = Pattern['\A\$sha1\$[1-9][0-9]+\$[./0-9A-Za-z]{1,64}\$[./0-9A-Za-z]{8,64}[./0-9A-Za-z]{32}\z']

--- a/types/libcrypt/sha2_256.pp
+++ b/types/libcrypt/sha2_256.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::SHA2_256 = Pattern['^\$5\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{43}$']
+type Simplib::Libcrypt::SHA2_256 = Pattern['\A\$5\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{43}\z']

--- a/types/libcrypt/sha2_512.pp
+++ b/types/libcrypt/sha2_512.pp
@@ -1,2 +1,2 @@
 # Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::SHA2_512 = Pattern['^\$6\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{86}$']
+type Simplib::Libcrypt::SHA2_512 = Pattern['\A\$6\$(rounds=[1-9][0-9]+\$)?[./0-9A-Za-z]{1,16}\$[./0-9A-Za-z]{86}\z']

--- a/types/libcrypt/yescript.pp
+++ b/types/libcrypt/yescript.pp
@@ -1,2 +1,0 @@
-# Regular expression pulled from the crypt(5) man page
-type Simplib::Libcrypt::Yescrypt = Pattern['^\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}$']

--- a/types/libcrypt/yescrypt.pp
+++ b/types/libcrypt/yescrypt.pp
@@ -1,0 +1,2 @@
+# Regular expression pulled from the crypt(5) man page
+type Simplib::Libcrypt::Yescrypt = Pattern['\A\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}\z']

--- a/types/macaddress.pp
+++ b/types/macaddress.pp
@@ -1,2 +1,2 @@
 # Matches MAC addresses
-type Simplib::Macaddress = Pattern['^[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}$']
+type Simplib::Macaddress = Pattern['\A[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\z']

--- a/types/shadowpass.pp
+++ b/types/shadowpass.pp
@@ -10,7 +10,7 @@
 type Simplib::ShadowPass = Variant[
   Enum['*','!','!!'],
   # Disabled Entries
-  Pattern['^!.*'],
+  Pattern['\A!.*\z'],
   Simplib::Libcrypt::SHA2_512,
   Simplib::Libcrypt::SHA2_256,
   Simplib::Libcrypt::SHA1,

--- a/types/systemd/servicename.pp
+++ b/types/systemd/servicename.pp
@@ -1,2 +1,2 @@
 # Valid systemd service names
-type Simplib::Systemd::ServiceName = Pattern['^(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}$']
+type Simplib::Systemd::ServiceName = Pattern['\A(([A-Za-z0-9.:_\\\\-])(@[A-Za-z0-9.:_\\\\-])?){1,256}\z']

--- a/types/umask.pp
+++ b/types/umask.pp
@@ -1,2 +1,2 @@
 # Matches umask patterns
-type Simplib::Umask = Pattern['^[0-7]{3,4}$']
+type Simplib::Umask = Pattern['\A[0-7]{3,4}\z']

--- a/types/uri.pp
+++ b/types/uri.pp
@@ -1,2 +1,2 @@
 # Matches URI strings
-type Simplib::URI = Pattern['^[a-zA-Z][a-zA-Z0-9+-.]*://.*$']
+type Simplib::URI = Pattern['\A[a-zA-Z][a-zA-Z0-9+-.]*://.*\z']


### PR DESCRIPTION
Fixes #353. Fixes #354.

Completes the anchoring sweep started in #352. Puppet's `Pattern` performs a regex *search* rather than a full-string match, and `^`/`$` are **line** anchors in Ruby, so any multi-line string containing a single valid line satisfied these types.

Each of these was accepted before this change:

| type | injecting value |
|---|---|
| `Simplib::Umask` | `"077\nevil"` |
| `Simplib::Macaddress` | `"00:11:22:33:44:55\nevil"` |
| `Simplib::EmailAddress` | `"a@b\nevil"` |
| `Simplib::URI` | `"https://foo\nevil"` |
| `Simplib::ShadowPass` | `"$6$salt$<86 chars>\nevil"` |
| `Simplib::Libcrypt::*` (12) | `"<valid hash>\nevil"` |

The outer `^`…`$` is replaced with `\A`…`\z` on `Simplib::EmailAddress`, `Simplib::Macaddress`, `Simplib::Umask`, `Simplib::URI`, `Simplib::Systemd::ServiceName`, the disabled-entry branch of `Simplib::ShadowPass`, and all twelve `Simplib::Libcrypt::*` types.

Per the issue, the IPv4/IPv6 types are deliberately untouched — they wrap their patterns in an inner `\A`…`\z` and already reject multi-line input.

## Two things that needed more than an anchor change

**`Simplib::Libcrypt::MD5_FreeBSD`.** Its salt is a negated character class, `[^$]`, which matches a newline *even when the pattern is anchored to the whole string*. Anchoring alone left this accepted:

```
"$1$0nIB\nEfm$QNNyqbDS5ZkwScfmvI37z."
```

The class is now `[^$\n]`. This is the only pattern in the sweep with a negated class; everything else relies on `.` or an explicit whitelist, and `.` already excludes `\n` by default.

**`Simplib::Libcrypt::Yescrypt` has never worked** (#354). Adding the missing `Simplib::Libcrypt::*` specs surfaced this. The file is named `types/libcrypt/yescript.pp` but defines `Simplib::Libcrypt::Yescrypt`, and Puppet autoloads type aliases by path — so the type has never been loadable. Referencing it directly raises `Resource type not found`, and through `Simplib::ShadowPass` it fails *silently*: the `Variant` branch simply never matches.

```puppet
$v = '$y$j9T$aaaa$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
notice("ShadowPass: ${$v =~ Simplib::ShadowPass}")   # before: false, after: true
```

So `Simplib::ShadowPass` was rejecting yescrypt hashes — the default crypt scheme on recent Fedora and EL10 — with nothing to indicate why. Present since the type was introduced in #162. Renaming the file to `yescrypt.pp` is the entire fix.

I folded it in here because this PR adds the specs that expose it and already touches the file; happy to split it out if you would rather review it on its own.

## Tests

New `spec/type_aliases/` specs, in the `allow_value` style the issue asked for, covering valid values, existing invalid values, and multi-line rejection (`"<valid>\nevil"`, `"evil\n<valid>"`, `"<valid>\n"`):

* the twelve `Simplib::Libcrypt::*` types, which had **no direct coverage at all** — they were only exercised indirectly through `Simplib::ShadowPass`, which is exactly why the yescrypt breakage went unnoticed
* `Simplib::EmailAddress`, `Simplib::Umask`, `Simplib::URI`, `Simplib::Systemd::ServiceName`

Anchoring contexts were added to the existing `Simplib::Macaddress` and `Simplib::ShadowPass` specs, plus a yescrypt value to `Simplib::ShadowPass` to lock in #354.

Note that `Simplib::EmailAddress`, `Simplib::Umask`, `Simplib::URI`, and `Simplib::Systemd::ServiceName` already have specs under `spec/unit/data_types/`. I added `spec/type_aliases/` files for them because the issue asked for that style, and because the `unit/data_types` harness interpolates values into a manifest, which is awkward for multi-line input. That does mean two spec files per type — same tension flagged in #352, still happy to consolidate in whichever direction you prefer.

Full suite: **13229 examples, 0 failures**. `rake lint`, `rake syntax`, and RuboCop clean. `REFERENCE.md` regenerated.

## Release

No version bump, per #353 — this appends to the unreleased `7.0.0` stanza that #352 already opened, so 7.0.0 must not be tagged until this merges.

## One open question

The sweep excludes `\n` but not `\r`, matching Ruby's default `.` semantics (only `\n` is excluded). If `\r` is a concern for any of the config files these values land in, `Simplib::URI`'s trailing `.*` and `Simplib::ShadowPass`'s `!.*` would both still admit it. Left alone deliberately rather than silently widening scope — say the word and I will tighten it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
