### PR TITLE
Fix hiera.yaml write race that randomly drops custom hieradata in specs

### DIFF
--- a/spec/functions/simplib/dlookup_spec.rb
+++ b/spec/functions/simplib/dlookup_spec.rb
@@ -49,14 +49,16 @@ describe 'simplib::stages', type: :class do
       end
 
       context 'overrides' do
+        # Select the override hieradata via this context's declared facts —
+        # unlike `let(:hieradata)`'s global default_facts mutation, these are
+        # part of rspec-puppet's catalogue cache key, so no cache_bust fact
+        # is needed. (The random CI failures here were a hiera.yaml write
+        # race under parallel_spec, fixed in spec_helper.rb — see #362.)
         let(:facts) do
           os_facts.merge(
-            cache_bust: Time.now.to_s,
-            hieradata: 'simplib_dlookup_overrides',
+            custom_hiera: 'simplib_dlookup_overrides',
           )
         end
-
-        let(:hieradata) { 'simplib_dlookup_overrides' }
 
         context 'with global overrides' do
           it { expect(gob[:attribute]).to eq('illusions') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,9 +126,13 @@ RSpec.configure do |c|
       end
     end
 
-    File.open(c.hiera_config, 'w') do |f|
-      f.write data.to_yaml
-    end
+    # Write atomically (write + rename) — every parallel_spec worker runs
+    # this hook, and a truncating write here can be observed as an empty
+    # hiera.yaml by a catalogue compile in another worker, silently dropping
+    # all custom hieradata (simp/pupmod-simp-simplib#362)
+    tmpfile = "#{c.hiera_config}.#{Process.pid}"
+    File.write(tmpfile, data.to_yaml)
+    File.rename(tmpfile, c.hiera_config)
   end
   # rubocop:enable RSpec/BeforeAfterAll
 


### PR DESCRIPTION
Fixes #362

### Root cause (confirmed by local reproduction)

The config-level `before(:all)` hook in the puppetsync-managed `spec/spec_helper.rb` rewrites `spec/fixtures/hieradata/hiera.yaml` with a truncating `File.open(..., 'w')` before **every top-level example group**. Under `rake parallel_spec`, every worker runs this hook — so a catalogue compile in one worker that reads `hiera.yaml` inside another worker's truncate-to-write window sees an **empty hiera config** and silently compiles without any custom hieradata.

That's why `dlookup_spec` intermittently gets the no-override default (`lucille2`) instead of `illusions`, and why other hieradata-dependent specs (e.g. `simplib::passgen::set`, which silently fell back to legacy mode in [this run](https://github.com/simp/pupmod-simp-simplib/actions/runs/32263058495/job/96101086862)) fail at the same instant.

**Reproduction:** rewriting `hiera.yaml` in a tight truncate-then-write loop while running `dlookup_spec` produced the exact CI failure on the first run. With atomic (same-directory write + rename) rewrites, 8/8 runs passed under the same concurrent load.

Notably, the first version of this PR (moving `custom_hiera` into `let(:facts)`, per the hardening suggested in #362) **still failed in its own CI run**, which is what disproved the test-state-leak theory and led to the race being found.

### Changes

1. **`spec/spec_helper.rb`** — write `hiera.yaml` atomically: write to a PID-suffixed temp file in the same directory and `File.rename` it into place. ⚠️ This file is puppetsync-managed, so the same fix needs to land in the puppetsync template (simp/puppetsync#90) or the next baseline sync will revert it.
2. **`spec/functions/simplib/dlookup_spec.rb`** — cleanup: select the override hieradata via the context's declared facts (part of rspec-puppet's catalogue cache key) instead of `let(:hieradata)` plus the 1-second-resolution `cache_bust: Time.now.to_s` hack.

### Verification

- Race harness: old code fails within 1–2 runs; patched code passes 8/8 under continuous concurrent rewrites
- `bundle exec rake parallel_spec`: 13,229 examples, 0 failures
- `rubocop`: clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)