### PR TITLE
[puppetsync] Add a create-release-tag workflow

### DIFF
--- a/.github/workflows/create_release_tag.yml
+++ b/.github/workflows/create_release_tag.yml
@@ -1,0 +1,34 @@
+# Manual action to create + push a release tag from metadata.json & CHANGELOG
+# ------------------------------------------------------------------------------
+#
+#             NOTICE: **This file is maintained with puppetsync**
+#
+# This file is updated automatically as part of a puppet module baseline.
+#
+# The next baseline sync will overwrite any local changes to this file!
+#
+# ==============================================================================
+#
+# All logic lives in the reusable workflow in simp/gha-workflows; this file
+# only forwards the manual trigger. See simp/puppetsync#85.
+#
+---
+name: 'RELENG: Create release tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (validate + report the tag annotation, don't push)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  create-release-tag:
+    uses: simp/gha-workflows/.github/workflows/puppet_create_release_tag.yml@v1.0.0
+    with:
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+    permissions:
+      contents: write


### PR DESCRIPTION
This patch adds create_release_tag.yml, a manually-dispatched
workflow that validates the release (SemVer version from
metadata.json, tag doesn't already exist, pkg:check_version,
pkg:compare_latest_tag, metadata_lint) BEFORE tagging, generates
the tag annotation from the CHANGELOG, and pushes the annotated
tag — triggering the existing tag_deploy.yml release pipeline. A
dry_run input reports the would-be annotation without pushing.

The file is a thin shim: the logic lives in the reusable workflow
simp/gha-workflows/.github/workflows/puppet_create_release_tag.yml
(pinned to v1.0.0, managed by Renovate), so fixes land there as a
tag bump instead of a fleet-wide sync. See simp/puppetsync#85.